### PR TITLE
Implement fseek/ftell/rewind

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ int *found = bsearch(&key, values, 3, sizeof(int), cmp_int);
 vlibc's stdio layer exposes global pointers `stdin`, `stdout`, and
 `stderr`. These lightweight streams wrap file descriptors 0, 1 and 2 and
 are initialized when `vlibc_init()` is called. They can be used with the
-provided `fread`, `fwrite`, `fprintf`, and `printf` functions.
+provided `fread`, `fwrite`, `fseek`, `ftell`, `rewind`, `fprintf`, and
+`printf` functions.
 
 ## Process Control
 

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -15,6 +15,9 @@ FILE *fopen(const char *path, const char *mode);
 size_t fread(void *ptr, size_t size, size_t nmemb, FILE *stream);
 size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
 int fclose(FILE *stream);
+int fseek(FILE *stream, long offset, int whence);
+long ftell(FILE *stream);
+void rewind(FILE *stream);
 
 int printf(const char *format, ...);
 int fprintf(FILE *stream, const char *format, ...);

--- a/src/stdio.c
+++ b/src/stdio.c
@@ -4,6 +4,7 @@
 #include "errno.h"
 #include <fcntl.h>
 #include <string.h>
+#include <unistd.h>
 
 FILE *stdin = NULL;
 FILE *stdout = NULL;
@@ -71,5 +72,30 @@ int fclose(FILE *stream)
     int ret = close(stream->fd);
     free(stream);
     return ret;
+}
+
+int fseek(FILE *stream, long offset, int whence)
+{
+    if (!stream)
+        return -1;
+    off_t r = lseek(stream->fd, (off_t)offset, whence);
+    return r == (off_t)-1 ? -1 : 0;
+}
+
+long ftell(FILE *stream)
+{
+    if (!stream)
+        return -1L;
+    off_t r = lseek(stream->fd, 0, SEEK_CUR);
+    if (r == (off_t)-1)
+        return -1L;
+    return (long)r;
+}
+
+void rewind(FILE *stream)
+{
+    if (!stream)
+        return;
+    lseek(stream->fd, 0, SEEK_SET);
 }
 

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -280,6 +280,36 @@ static const char *test_printf_functions(void)
     return 0;
 }
 
+static const char *test_fseek_rewind(void)
+{
+    FILE *f = fopen("tmp_seek", "w+");
+    mu_assert("fopen seek", f != NULL);
+
+    const char *msg = "abcdef";
+    size_t w = fwrite(msg, 1, strlen(msg), f);
+    mu_assert("fwrite seek", w == strlen(msg));
+
+    mu_assert("fseek set", fseek(f, 0, SEEK_SET) == 0);
+    char buf[4] = {0};
+    size_t r = fread(buf, 1, 3, f);
+    mu_assert("fread seek", r == 3);
+    mu_assert("content seek", strncmp(buf, "abc", 3) == 0);
+
+    long pos = ftell(f);
+    mu_assert("ftell pos", pos == 3);
+
+    mu_assert("fseek end", fseek(f, 0, SEEK_END) == 0);
+    pos = ftell(f);
+    mu_assert("ftell end", pos == (long)strlen(msg));
+
+    rewind(f);
+    mu_assert("rewind pos", ftell(f) == 0);
+
+    fclose(f);
+    unlink("tmp_seek");
+    return 0;
+}
+
 
 static const char *test_pthread(void)
 {
@@ -442,6 +472,7 @@ static const char *all_tests(void)
     mu_run_test(test_stat_wrappers);
     mu_run_test(test_string_helpers);
     mu_run_test(test_printf_functions);
+    mu_run_test(test_fseek_rewind);
     mu_run_test(test_pthread);
     mu_run_test(test_sleep_functions);
     mu_run_test(test_environment);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -106,7 +106,9 @@ if (fd >= 0) {
 The stdio module also exposes `stdin`, `stdout`, and `stderr` as global
 pointers. These streams wrap file descriptors 0, 1 and 2 and are
 initialized in `vlibc_init()` so they can be used with the basic FILE
-APIs.
+APIs. Available helpers include `fopen`, `fread`, `fwrite`, `fseek`,
+`ftell`, `rewind`, `fclose`, and simple formatted output via `fprintf`
+and `printf`.
 
 ## String Handling
 


### PR DESCRIPTION
## Summary
- extend stdio.h with `fseek`, `ftell`, `rewind`
- implement the seek helpers using `lseek`
- test seek and rewind behavior
- document the new APIs in README and vlibcdoc

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68573af023ec8324bad9d765fea8e0b8