### PR TITLE
Add qsort/bsearch with tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ SRC := \
     src/time.c \
     src/stat.c \
     src/pthread.c \
-    src/dirent.c
+    src/dirent.c \
+    src/qsort.c
 
 OBJ := $(SRC:.c=.o)
 LIB := libvlibc.a

--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ char *end;
 long x = strtol("ff", &end, 16); /* x == 255 and *end == '\0' */
 ```
 
+## Sorting Helpers
+
+`qsort()` sorts an array in-place using a user-provided comparison
+function, while `bsearch()` performs binary search on a sorted array.
+
+```c
+int values[] = {4, 2, 7};
+qsort(values, 3, sizeof(int), cmp_int);
+int key = 7;
+int *found = bsearch(&key, values, 3, sizeof(int), cmp_int);
+```
+
 ## Standard Streams
 
 vlibc's stdio layer exposes global pointers `stdin`, `stdout`, and

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -16,4 +16,10 @@ int system(const char *command);
 long strtol(const char *nptr, char **endptr, int base);
 int atoi(const char *nptr);
 
+/* Sorting helpers */
+void qsort(void *base, size_t nmemb, size_t size,
+           int (*compar)(const void *, const void *));
+void *bsearch(const void *key, const void *base, size_t nmemb, size_t size,
+              int (*compar)(const void *, const void *));
+
 #endif /* STDLIB_H */

--- a/src/qsort.c
+++ b/src/qsort.c
@@ -1,0 +1,45 @@
+#include "stdlib.h"
+
+static void swap(char *a, char *b, size_t size)
+{
+    while (size--) {
+        char tmp = *a;
+        *a++ = *b;
+        *b++ = tmp;
+    }
+}
+
+void qsort(void *base, size_t nmemb, size_t size,
+           int (*compar)(const void *, const void *))
+{
+    char *b = base;
+    for (size_t i = 0; i < nmemb; i++) {
+        for (size_t j = i + 1; j < nmemb; j++) {
+            char *pi = b + i * size;
+            char *pj = b + j * size;
+            if (compar(pi, pj) > 0)
+                swap(pi, pj, size);
+        }
+    }
+}
+
+void *bsearch(const void *key, const void *base, size_t nmemb, size_t size,
+              int (*compar)(const void *, const void *))
+{
+    size_t low = 0;
+    size_t high = nmemb;
+    const char *b = base;
+
+    while (low < high) {
+        size_t mid = (low + high) / 2;
+        const void *elem = b + mid * size;
+        int c = compar(key, elem);
+        if (c < 0)
+            high = mid;
+        else if (c > 0)
+            low = mid + 1;
+        else
+            return (void *)elem;
+    }
+    return NULL;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -369,6 +369,48 @@ static const char *test_dirent(void)
     return 0;
 }
 
+static int int_cmp(const void *a, const void *b)
+{
+    int ia = *(const int *)a;
+    int ib = *(const int *)b;
+    return (ia > ib) - (ia < ib);
+}
+
+static int str_cmp(const void *a, const void *b)
+{
+    const char *sa = *(const char * const *)a;
+    const char *sb = *(const char * const *)b;
+    return strcmp(sa, sb);
+}
+
+static const char *test_qsort_int(void)
+{
+    int arr[] = {4, 2, 7, 1, -1};
+    qsort(arr, 5, sizeof(int), int_cmp);
+    int sorted[] = {-1, 1, 2, 4, 7};
+    for (int i = 0; i < 5; ++i)
+        mu_assert("int sort", arr[i] == sorted[i]);
+
+    int key = 4;
+    int *res = bsearch(&key, arr, 5, sizeof(int), int_cmp);
+    mu_assert("bsearch int", res && *res == 4);
+    return 0;
+}
+
+static const char *test_qsort_strings(void)
+{
+    const char *arr[] = {"pear", "apple", "orange", "banana"};
+    qsort((void *)arr, 4, sizeof(char *), str_cmp);
+    const char *sorted[] = {"apple", "banana", "orange", "pear"};
+    for (int i = 0; i < 4; ++i)
+        mu_assert("string sort", strcmp(arr[i], sorted[i]) == 0);
+
+    const char *key = "orange";
+    char **p = bsearch(&key, arr, 4, sizeof(char *), str_cmp);
+    mu_assert("bsearch str", p && strcmp(*p, "orange") == 0);
+    return 0;
+}
+
 static const char *all_tests(void)
 {
     mu_run_test(test_malloc);
@@ -387,6 +429,8 @@ static const char *all_tests(void)
     mu_run_test(test_environment);
     mu_run_test(test_system_fn);
     mu_run_test(test_dirent);
+    mu_run_test(test_qsort_int);
+    mu_run_test(test_qsort_strings);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- declare qsort/bsearch in stdlib.h
- implement both helpers
- compile new source file
- cover sorting and searching in tests
- document sorting helpers in the README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685739a1e298832482191219f8feff8c