### PR TITLE
Add process and signal wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,6 @@ cc your_app.c -I/path/to/vlibc/include -L/path/to/vlibc -lvlibc
 - The I/O routines (`open`, `read`, `write`, `close`) are thin wrappers around
   the corresponding system calls. They perform no buffering and provide only
   basic error reporting.
+- Process creation and signal functions rely on Linux `fork`, `execve`,
+  `wait4`/`waitpid`, and `rt_sigaction` syscalls. Porting to other UNIX-like
+  kernels may require adapting these calls.

--- a/include/process.h
+++ b/include/process.h
@@ -1,0 +1,16 @@
+#ifndef PROCESS_H
+#define PROCESS_H
+
+#define _POSIX_C_SOURCE 200809L
+#include <sys/types.h>
+#include <signal.h>
+
+pid_t fork(void);
+int execve(const char *pathname, char *const argv[], char *const envp[]);
+pid_t waitpid(pid_t pid, int *status, int options);
+int kill(pid_t pid, int sig);
+
+typedef void (*sighandler_t)(int);
+sighandler_t signal(int signum, sighandler_t handler);
+
+#endif /* PROCESS_H */

--- a/src/process.c
+++ b/src/process.c
@@ -1,0 +1,50 @@
+#include "process.h"
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <signal.h>
+#include <string.h>
+
+extern long syscall(long number, ...);
+
+pid_t fork(void)
+{
+#ifdef SYS_fork
+    return (pid_t)syscall(SYS_fork);
+#else
+    return (pid_t)syscall(SYS_clone, SIGCHLD, 0);
+#endif
+}
+
+int execve(const char *pathname, char *const argv[], char *const envp[])
+{
+    return (int)syscall(SYS_execve, pathname, argv, envp);
+}
+
+pid_t waitpid(pid_t pid, int *status, int options)
+{
+#ifdef SYS_waitpid
+    return (pid_t)syscall(SYS_waitpid, pid, status, options);
+#else
+    return (pid_t)syscall(SYS_wait4, pid, status, options, NULL);
+#endif
+}
+
+int kill(pid_t pid, int sig)
+{
+    return (int)syscall(SYS_kill, pid, sig);
+}
+
+sighandler_t signal(int signum, sighandler_t handler)
+{
+#ifdef SYS_rt_sigaction
+    struct sigaction act, old;
+    memset(&act, 0, sizeof(act));
+    act.sa_handler = handler;
+    if (syscall(SYS_rt_sigaction, signum, &act, &old, sizeof(sigset_t)) < 0)
+        return SIG_ERR;
+    return old.sa_handler;
+#else
+    return (sighandler_t)syscall(SYS_signal, signum, handler);
+#endif
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -112,13 +112,37 @@ The goal is to offer just enough functionality for common tasks without the comp
 
 ## Process Control
 
-Process-related functionality resides in the **process** module. Planned features include:
+Process-related functionality resides in the **process** module. It provides
+minimal wrappers for creating and managing processes as well as installing
+signal handlers:
 
-- `vfork`, `vexecve`, and `vwaitpid` wrappers for spawning and tracking processes.
-- Simplified environment handling for child processes.
-- Basic signal support to allow clean termination and child process monitoring.
+```c
+pid_t fork(void);
+int execve(const char *pathname, char *const argv[], char *const envp[]);
+pid_t waitpid(pid_t pid, int *status, int options);
+int kill(pid_t pid, int sig);
+sighandler_t signal(int signum, sighandler_t handler);
+```
 
-The design favors straightforward semantics over comprehensive POSIX conformance.
+### Example
+
+```c
+/* Spawn a child that prints a message and wait for it to finish. */
+pid_t pid = fork();
+if (pid == 0) {
+    char *args[] = {"/bin/echo", "hello", NULL};
+    execve("/bin/echo", args, NULL);
+}
+waitpid(pid, NULL, 0);
+
+/* Install a handler and send the process an interrupt. */
+void on_int(int signo) { (void)signo; }
+signal(SIGINT, on_int);
+kill(getpid(), SIGINT);
+```
+
+The design favors straightforward semantics over comprehensive POSIX
+conformance.
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary
- implement `fork`, `execve`, `waitpid`, `kill` and `signal`
- document new APIs in `vlibcdoc.md`
- note portability of process/signal functions in `README.md`

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6857117da6a88324a71d0541551bd637