### PR TITLE
Add sleep wrappers with tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SRC := \
     src/syscall.c \
     src/mmap.c \
     src/env.c \
+    src/sleep.c \
     src/time.c \
     src/stat.c
 

--- a/include/time.h
+++ b/include/time.h
@@ -2,6 +2,10 @@
 #define TIME_H
 
 #include <sys/types.h>
+#ifndef __useconds_t_defined
+typedef unsigned useconds_t;
+#define __useconds_t_defined
+#endif
 
 struct timespec {
     time_t tv_sec;
@@ -15,5 +19,10 @@ struct timeval {
 
 time_t time(time_t *t);
 int gettimeofday(struct timeval *tv, void *tz);
+
+/* sleep helpers */
+unsigned sleep(unsigned seconds);
+int usleep(useconds_t usec);
+int nanosleep(const struct timespec *req, struct timespec *rem);
 
 #endif /* TIME_H */

--- a/src/sleep.c
+++ b/src/sleep.c
@@ -1,0 +1,35 @@
+#include "time.h"
+#include "errno.h"
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int nanosleep(const struct timespec *req, struct timespec *rem)
+{
+    long ret = vlibc_syscall(SYS_nanosleep, (long)req, (long)rem, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+}
+
+int usleep(useconds_t usec)
+{
+    struct timespec ts;
+    ts.tv_sec = usec / 1000000;
+    ts.tv_nsec = (usec % 1000000) * 1000;
+    return nanosleep(&ts, NULL);
+}
+
+unsigned sleep(unsigned seconds)
+{
+    struct timespec ts = {seconds, 0};
+    struct timespec rem = {0, 0};
+    int r = nanosleep(&ts, &rem);
+    if (r < 0 && errno == EINTR)
+        return rem.tv_sec;
+    return 0;
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <errno.h>
+#include "../include/time.h"
 
 /* use host printf for test output */
 int printf(const char *fmt, ...);
@@ -142,6 +143,9 @@ static const char *test_string_helpers(void)
     mu_assert("strdup failed", dup && strcmp(dup, "test") == 0);
     free(dup);
 
+    return 0;
+}
+
 static const char *test_printf_functions(void)
 {
     char buf[32];
@@ -167,6 +171,29 @@ static const char *test_printf_functions(void)
     return 0;
 }
 
+static const char *test_sleep_functions(void)
+{
+    time_t t1 = time(NULL);
+    unsigned r = sleep(1);
+    time_t t2 = time(NULL);
+    mu_assert("sleep returned", r == 0);
+    mu_assert("sleep delay", t2 - t1 >= 1 && t2 - t1 <= 3);
+
+    t1 = time(NULL);
+    mu_assert("usleep failed", usleep(500000) == 0);
+    mu_assert("usleep failed2", usleep(500000) == 0);
+    t2 = time(NULL);
+    mu_assert("usleep delay", t2 - t1 >= 1 && t2 - t1 <= 3);
+
+    struct timespec ts = {1, 0};
+    t1 = time(NULL);
+    mu_assert("nanosleep failed", nanosleep(&ts, NULL) == 0);
+    t2 = time(NULL);
+    mu_assert("nanosleep delay", t2 - t1 >= 1 && t2 - t1 <= 3);
+
+    return 0;
+}
+
 static const char *all_tests(void)
 {
     mu_run_test(test_malloc);
@@ -178,6 +205,7 @@ static const char *all_tests(void)
     mu_run_test(test_stat_wrappers);
     mu_run_test(test_string_helpers);
     mu_run_test(test_printf_functions);
+    mu_run_test(test_sleep_functions);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- expose nanosleep/usleep/sleep declarations
- implement wrappers using `SYS_nanosleep`
- compile new file
- add unit tests exercising the new functions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68573359d2d083248a3c1fa479175fdc