### PR TITLE
Add stdlib env prototypes and tests

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -1,0 +1,12 @@
+#ifndef STDLIB_H
+#define STDLIB_H
+
+#include <stddef.h>
+
+/* Environment variable access */
+extern char **environ;
+char *getenv(const char *name);
+int setenv(const char *name, const char *value, int overwrite);
+int unsetenv(const char *name);
+
+#endif /* STDLIB_H */

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -7,6 +7,8 @@
 
 #include <fcntl.h>
 #include "../include/string.h"
+#include "../include/stdlib.h"
+#include "../include/env.h"
 #include <unistd.h>
 #include <stdio.h>
 #include <errno.h>
@@ -142,6 +144,9 @@ static const char *test_string_helpers(void)
     mu_assert("strdup failed", dup && strcmp(dup, "test") == 0);
     free(dup);
 
+    return 0;
+}
+
 static const char *test_printf_functions(void)
 {
     char buf[32];
@@ -167,6 +172,31 @@ static const char *test_printf_functions(void)
     return 0;
 }
 
+static const char *test_environment(void)
+{
+    env_init(NULL);
+    mu_assert("empty env", getenv("FOO") == NULL);
+
+    int r = setenv("FOO", "BAR", 0);
+    mu_assert("setenv new", r == 0);
+    char *v = getenv("FOO");
+    mu_assert("getenv new", v && strcmp(v, "BAR") == 0);
+
+    r = setenv("FOO", "BAZ", 0);
+    v = getenv("FOO");
+    mu_assert("no overwrite", v && strcmp(v, "BAR") == 0);
+
+    r = setenv("FOO", "BAZ", 1);
+    mu_assert("overwrite", r == 0);
+    v = getenv("FOO");
+    mu_assert("getenv overwrite", v && strcmp(v, "BAZ") == 0);
+
+    unsetenv("FOO");
+    mu_assert("unsetenv", getenv("FOO") == NULL);
+
+    return 0;
+}
+
 static const char *all_tests(void)
 {
     mu_run_test(test_malloc);
@@ -178,6 +208,7 @@ static const char *all_tests(void)
     mu_run_test(test_stat_wrappers);
     mu_run_test(test_string_helpers);
     mu_run_test(test_printf_functions);
+    mu_run_test(test_environment);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- add new `include/stdlib.h` providing environment prototypes
- fix `test_vlibc` by closing `test_string_helpers`
- add tests for environment variable functions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857336a8f8883248d5a188d76d28961