### PR TITLE
Implement socket wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ SRC := \
     src/io.c \
     src/memory.c \
     src/process.c \
-    src/string.c
+    src/string.c \
+    src/socket.c
 OBJ := $(SRC:.c=.o)
 LIB := libvlibc.a
 TEST_SRC := $(wildcard tests/*.c)
@@ -35,6 +36,8 @@ install: $(LIB)
 	install -m 644 $(LIB) $(DESTDIR)$(PREFIX)/lib
 	install -d $(DESTDIR)$(PREFIX)/include
 	install -m 644 include/*.h $(DESTDIR)$(PREFIX)/include
+	install -d $(DESTDIR)$(PREFIX)/include/sys
+	install -m 644 include/sys/*.h $(DESTDIR)$(PREFIX)/include/sys
 
 clean:
 	rm -f $(OBJ) $(LIB) $(TEST_BIN)

--- a/include/string.h
+++ b/include/string.h
@@ -8,3 +8,5 @@ char *vstrcpy(char *dest, const char *src);
 int vstrncmp(const char *s1, const char *s2, size_t n);
 
 #endif /* STRING_H */
+
+#include_next <string.h>

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -1,0 +1,51 @@
+#ifndef SYS_SOCKET_H
+#define SYS_SOCKET_H
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <stddef.h>
+
+/* Basic socket address structures */
+
+typedef uint16_t sa_family_t;
+typedef uint16_t in_port_t;
+typedef uint32_t in_addr_t;
+typedef unsigned int socklen_t;
+
+/* Common address families */
+#define AF_UNSPEC 0
+#define AF_UNIX   1
+#define AF_LOCAL  1
+#define AF_INET   2
+#define AF_INET6  10
+
+/* Socket types */
+#define SOCK_STREAM 1
+#define SOCK_DGRAM  2
+
+struct sockaddr {
+    sa_family_t sa_family;
+    char sa_data[14];
+};
+
+struct in_addr {
+    in_addr_t s_addr;
+};
+
+struct sockaddr_in {
+    sa_family_t sin_family;
+    in_port_t sin_port;
+    struct in_addr sin_addr;
+    unsigned char sin_zero[8];
+};
+
+/* Socket API wrappers */
+int socket(int domain, int type, int protocol);
+int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
+int listen(int sockfd, int backlog);
+int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
+ssize_t send(int sockfd, const void *buf, size_t len, int flags);
+ssize_t recv(int sockfd, void *buf, size_t len, int flags);
+
+#endif /* SYS_SOCKET_H */

--- a/src/socket.c
+++ b/src/socket.c
@@ -1,0 +1,44 @@
+#include "sys/socket.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+
+extern long syscall(long number, ...);
+
+int socket(int domain, int type, int protocol)
+{
+    return (int)syscall(SYS_socket, domain, type, protocol);
+}
+
+int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+{
+    return (int)syscall(SYS_bind, sockfd, addr, addrlen);
+}
+
+int listen(int sockfd, int backlog)
+{
+    return (int)syscall(SYS_listen, sockfd, backlog);
+}
+
+int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
+{
+#ifdef SYS_accept4
+    return (int)syscall(SYS_accept4, sockfd, addr, addrlen, 0);
+#else
+    return (int)syscall(SYS_accept, sockfd, addr, addrlen);
+#endif
+}
+
+int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+{
+    return (int)syscall(SYS_connect, sockfd, addr, addrlen);
+}
+
+ssize_t send(int sockfd, const void *buf, size_t len, int flags)
+{
+    return (ssize_t)syscall(SYS_sendto, sockfd, buf, len, flags, NULL, 0);
+}
+
+ssize_t recv(int sockfd, void *buf, size_t len, int flags)
+{
+    return (ssize_t)syscall(SYS_recvfrom, sockfd, buf, len, flags, NULL, NULL);
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1,6 +1,7 @@
 #include "minunit.h"
 #include "../include/memory.h"
 #include "../include/io.h"
+#include "../include/sys/socket.h"
 
 #include <fcntl.h>
 #include <string.h>
@@ -38,10 +39,20 @@ static const char *test_io(void)
     return 0;
 }
 
+static const char *test_socket(void)
+{
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    mu_assert("socket creation failed", fd >= 0);
+    if (fd >= 0)
+        close(fd);
+    return 0;
+}
+
 static const char *all_tests(void)
 {
     mu_run_test(test_malloc);
     mu_run_test(test_io);
+    mu_run_test(test_socket);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- add socket API definitions and wrappers
- include real `<string.h>` after custom header
- compile new socket module
- install new sys headers
- extend unit tests with a simple socket case

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857174b86f48324b1c0845d36edc5eb