### PR TITLE
Implement errno and raw syscall handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ SRC := \
     src/process.c \
     src/string.c \
     src/socket.c \
+    src/syscall.c \
     src/mmap.c \
     src/env.c \
     src/time.c \

--- a/include/syscall.h
+++ b/include/syscall.h
@@ -1,0 +1,4 @@
+#ifndef VLIBC_SYSCALL_H
+#define VLIBC_SYSCALL_H
+long vlibc_syscall(long number, ...);
+#endif

--- a/src/io.c
+++ b/src/io.c
@@ -3,10 +3,10 @@
 #include <sys/types.h>
 #include <sys/syscall.h>
 #include <unistd.h>
+#include "syscall.h"
 #include <fcntl.h>
 #include <stdarg.h>
 
-extern long syscall(long number, ...);
 
 int open(const char *path, int flags, ...)
 {
@@ -18,9 +18,9 @@ int open(const char *path, int flags, ...)
         va_end(ap);
     }
 #ifdef SYS_open
-    long ret = syscall(SYS_open, path, flags, mode);
+    long ret = vlibc_syscall(SYS_open, (long)path, flags, mode, 0, 0, 0);
 #else
-    long ret = syscall(SYS_openat, AT_FDCWD, path, flags, mode);
+    long ret = vlibc_syscall(SYS_openat, AT_FDCWD, (long)path, flags, mode, 0, 0);
 #endif
     if (ret < 0) {
         errno = -ret;
@@ -31,7 +31,7 @@ int open(const char *path, int flags, ...)
 
 ssize_t read(int fd, void *buf, size_t count)
 {
-    long ret = syscall(SYS_read, fd, buf, count);
+    long ret = vlibc_syscall(SYS_read, fd, (long)buf, count, 0, 0, 0);
     if (ret < 0) {
         errno = -ret;
         return -1;
@@ -41,7 +41,7 @@ ssize_t read(int fd, void *buf, size_t count)
 
 ssize_t write(int fd, const void *buf, size_t count)
 {
-    long ret = syscall(SYS_write, fd, buf, count);
+    long ret = vlibc_syscall(SYS_write, fd, (long)buf, count, 0, 0, 0);
     if (ret < 0) {
         errno = -ret;
         return -1;
@@ -51,7 +51,7 @@ ssize_t write(int fd, const void *buf, size_t count)
 
 int close(int fd)
 {
-    long ret = syscall(SYS_close, fd);
+    long ret = vlibc_syscall(SYS_close, fd, 0, 0, 0, 0, 0);
     if (ret < 0) {
         errno = -ret;
         return -1;

--- a/src/mmap.c
+++ b/src/mmap.c
@@ -1,15 +1,25 @@
 #include "sys/mman.h"
+#include "errno.h"
 #include <sys/syscall.h>
 #include <unistd.h>
-
-extern long syscall(long number, ...);
+#include "syscall.h"
 
 void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
 {
-    return (void *)syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
+    long ret = vlibc_syscall(SYS_mmap, (long)addr, length, prot, flags, fd, offset);
+    if (ret < 0) {
+        errno = -ret;
+        return (void *)-1;
+    }
+    return (void *)ret;
 }
 
 int munmap(void *addr, size_t length)
 {
-    return (int)syscall(SYS_munmap, addr, length);
+    long ret = vlibc_syscall(SYS_munmap, (long)addr, length, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
 }

--- a/src/process.c
+++ b/src/process.c
@@ -5,15 +5,14 @@
 #include <unistd.h>
 #include <signal.h>
 #include <string.h>
-
-extern long syscall(long number, ...);
+#include "syscall.h"
 
 pid_t fork(void)
 {
 #ifdef SYS_fork
-    long ret = syscall(SYS_fork);
+    long ret = vlibc_syscall(SYS_fork, 0, 0, 0, 0, 0, 0);
 #else
-    long ret = syscall(SYS_clone, SIGCHLD, 0);
+    long ret = vlibc_syscall(SYS_clone, SIGCHLD, 0, 0, 0, 0, 0);
 #endif
     if (ret < 0) {
         errno = -ret;
@@ -24,7 +23,7 @@ pid_t fork(void)
 
 int execve(const char *pathname, char *const argv[], char *const envp[])
 {
-    long ret = syscall(SYS_execve, pathname, argv, envp);
+    long ret = vlibc_syscall(SYS_execve, (long)pathname, (long)argv, (long)envp, 0, 0, 0);
     if (ret < 0) {
         errno = -ret;
         return -1;
@@ -35,9 +34,9 @@ int execve(const char *pathname, char *const argv[], char *const envp[])
 pid_t waitpid(pid_t pid, int *status, int options)
 {
 #ifdef SYS_waitpid
-    long ret = syscall(SYS_waitpid, pid, status, options);
+    long ret = vlibc_syscall(SYS_waitpid, pid, (long)status, options, 0, 0, 0);
 #else
-    long ret = syscall(SYS_wait4, pid, status, options, NULL);
+    long ret = vlibc_syscall(SYS_wait4, pid, (long)status, options, 0, 0, 0);
 #endif
     if (ret < 0) {
         errno = -ret;
@@ -48,7 +47,7 @@ pid_t waitpid(pid_t pid, int *status, int options)
 
 int kill(pid_t pid, int sig)
 {
-    long ret = syscall(SYS_kill, pid, sig);
+    long ret = vlibc_syscall(SYS_kill, pid, sig, 0, 0, 0, 0);
     if (ret < 0) {
         errno = -ret;
         return -1;
@@ -59,7 +58,7 @@ int kill(pid_t pid, int sig)
 
 void _exit(int status)
 {
-    syscall(SYS_exit, status);
+    vlibc_syscall(SYS_exit, status, 0, 0, 0, 0, 0);
     for (;;) {}
 }
 
@@ -75,14 +74,14 @@ sighandler_t signal(int signum, sighandler_t handler)
     struct sigaction act, old;
     memset(&act, 0, sizeof(act));
     act.sa_handler = handler;
-    long ret = syscall(SYS_rt_sigaction, signum, &act, &old, sizeof(sigset_t));
+    long ret = vlibc_syscall(SYS_rt_sigaction, signum, (long)&act, (long)&old, sizeof(sigset_t), 0, 0);
     if (ret < 0) {
         errno = -ret;
         return SIG_ERR;
     }
     return old.sa_handler;
 #else
-    long ret = syscall(SYS_signal, signum, handler);
+    long ret = vlibc_syscall(SYS_signal, signum, (long)handler, 0, 0, 0, 0);
     if (ret < 0) {
         errno = -ret;
         return SIG_ERR;

--- a/src/socket.c
+++ b/src/socket.c
@@ -1,44 +1,79 @@
 #include "sys/socket.h"
+#include "errno.h"
 #include <sys/syscall.h>
 #include <unistd.h>
-
-extern long syscall(long number, ...);
+#include "syscall.h"
 
 int socket(int domain, int type, int protocol)
 {
-    return (int)syscall(SYS_socket, domain, type, protocol);
+    long ret = vlibc_syscall(SYS_socket, domain, type, protocol, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
 }
 
 int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
-    return (int)syscall(SYS_bind, sockfd, addr, addrlen);
+    long ret = vlibc_syscall(SYS_bind, sockfd, (long)addr, addrlen, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
 }
 
 int listen(int sockfd, int backlog)
 {
-    return (int)syscall(SYS_listen, sockfd, backlog);
+    long ret = vlibc_syscall(SYS_listen, sockfd, backlog, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
 }
 
 int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 {
 #ifdef SYS_accept4
-    return (int)syscall(SYS_accept4, sockfd, addr, addrlen, 0);
+    long ret = vlibc_syscall(SYS_accept4, sockfd, (long)addr, (long)addrlen, 0, 0, 0);
 #else
-    return (int)syscall(SYS_accept, sockfd, addr, addrlen);
+    long ret = vlibc_syscall(SYS_accept, sockfd, (long)addr, (long)addrlen, 0, 0, 0);
 #endif
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
 }
 
 int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
-    return (int)syscall(SYS_connect, sockfd, addr, addrlen);
+    long ret = vlibc_syscall(SYS_connect, sockfd, (long)addr, addrlen, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
 }
 
 ssize_t send(int sockfd, const void *buf, size_t len, int flags)
 {
-    return (ssize_t)syscall(SYS_sendto, sockfd, buf, len, flags, NULL, 0);
+    long ret = vlibc_syscall(SYS_sendto, sockfd, (long)buf, len, flags, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (ssize_t)ret;
 }
 
 ssize_t recv(int sockfd, void *buf, size_t len, int flags)
 {
-    return (ssize_t)syscall(SYS_recvfrom, sockfd, buf, len, flags, NULL, NULL);
+    long ret = vlibc_syscall(SYS_recvfrom, sockfd, (long)buf, len, flags, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (ssize_t)ret;
 }

--- a/src/stat.c
+++ b/src/stat.c
@@ -1,20 +1,35 @@
 #include "sys/stat.h"
+#include "errno.h"
 #include <sys/syscall.h>
 #include <unistd.h>
-
-extern long syscall(long number, ...);
+#include "syscall.h"
 
 int stat(const char *path, struct stat *buf)
 {
-    return (int)syscall(SYS_stat, path, buf);
+    long ret = vlibc_syscall(SYS_stat, (long)path, (long)buf, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
 }
 
 int fstat(int fd, struct stat *buf)
 {
-    return (int)syscall(SYS_fstat, fd, buf);
+    long ret = vlibc_syscall(SYS_fstat, fd, (long)buf, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
 }
 
 int lstat(const char *path, struct stat *buf)
 {
-    return (int)syscall(SYS_lstat, path, buf);
+    long ret = vlibc_syscall(SYS_lstat, (long)path, (long)buf, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
 }

--- a/src/stdio.c
+++ b/src/stdio.c
@@ -1,6 +1,7 @@
 #include "stdio.h"
 #include "io.h"
 #include "memory.h"
+#include "errno.h"
 #include <fcntl.h>
 #include <string.h>
 
@@ -30,6 +31,7 @@ FILE *fopen(const char *path, const char *mode)
     FILE *f = malloc(sizeof(FILE));
     if (!f) {
         close(fd);
+        errno = ENOMEM;
         return NULL;
     }
     f->fd = fd;

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdint.h>
+
+long vlibc_syscall(long number, ...)
+{
+    va_list ap;
+    va_start(ap, number);
+    unsigned long a1 = va_arg(ap, unsigned long);
+    unsigned long a2 = va_arg(ap, unsigned long);
+    unsigned long a3 = va_arg(ap, unsigned long);
+    unsigned long a4 = va_arg(ap, unsigned long);
+    unsigned long a5 = va_arg(ap, unsigned long);
+    unsigned long a6 = va_arg(ap, unsigned long);
+    va_end(ap);
+
+    register unsigned long r10 __asm__("r10") = a4;
+    register unsigned long r8 __asm__("r8") = a5;
+    register unsigned long r9 __asm__("r9") = a6;
+    unsigned long ret;
+    __asm__ volatile("syscall"
+                     : "=a"(ret)
+                     : "a"(number), "D"(a1), "S"(a2), "d"(a3),
+                       "r"(r10), "r"(r8), "r"(r9)
+                     : "rcx", "r11", "memory");
+    return (long)ret;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -7,6 +7,8 @@
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
 
 int tests_run = 0;
 
@@ -49,6 +51,23 @@ static const char *test_socket(void)
     return 0;
 }
 
+static const char *test_errno_open(void)
+{
+    int fd = open("/this/file/does/not/exist", O_RDONLY);
+    mu_assert("open should fail", fd == -1);
+    mu_assert("errno should be ENOENT", errno == ENOENT);
+    return 0;
+}
+
+static const char *test_errno_stat(void)
+{
+    struct stat st;
+    int r = stat("/this/file/does/not/exist", &st);
+    mu_assert("stat should fail", r == -1);
+    mu_assert("errno should be ENOENT", errno == ENOENT);
+    return 0;
+}
+
 static const char *test_stat_wrappers(void)
 {
     const char *fname = "tmp_stat_file";
@@ -84,6 +103,8 @@ static const char *all_tests(void)
     mu_run_test(test_malloc);
     mu_run_test(test_io);
     mu_run_test(test_socket);
+    mu_run_test(test_errno_open);
+    mu_run_test(test_errno_stat);
     mu_run_test(test_stat_wrappers);
     return 0;
 }


### PR DESCRIPTION
## Summary
- add raw syscall helper and header
- update wrappers to use raw syscalls and set `errno`
- test error conditions for `open` and `stat`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68571f80ea888324bb05ff3fac91d294