### PR TITLE
Add process exit functions

### DIFF
--- a/include/process.h
+++ b/include/process.h
@@ -10,6 +10,9 @@ int execve(const char *pathname, char *const argv[], char *const envp[]);
 pid_t waitpid(pid_t pid, int *status, int options);
 int kill(pid_t pid, int sig);
 
+void _exit(int status);
+void exit(int status);
+
 typedef void (*sighandler_t)(int);
 sighandler_t signal(int signum, sighandler_t handler);
 

--- a/src/process.c
+++ b/src/process.c
@@ -35,6 +35,19 @@ int kill(pid_t pid, int sig)
     return (int)syscall(SYS_kill, pid, sig);
 }
 
+
+void _exit(int status)
+{
+    syscall(SYS_exit, status);
+    for (;;) {}
+}
+
+void exit(int status)
+{
+    /* No stdio buffering yet, so nothing to flush. */
+    _exit(status);
+}
+
 sighandler_t signal(int signum, sighandler_t handler)
 {
 #ifdef SYS_rt_sigaction


### PR DESCRIPTION
## Summary
- add prototypes for `_exit` and `exit`
- implement `_exit` using the `SYS_exit` syscall
- implement `exit` that delegates to `_exit`

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857181d8f688324b20d7a4c32bfe08f