### PR TITLE
Add basic unit test framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,19 @@ AR ?= ar
 SRC := $(wildcard src/*.c)
 OBJ := $(SRC:.c=.o)
 LIB := libvlibc.a
+TEST_SRC := $(wildcard tests/*.c)
+TEST_BIN := tests/run_tests
 
 all: $(LIB)
 
 $(LIB): $(OBJ)
 	$(AR) rcs $@ $^
+
+$(TEST_BIN): $(TEST_SRC) $(LIB)
+	$(CC) $(CFLAGS) $(TEST_SRC) $(LIB) -o $@
+
+test: $(TEST_BIN)
+	./$(TEST_BIN)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
@@ -24,6 +32,6 @@ install: $(LIB)
 	install -m 644 include/*.h $(DESTDIR)$(PREFIX)/include
 
 clean:
-	rm -f $(OBJ) $(LIB)
+	rm -f $(OBJ) $(LIB) $(TEST_BIN)
 
-.PHONY: all install clean
+.PHONY: all install clean test

--- a/README.md
+++ b/README.md
@@ -42,10 +42,7 @@ The repository uses a straightforward layout:
 
 - `src/` contains the library's source files.
 - `include/` holds public header files.
-- `tests/` will store test cases and examples.
-
-These directories are empty initially, acting as placeholders for future
-development.
+- `tests/` contains unit tests.
 
 ## Building the Library
 
@@ -71,6 +68,17 @@ compiling:
 ```sh
 cc your_app.c -I/path/to/vlibc/include -L/path/to/vlibc -lvlibc
 ```
+
+## Running Tests
+
+Unit tests live in `tests/` and use a tiny test harness. The suite aims to
+exercise the library's core functions. Build and execute the tests with:
+
+```sh
+make test
+```
+
+This command builds `tests/run_tests` and runs it automatically.
 
 ## Limitations
 

--- a/tests/minunit.h
+++ b/tests/minunit.h
@@ -1,0 +1,12 @@
+#ifndef MINUNIT_H
+#define MINUNIT_H
+
+#include <stdio.h>
+
+#define mu_assert(message, test) do { if (!(test)) return message; } while (0)
+#define mu_run_test(test) do { const char *message = test(); tests_run++; \
+                               if (message) return message; } while (0)
+
+extern int tests_run;
+
+#endif /* MINUNIT_H */

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1,0 +1,57 @@
+#include "minunit.h"
+#include "../include/memory.h"
+#include "../include/io.h"
+
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+int tests_run = 0;
+
+static const char *test_malloc(void)
+{
+    void *p = malloc(16);
+    mu_assert("malloc returned NULL", p != NULL);
+    memset(p, 0xAA, 16);
+    free(p);
+    return 0;
+}
+
+static const char *test_io(void)
+{
+    const char *fname = "tmp_test_file";
+    int fd = open(fname, O_CREAT | O_RDWR, 0644);
+    mu_assert("open failed", fd >= 0);
+
+    const char *msg = "abc";
+    ssize_t w = write(fd, msg, strlen(msg));
+    mu_assert("write failed", w == (ssize_t)strlen(msg));
+
+    lseek(fd, 0, SEEK_SET);
+    char buf[4] = {0};
+    ssize_t r = read(fd, buf, 3);
+    mu_assert("read failed", r == 3);
+    mu_assert("content mismatch", strncmp(msg, buf, 3) == 0);
+
+    close(fd);
+    unlink(fname);
+    return 0;
+}
+
+static const char *all_tests(void)
+{
+    mu_run_test(test_malloc);
+    mu_run_test(test_io);
+    return 0;
+}
+
+int main(void)
+{
+    const char *result = all_tests();
+    if (result)
+        printf("%s\n", result);
+    else
+        printf("ALL TESTS PASSED\n");
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}


### PR DESCRIPTION
## Summary
- add a tiny C unit test framework and sample tests
- extend Makefile with `make test`
- document how to run the tests in README

## Testing
- `make test`
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_6857128c0d1083249ee13f261bc45c40