### PR TITLE
Add Makefile and build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# Simple build rules for vlibc
+
+PREFIX ?= /usr/local
+CC ?= cc
+CFLAGS ?= -O2 -std=c11 -Wall -Wextra -Iinclude
+AR ?= ar
+
+SRC := $(wildcard src/*.c)
+OBJ := $(SRC:.c=.o)
+LIB := libvlibc.a
+
+all: $(LIB)
+
+$(LIB): $(OBJ)
+	$(AR) rcs $@ $^
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+install: $(LIB)
+	install -d $(DESTDIR)$(PREFIX)/lib
+	install -m 644 $(LIB) $(DESTDIR)$(PREFIX)/lib
+	install -d $(DESTDIR)$(PREFIX)/include
+	install -m 644 include/*.h $(DESTDIR)$(PREFIX)/include
+
+clean:
+	rm -f $(OBJ) $(LIB)
+
+.PHONY: all install clean

--- a/README.md
+++ b/README.md
@@ -46,3 +46,28 @@ The repository uses a straightforward layout:
 
 These directories are empty initially, acting as placeholders for future
 development.
+
+## Building the Library
+
+The project uses a simple `make`-based build system. To compile the
+static library, run:
+
+```sh
+make
+```
+
+This produces `libvlibc.a` in the repository root. You can optionally
+install the headers and library with:
+
+```sh
+make install PREFIX=/usr/local
+```
+
+`PREFIX` controls the installation path and defaults to `/usr/local`.
+
+To link against vlibc in your application, add the following flags when
+compiling:
+
+```sh
+cc your_app.c -I/path/to/vlibc/include -L/path/to/vlibc -lvlibc
+```

--- a/include/vlibc.h
+++ b/include/vlibc.h
@@ -1,0 +1,7 @@
+#ifndef VLIBC_H
+#define VLIBC_H
+
+/* Minimal entry point for the library. */
+void vlibc_init(void);
+
+#endif /* VLIBC_H */

--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,7 @@
+#include "vlibc.h"
+
+/* Placeholder implementation. */
+void vlibc_init(void)
+{
+    /* Nothing to do yet. */
+}


### PR DESCRIPTION
## Summary
- add minimal `Makefile` to build static library `libvlibc.a`
- stub `vlibc_init` implementation and header
- document how to build and link the library

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68570ed87dc0832493959c7b924c2a0c