### PR TITLE
Expose standard memory functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 PREFIX ?= /usr/local
 CC ?= cc
-CFLAGS ?= -O2 -std=c11 -Wall -Wextra -fno-stack-protector -Iinclude
+CFLAGS ?= -O2 -std=c11 -Wall -Wextra -fno-stack-protector -fno-builtin -Iinclude
 AR ?= ar
 
 SRC := \

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ The repository uses a straightforward layout:
 - `include/` holds public header files.
 - `tests/` contains unit tests.
 
+Common memory routines (`memcpy`, `memmove`, `memset`, `memcmp`) are available
+as wrappers around the internal `v*` implementations so existing code can use
+the familiar names.
+
 ## Building the Library
 
 The project uses a simple `make`-based build system. To compile the

--- a/include/string.h
+++ b/include/string.h
@@ -15,6 +15,11 @@ void *vmemmove(void *dest, const void *src, size_t n);
 void *vmemset(void *s, int c, size_t n);
 int vmemcmp(const void *s1, const void *s2, size_t n);
 
+void *memcpy(void *dest, const void *src, size_t n);
+void *memmove(void *dest, const void *src, size_t n);
+void *memset(void *s, int c, size_t n);
+int memcmp(const void *s1, const void *s2, size_t n);
+
 #endif /* STRING_H */
 
 #include_next <string.h>

--- a/src/memory_ops.c
+++ b/src/memory_ops.c
@@ -46,3 +46,23 @@ int vmemcmp(const void *s1, const void *s2, size_t n)
     }
     return 0;
 }
+
+void *memset(void *s, int c, size_t n)
+{
+    return vmemset(s, c, n);
+}
+
+void *memcpy(void *dest, const void *src, size_t n)
+{
+    return vmemcpy(dest, src, n);
+}
+
+void *memmove(void *dest, const void *src, size_t n)
+{
+    return vmemmove(dest, src, n);
+}
+
+int memcmp(const void *s1, const void *s2, size_t n)
+{
+    return vmemcmp(s1, s2, n);
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -77,6 +77,18 @@ static const char *test_memory_ops(void)
     mu_assert("vmemmove failed", buf[1] == 'a' && buf[2] == 'b');
 
     mu_assert("vmemcmp diff", vmemcmp("abc", "abd", 3) < 0);
+
+    memset(buf, 'y', sizeof(buf));
+    for (size_t i = 0; i < sizeof(buf); i++)
+        mu_assert("memset failed", buf[i] == 'y');
+
+    memcpy(buf, src, 8);
+    mu_assert("memcpy failed", memcmp(buf, src, 8) == 0);
+
+    memmove(buf + 2, buf, 6);
+    mu_assert("memmove std failed", buf[2] == 'a' && buf[3] == 'b');
+
+    mu_assert("memcmp diff std", memcmp("abc", "abd", 3) < 0);
     return 0;
 }
 
@@ -297,6 +309,9 @@ static const char *test_sleep_functions(void)
     t2 = time(NULL);
     mu_assert("nanosleep delay", t2 - t1 >= 1 && t2 - t1 <= 3);
 
+    return 0;
+}
+
 static const char *test_environment(void)
 {
     env_init(NULL);
@@ -337,6 +352,8 @@ static const char *test_dirent(void)
     closedir(d);
     mu_assert("entries missing", found == 3);
 
+    return 0;
+}
 static const char *all_tests(void)
 {
     mu_run_test(test_malloc);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -106,6 +106,8 @@ if (fd >= 0) {
 The **string** module provides fundamental operations needed by most C programs:
 
 - `vstrlen`, `vstrcpy`, and `vstrncmp` equivalents.
+- Conventional memory routines (`memcpy`, `memmove`, `memset`, `memcmp`) map to
+  the internal `v` implementations.
 - Minimal locale or encoding support; all strings are treated as byte sequences.
 - Utility functions for tokenizing and simple formatting.
 


### PR DESCRIPTION
## Summary
- provide memcpy/memmove/memset/memcmp names in `string.h`
- implement these wrappers in `memory_ops.c`
- document the availability of standard memory routines
- adjust build flags to avoid builtin recursion
- expand unit tests to exercise the new wrappers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857370a5fd483249b9790034415304d