### PR TITLE
Implement system()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ SRC := \
     src/memory.c \
     src/memory_ops.c \
     src/process.c \
+    src/system.c \
     src/string.c \
     src/socket.c \
     src/fd.c \

--- a/README.md
+++ b/README.md
@@ -88,5 +88,7 @@ This command builds `tests/run_tests` and runs it automatically.
 - Process creation and signal functions rely on Linux `fork`, `execve`,
   `wait4`/`waitpid`, and `rt_sigaction` syscalls. Porting to other UNIX-like
   kernels may require adapting these calls.
+- The `system()` helper simply spawns `/bin/sh -c` in a child process.
+  It does not handle complex quoting or return detailed status codes.
 - Basic thread support is implemented using the `clone` syscall. Only
   `pthread_create`, `pthread_join`, and simple mutexes are provided.

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -9,4 +9,7 @@ char *getenv(const char *name);
 int setenv(const char *name, const char *value, int overwrite);
 int unsetenv(const char *name);
 
+/* Execute a shell command */
+int system(const char *command);
+
 #endif /* STDLIB_H */

--- a/src/system.c
+++ b/src/system.c
@@ -1,0 +1,26 @@
+#include "process.h"
+#include "stdlib.h"
+#include "string.h"
+
+/* Simple implementation of system(3) using fork/execve/waitpid */
+int system(const char *command)
+{
+    if (!command)
+        return 1;
+
+    pid_t pid = fork();
+    if (pid < 0)
+        return -1;
+    if (pid == 0) {
+        char *argv[] = {"/bin/sh", "-c", (char *)command, NULL};
+        extern char **environ;
+        execve("/bin/sh", argv, environ);
+        _exit(127);
+    }
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0)
+        return -1;
+    return status;
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -297,6 +297,9 @@ static const char *test_sleep_functions(void)
     t2 = time(NULL);
     mu_assert("nanosleep delay", t2 - t1 >= 1 && t2 - t1 <= 3);
 
+    return 0;
+}
+
 static const char *test_environment(void)
 {
     env_init(NULL);
@@ -322,6 +325,15 @@ static const char *test_environment(void)
     return 0;
 }
 
+static const char *test_system_fn(void)
+{
+    int r = system("true");
+    mu_assert("system true", r == 0);
+    r = system("exit 7");
+    mu_assert("system exit code", (r >> 8) == 7);
+    return 0;
+}
+
 static const char *test_dirent(void)
 {
     DIR *d = opendir("tests");
@@ -336,6 +348,9 @@ static const char *test_dirent(void)
     }
     closedir(d);
     mu_assert("entries missing", found == 3);
+
+    return 0;
+}
 
 static const char *all_tests(void)
 {
@@ -353,6 +368,7 @@ static const char *all_tests(void)
     mu_run_test(test_pthread);
     mu_run_test(test_sleep_functions);
     mu_run_test(test_environment);
+    mu_run_test(test_system_fn);
     mu_run_test(test_dirent);
 
     return 0;

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -123,6 +123,7 @@ int execve(const char *pathname, char *const argv[], char *const envp[]);
 pid_t waitpid(pid_t pid, int *status, int options);
 int kill(pid_t pid, int sig);
 sighandler_t signal(int signum, sighandler_t handler);
+int system(const char *command);
 ```
 
 ### Example
@@ -141,6 +142,10 @@ void on_int(int signo) { (void)signo; }
 signal(SIGINT, on_int);
 kill(getpid(), SIGINT);
 ```
+
+The convenience `system()` call executes a shell command by forking and
+invoking `/bin/sh -c command`. It returns the raw status from `waitpid`
+and is intended only for simple helper tasks.
 
 
 The design favors straightforward semantics over comprehensive POSIX


### PR DESCRIPTION
## Summary
- expose `system()` in the public headers
- implement `system()` using `fork`, `execve`, and `waitpid`
- test command execution with new unit test
- document how `system()` works and its limitations

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857371ce4d88324838fa2242594f67b