### PR TITLE
Implement common string helpers

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -7,6 +7,11 @@ size_t vstrlen(const char *s);
 char *vstrcpy(char *dest, const char *src);
 int vstrncmp(const char *s1, const char *s2, size_t n);
 
+int strcmp(const char *s1, const char *s2);
+char *strchr(const char *s, int c);
+char *strdup(const char *s);
+char *strncpy(char *dest, const char *src, size_t n);
+
 #endif /* STRING_H */
 
 #include_next <string.h>

--- a/src/string.c
+++ b/src/string.c
@@ -1,4 +1,5 @@
 #include "string.h"
+#include "memory.h"
 
 size_t vstrlen(const char *s)
 {
@@ -29,4 +30,45 @@ int vstrncmp(const char *s1, const char *s2, size_t n)
             break;
     }
     return 0;
+}
+
+int strcmp(const char *s1, const char *s2)
+{
+    return vstrncmp(s1, s2, (size_t)-1);
+}
+
+char *strchr(const char *s, int c)
+{
+    unsigned char ch = (unsigned char)c;
+    while (*s) {
+        if ((unsigned char)*s == ch)
+            return (char *)s;
+        s++;
+    }
+    if (ch == '\0')
+        return (char *)s;
+    return NULL;
+}
+
+char *strdup(const char *s)
+{
+    size_t len = vstrlen(s);
+    char *dup = malloc(len + 1);
+    if (!dup)
+        return NULL;
+    vstrcpy(dup, s);
+    return dup;
+}
+
+char *strncpy(char *dest, const char *src, size_t n)
+{
+    char *d = dest;
+    while (n && *src) {
+        *d++ = *src++;
+        --n;
+    }
+    while (n--) {
+        *d++ = '\0';
+    }
+    return dest;
 }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -79,12 +79,38 @@ static const char *test_stat_wrappers(void)
     return 0;
 }
 
+static const char *test_string_helpers(void)
+{
+    mu_assert("strcmp equal", strcmp("abc", "abc") == 0);
+    mu_assert("strcmp lt", strcmp("abc", "abd") < 0);
+    mu_assert("strcmp gt", strcmp("abd", "abc") > 0);
+
+    const char *p = strchr("hello", 'e');
+    mu_assert("strchr failed", p && p - "hello" == 1);
+
+    char tmp[5];
+    for (int i = 0; i < 5; ++i) tmp[i] = 'X';
+    strncpy(tmp, "abc", 2);
+    mu_assert("strncpy partial", tmp[0] == 'a' && tmp[1] == 'b' && tmp[2] == 'X');
+
+    char buf[5];
+    strncpy(buf, "hi", sizeof(buf));
+    mu_assert("strncpy pad", buf[2] == '\0' && buf[3] == '\0');
+
+    char *dup = strdup("test");
+    mu_assert("strdup failed", dup && strcmp(dup, "test") == 0);
+    free(dup);
+
+    return 0;
+}
+
 static const char *all_tests(void)
 {
     mu_run_test(test_malloc);
     mu_run_test(test_io);
     mu_run_test(test_socket);
     mu_run_test(test_stat_wrappers);
+    mu_run_test(test_string_helpers);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- extend public string header with common C functions
- implement strcmp/strchr/strdup/strncpy
- add unit tests covering the new helpers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68571f990f788324a86aefd745c6ca92