### PR TITLE
Implement getpid/getppid wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ vlibc's stdio layer exposes global pointers `stdin`, `stdout`, and
 are initialized when `vlibc_init()` is called. They can be used with the
 provided `fread`, `fwrite`, `fprintf`, and `printf` functions.
 
+## Process Control
+
+The process module forwards common process-management calls directly to the kernel. Wrappers are available for `fork`, `execve`, `waitpid`, `kill`, `getpid`, `getppid`, and `signal`. A simple `system()` convenience function is also included.
 
 ## Limitations
 

--- a/include/process.h
+++ b/include/process.h
@@ -9,6 +9,8 @@ pid_t fork(void);
 int execve(const char *pathname, char *const argv[], char *const envp[]);
 pid_t waitpid(pid_t pid, int *status, int options);
 int kill(pid_t pid, int sig);
+pid_t getpid(void);
+pid_t getppid(void);
 
 void _exit(int status);
 void exit(int status);

--- a/src/process.c
+++ b/src/process.c
@@ -57,6 +57,26 @@ int kill(pid_t pid, int sig)
     return (int)ret;
 }
 
+pid_t getpid(void)
+{
+    long ret = vlibc_syscall(SYS_getpid, 0, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (pid_t)ret;
+}
+
+pid_t getppid(void)
+{
+    long ret = vlibc_syscall(SYS_getppid, 0, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (pid_t)ret;
+}
+
 
 void _exit(int status)
 {

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -11,6 +11,7 @@
 #include "../include/string.h"
 #include "../include/stdlib.h"
 #include "../include/env.h"
+#include "../include/process.h"
 #include <unistd.h>
 #include <stdio.h>
 #include <errno.h>
@@ -342,6 +343,14 @@ static const char *test_environment(void)
     return 0;
 }
 
+static const char *test_pid_functions(void)
+{
+    pid_t self = getpid();
+    mu_assert("getpid positive", self > 0);
+    mu_assert("getppid positive", getppid() > 0);
+    return 0;
+}
+
 static const char *test_system_fn(void)
 {
     int r = system("true");
@@ -385,6 +394,7 @@ static const char *all_tests(void)
     mu_run_test(test_pthread);
     mu_run_test(test_sleep_functions);
     mu_run_test(test_environment);
+    mu_run_test(test_pid_functions);
     mu_run_test(test_system_fn);
     mu_run_test(test_dirent);
 

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -122,14 +122,16 @@ The goal is to offer just enough functionality for common tasks without the comp
 ## Process Control
 
 Process-related functionality resides in the **process** module. It provides
-minimal wrappers for creating and managing processes as well as installing
-signal handlers:
+minimal wrappers for creating and managing processes, querying process IDs,
+and installing signal handlers:
 
 ```c
 pid_t fork(void);
 int execve(const char *pathname, char *const argv[], char *const envp[]);
 pid_t waitpid(pid_t pid, int *status, int options);
 int kill(pid_t pid, int sig);
+pid_t getpid(void);
+pid_t getppid(void);
 sighandler_t signal(int signum, sighandler_t handler);
 int system(const char *command);
 ```


### PR DESCRIPTION
## Summary
- expose `getpid` and `getppid` in `process.h`
- implement the wrappers via direct syscalls
- document new process helpers in README and vlibcdoc
- test the new calls in the unit suite

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68573976139483249a6dd14c029bf3a4