### PR TITLE
Add simple string conversion functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ SRC := \
     src/memory_ops.c \
     src/process.c \
     src/string.c \
+    src/strto.c \
     src/socket.c \
     src/fd.c \
     src/syscall.c \

--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ make test
 
 This command builds `tests/run_tests` and runs it automatically.
 
+## String Conversion
+
+vlibc provides simple helpers to convert strings into integers. Use
+`atoi()` for basic decimal parsing or `strtol()` when you need other
+bases or the end pointer.
+
+```c
+int v = atoi("123");            /* v == 123 */
+char *end;
+long x = strtol("ff", &end, 16); /* x == 255 and *end == '\0' */
+```
+
 ## Limitations
 
 - The I/O routines (`open`, `read`, `write`, `close`) are thin wrappers around

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -9,4 +9,8 @@ char *getenv(const char *name);
 int setenv(const char *name, const char *value, int overwrite);
 int unsetenv(const char *name);
 
+/* String conversion */
+long strtol(const char *nptr, char **endptr, int base);
+int atoi(const char *nptr);
+
 #endif /* STDLIB_H */

--- a/src/strto.c
+++ b/src/strto.c
@@ -1,0 +1,69 @@
+#include "stdlib.h"
+#include "string.h"
+
+static int digit_val(char c)
+{
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    if (c >= 'a' && c <= 'z')
+        return c - 'a' + 10;
+    if (c >= 'A' && c <= 'Z')
+        return c - 'A' + 10;
+    return -1;
+}
+
+long strtol(const char *nptr, char **endptr, int base)
+{
+    const char *s = nptr;
+    while (*s == ' ' || *s == '\t' || *s == '\n' || *s == '\r' || *s == '\f' || *s == '\v')
+        s++;
+
+    int neg = 0;
+    if (*s == '+' || *s == '-') {
+        if (*s == '-')
+            neg = 1;
+        s++;
+    }
+
+    if (base == 0) {
+        if (*s == '0') {
+            if (s[1] == 'x' || s[1] == 'X') {
+                base = 16;
+                s += 2;
+            } else {
+                base = 8;
+                s += 1;
+            }
+        } else {
+            base = 10;
+        }
+    } else if (base == 16) {
+        if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X'))
+            s += 2;
+    }
+
+    unsigned long val = 0;
+    const char *start = s;
+    int d;
+    while ((d = digit_val(*s)) >= 0 && d < base) {
+        val = val * (unsigned long)base + (unsigned long)d;
+        s++;
+    }
+
+    if (endptr)
+        *endptr = (char *)(s != start ? s : nptr);
+
+    if (s == start)
+        return 0;
+
+    long result = (long)val;
+    if (neg)
+        result = -result;
+    return result;
+}
+
+int atoi(const char *nptr)
+{
+    return (int)strtol(nptr, NULL, 10);
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -234,6 +234,11 @@ static const char *test_string_helpers(void)
     mu_assert("strdup failed", dup && strcmp(dup, "test") == 0);
     free(dup);
 
+    mu_assert("atoi", atoi("42") == 42);
+    char *end;
+    mu_assert("strtol hex", strtol("ff", &end, 16) == 255 && *end == '\0');
+    mu_assert("strtol partial", strtol("12xy", &end, 10) == 12 && strcmp(end, "xy") == 0);
+
     return 0;
 }
 
@@ -297,6 +302,10 @@ static const char *test_sleep_functions(void)
     t2 = time(NULL);
     mu_assert("nanosleep delay", t2 - t1 >= 1 && t2 - t1 <= 3);
 
+    return 0;
+}
+
+
 static const char *test_environment(void)
 {
     env_init(NULL);
@@ -336,6 +345,10 @@ static const char *test_dirent(void)
     }
     closedir(d);
     mu_assert("entries missing", found == 3);
+
+    return 0;
+}
+
 
 static const char *all_tests(void)
 {

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -108,6 +108,7 @@ The **string** module provides fundamental operations needed by most C programs:
 - `vstrlen`, `vstrcpy`, and `vstrncmp` equivalents.
 - Minimal locale or encoding support; all strings are treated as byte sequences.
 - Utility functions for tokenizing and simple formatting.
+- Simple number conversion helpers `atoi` and `strtol`.
 
 The goal is to offer just enough functionality for common tasks without the complexity of full locale-aware libraries.
 


### PR DESCRIPTION
## Summary
- provide `strtol` and `atoi` prototypes
- implement new `src/strto.c`
- document conversion helpers in README and vlibcdoc
- test conversions via unit tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685736f25a9c83248b02882da608dec5