### PR TITLE
Add standard streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ make test
 
 This command builds `tests/run_tests` and runs it automatically.
 
+## Standard Streams
+
+vlibc's stdio layer exposes global pointers `stdin`, `stdout`, and
+`stderr`. These lightweight streams wrap file descriptors 0, 1 and 2 and
+are initialized when `vlibc_init()` is called. They can be used with the
+provided `fread`, `fwrite`, `fprintf`, and `printf` functions.
+
 ## Limitations
 
 - The I/O routines (`open`, `read`, `write`, `close`) are thin wrappers around

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -7,6 +7,10 @@ typedef struct {
     int fd;
 } FILE;
 
+extern FILE *stdin;
+extern FILE *stdout;
+extern FILE *stderr;
+
 FILE *fopen(const char *path, const char *mode);
 size_t fread(void *ptr, size_t size, size_t nmemb, FILE *stream);
 size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);

--- a/src/init.c
+++ b/src/init.c
@@ -1,7 +1,18 @@
 #include "vlibc.h"
+#include "stdio.h"
+#include "memory.h"
 
-/* Placeholder implementation. */
 void vlibc_init(void)
 {
-    /* Nothing to do yet. */
+    stdin = malloc(sizeof(FILE));
+    if (stdin)
+        stdin->fd = 0;
+
+    stdout = malloc(sizeof(FILE));
+    if (stdout)
+        stdout->fd = 1;
+
+    stderr = malloc(sizeof(FILE));
+    if (stderr)
+        stderr->fd = 2;
 }

--- a/src/stdio.c
+++ b/src/stdio.c
@@ -5,6 +5,10 @@
 #include <fcntl.h>
 #include <string.h>
 
+FILE *stdin = NULL;
+FILE *stdout = NULL;
+FILE *stderr = NULL;
+
 FILE *fopen(const char *path, const char *mode)
 {
     int flags = -1;

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -297,6 +297,9 @@ static const char *test_sleep_functions(void)
     t2 = time(NULL);
     mu_assert("nanosleep delay", t2 - t1 >= 1 && t2 - t1 <= 3);
 
+    return 0;
+}
+
 static const char *test_environment(void)
 {
     env_init(NULL);
@@ -336,6 +339,9 @@ static const char *test_dirent(void)
     }
     closedir(d);
     mu_assert("entries missing", found == 3);
+
+    return 0;
+}
 
 static const char *all_tests(void)
 {

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -101,6 +101,11 @@ if (fd >= 0) {
 }
 ```
 
+The stdio module also exposes `stdin`, `stdout`, and `stderr` as global
+pointers. These streams wrap file descriptors 0, 1 and 2 and are
+initialized in `vlibc_init()` so they can be used with the basic FILE
+APIs.
+
 ## String Handling
 
 The **string** module provides fundamental operations needed by most C programs:


### PR DESCRIPTION
## Summary
- expose `stdin`, `stdout` and `stderr` in the stdio API
- initialise the streams in `vlibc_init`
- update docs with the new global streams
- fix missing return statements in tests

## Testing
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_685736e28ae083249a12b0ed9460ef7a