### PR TITLE
Add mmap wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ SRC := \
     src/io.c \
     src/memory.c \
     src/process.c \
-    src/string.c
+    src/string.c \
+    src/mmap.c
 OBJ := $(SRC:.c=.o)
 LIB := libvlibc.a
 TEST_SRC := $(wildcard tests/*.c)

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -1,0 +1,10 @@
+#ifndef MMAN_H
+#define MMAN_H
+
+#include <sys/types.h>
+#include <stddef.h>
+
+void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
+int munmap(void *addr, size_t length);
+
+#endif /* MMAN_H */

--- a/src/mmap.c
+++ b/src/mmap.c
@@ -1,0 +1,15 @@
+#include "sys/mman.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+
+extern long syscall(long number, ...);
+
+void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
+{
+    return (void *)syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
+}
+
+int munmap(void *addr, size_t length)
+{
+    return (int)syscall(SYS_munmap, addr, length);
+}


### PR DESCRIPTION
## Summary
- add mmap/munmap wrappers
- expose mmap prototypes in a new `sys/mman.h` header
- compile mmap.c when building `libvlibc.a`

## Testing
- `make clean && make test`

------
https://chatgpt.com/codex/tasks/task_e_6857174c78148324a501d7bb3772c5ff