### PR TITLE
Implement vlibc memory ops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ SRC := \
     src/io.c \
     src/stdio.c \
     src/memory.c \
+    src/memory_ops.c \
     src/process.c \
     src/string.c \
     src/socket.c \

--- a/include/string.h
+++ b/include/string.h
@@ -7,6 +7,11 @@ size_t vstrlen(const char *s);
 char *vstrcpy(char *dest, const char *src);
 int vstrncmp(const char *s1, const char *s2, size_t n);
 
+void *vmemcpy(void *dest, const void *src, size_t n);
+void *vmemmove(void *dest, const void *src, size_t n);
+void *vmemset(void *s, int c, size_t n);
+int vmemcmp(const void *s1, const void *s2, size_t n);
+
 #endif /* STRING_H */
 
 #include_next <string.h>

--- a/src/env.c
+++ b/src/env.c
@@ -1,7 +1,6 @@
 #include "env.h"
 #include "memory.h"
 #include "string.h"
-#include <string.h>
 
 /* pointer to current environment */
 char **environ = 0;
@@ -50,9 +49,9 @@ int setenv(const char *name, const char *value, int overwrite)
     char *entry = malloc(nlen + vlen + 2); /* name=value\0 */
     if (!entry)
         return -1;
-    memcpy(entry, name, nlen);
+    vmemcpy(entry, name, nlen);
     entry[nlen] = '=';
-    memcpy(entry + nlen + 1, value, vlen);
+    vmemcpy(entry + nlen + 1, value, vlen);
     entry[nlen + 1 + vlen] = '\0';
 
     if (idx >= 0) {

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,6 +1,6 @@
 #include "memory.h"
 #include <unistd.h>
-#include <string.h>
+#include "string.h"
 #include <stdint.h>
 
 /* Declare sbrk for strict environments */
@@ -64,7 +64,7 @@ void *calloc(size_t nmemb, size_t size)
     size_t total = nmemb * size;
     void *ptr = malloc(total);
     if (ptr)
-        memset(ptr, 0, total);
+        vmemset(ptr, 0, total);
     return ptr;
 }
 
@@ -75,6 +75,6 @@ void *realloc(void *ptr, size_t size)
 
     void *new_ptr = malloc(size);
     if (new_ptr && size > 0)
-        memmove(new_ptr, ptr, size);
+        vmemmove(new_ptr, ptr, size);
     return new_ptr;
 }

--- a/src/memory_ops.c
+++ b/src/memory_ops.c
@@ -1,0 +1,48 @@
+#include "string.h"
+
+void *vmemset(void *s, int c, size_t n)
+{
+    unsigned char *p = s;
+    while (n--)
+        *p++ = (unsigned char)c;
+    return s;
+}
+
+void *vmemcpy(void *dest, const void *src, size_t n)
+{
+    unsigned char *d = dest;
+    const unsigned char *s = src;
+    while (n--)
+        *d++ = *s++;
+    return dest;
+}
+
+void *vmemmove(void *dest, const void *src, size_t n)
+{
+    unsigned char *d = dest;
+    const unsigned char *s = src;
+    if (d == s || n == 0)
+        return dest;
+    if (d < s) {
+        while (n--)
+            *d++ = *s++;
+    } else {
+        d += n;
+        s += n;
+        while (n--)
+            *--d = *--s;
+    }
+    return dest;
+}
+
+int vmemcmp(const void *s1, const void *s2, size_t n)
+{
+    const unsigned char *p1 = s1;
+    const unsigned char *p2 = s2;
+    while (n--) {
+        if (*p1 != *p2)
+            return *p1 - *p2;
+        p1++; p2++;
+    }
+    return 0;
+}

--- a/src/process.c
+++ b/src/process.c
@@ -4,7 +4,7 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 #include <signal.h>
-#include <string.h>
+#include "string.h"
 
 extern long syscall(long number, ...);
 
@@ -73,7 +73,7 @@ sighandler_t signal(int signum, sighandler_t handler)
 {
 #ifdef SYS_rt_sigaction
     struct sigaction act, old;
-    memset(&act, 0, sizeof(act));
+    vmemset(&act, 0, sizeof(act));
     act.sa_handler = handler;
     long ret = syscall(SYS_rt_sigaction, signum, &act, &old, sizeof(sigset_t));
     if (ret < 0) {


### PR DESCRIPTION
## Summary
- implement `vmemset`, `vmemcpy`, `vmemmove`, and `vmemcmp`
- expose prototypes in the public header
- compile new source file and use these helpers internally
- test the new memory primitives

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68571f8f60a0832483ebe8367e952584