### PR TITLE
Add memory management module

### DIFF
--- a/include/memory.h
+++ b/include/memory.h
@@ -1,0 +1,11 @@
+#ifndef MEMORY_H
+#define MEMORY_H
+
+#include <stddef.h>
+
+void *malloc(size_t size);
+void free(void *ptr);
+void *calloc(size_t nmemb, size_t size);
+void *realloc(void *ptr, size_t size);
+
+#endif /* MEMORY_H */

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,0 +1,56 @@
+#include "memory.h"
+#include <unistd.h>
+#include <string.h>
+#include <stdint.h>
+
+/* Declare sbrk for strict environments */
+extern void *sbrk(intptr_t increment);
+
+/*
+ * Extremely small bump allocator. Memory obtained via sbrk is never
+ * returned to the system. free() is therefore a stub. This is suitable
+ * for tiny programs or testing but not for long-running processes.
+ */
+
+static char *heap_end = NULL;
+
+void *malloc(size_t size)
+{
+    if (size == 0)
+        return NULL;
+
+    if (!heap_end)
+        heap_end = sbrk(0);
+
+    char *prev = heap_end;
+    if (sbrk(size) == (void *)-1)
+        return NULL;
+
+    heap_end += size;
+    return prev;
+}
+
+void free(void *ptr)
+{
+    (void)ptr; /* no-op */
+}
+
+void *calloc(size_t nmemb, size_t size)
+{
+    size_t total = nmemb * size;
+    void *ptr = malloc(total);
+    if (ptr)
+        memset(ptr, 0, total);
+    return ptr;
+}
+
+void *realloc(void *ptr, size_t size)
+{
+    if (!ptr)
+        return malloc(size);
+
+    void *new_ptr = malloc(size);
+    if (new_ptr && size > 0)
+        memmove(new_ptr, ptr, size);
+    return new_ptr;
+}


### PR DESCRIPTION
## Summary
- implement a very small bump allocator using `sbrk`
- expose `malloc`, `free`, `calloc` and `realloc` via new header
- document allocator behavior in `vlibcdoc.md`

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68570fabc0e88324a77bca50a7cb2631