### PR TITLE
Add file removal and rename wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SRC := \
     src/strto.c \
     src/socket.c \
     src/fd.c \
+    src/file.c \
     src/syscall.c \
     src/mmap.c \
     src/env.c \

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ provided `fread`, `fwrite`, `fprintf`, and `printf` functions.
 
 ## Limitations
 
-- The I/O routines (`open`, `read`, `write`, `close`) are thin wrappers around
+- The I/O routines (`open`, `read`, `write`, `close`, `unlink`, `rename`) are thin wrappers around
   the corresponding system calls. They perform no buffering and provide only
   basic error reporting.
 - Process creation and signal functions rely on Linux `fork`, `execve`,

--- a/include/io.h
+++ b/include/io.h
@@ -11,5 +11,7 @@ off_t lseek(int fd, off_t offset, int whence);
 int dup(int oldfd);
 int dup2(int oldfd, int newfd);
 int pipe(int pipefd[2]);
+int unlink(const char *pathname);
+int rename(const char *oldpath, const char *newpath);
 
 #endif /* IO_H */

--- a/src/file.c
+++ b/src/file.c
@@ -1,0 +1,31 @@
+#include "io.h"
+#include "errno.h"
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <fcntl.h>
+#ifndef AT_FDCWD
+#define AT_FDCWD -100
+#endif
+#include "syscall.h"
+
+int unlink(const char *pathname)
+{
+    long ret = vlibc_syscall(SYS_unlinkat, AT_FDCWD, (long)pathname, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+}
+
+int rename(const char *oldpath, const char *newpath)
+{
+    long ret = vlibc_syscall(SYS_renameat, AT_FDCWD, (long)oldpath, AT_FDCWD,
+                             (long)newpath, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -87,6 +87,8 @@ int open(const char *path, int flags, mode_t mode);
 ssize_t read(int fd, void *buf, size_t count);
 ssize_t write(int fd, const void *buf, size_t count);
 int close(int fd);
+int unlink(const char *pathname);
+int rename(const char *oldpath, const char *newpath);
 ```
 
 These functions forward their arguments directly to the kernel using the syscall interface. No buffering or stream abstraction is performed.


### PR DESCRIPTION
## Summary
- expose `unlink` and `rename` declarations in `include/io.h`
- implement `unlink` and `rename` using `SYS_unlinkat` and `SYS_renameat`
- build new source file in Makefile
- document the new APIs in README and `vlibcdoc.md`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857394b4f7c83248b6f10b3772c2dd0