### PR TITLE
Add basic strftime and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ SRC := \
     src/env.c \
     src/sleep.c \
     src/time.c \
+    src/strftime.c \
     src/stat.c \
     src/pthread.c \
     src/dirent.c

--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ vlibc's stdio layer exposes global pointers `stdin`, `stdout`, and
 are initialized when `vlibc_init()` is called. They can be used with the
 provided `fread`, `fwrite`, `fprintf`, and `printf` functions.
 
+## Time Formatting
+
+The library includes a minimal `strftime` implementation for producing
+human-readable timestamps. Supported conversion sequences are `%Y`, `%m`,
+`%d`, `%H`, `%M`, and `%S`. All other specifiers are copied verbatim and
+no locale handling is performed.
+
 
 ## Limitations
 

--- a/include/time.h
+++ b/include/time.h
@@ -2,6 +2,7 @@
 #define TIME_H
 
 #include <sys/types.h>
+#include <stddef.h>
 #ifndef __useconds_t_defined
 typedef unsigned useconds_t;
 #define __useconds_t_defined
@@ -17,6 +18,18 @@ struct timeval {
     long tv_usec;
 };
 
+struct tm {
+    int tm_sec;   /* seconds [0,60] */
+    int tm_min;   /* minutes [0,59] */
+    int tm_hour;  /* hours [0,23] */
+    int tm_mday;  /* day of month [1,31] */
+    int tm_mon;   /* months since January [0,11] */
+    int tm_year;  /* years since 1900 */
+    int tm_wday;  /* days since Sunday [0,6] */
+    int tm_yday;  /* days since January 1 [0,365] */
+    int tm_isdst; /* daylight savings time flag */
+};
+
 time_t time(time_t *t);
 int gettimeofday(struct timeval *tv, void *tz);
 
@@ -24,5 +37,7 @@ int gettimeofday(struct timeval *tv, void *tz);
 unsigned sleep(unsigned seconds);
 int usleep(useconds_t usec);
 int nanosleep(const struct timespec *req, struct timespec *rem);
+
+size_t strftime(char *s, size_t max, const char *format, const struct tm *tm);
 
 #endif /* TIME_H */

--- a/src/strftime.c
+++ b/src/strftime.c
@@ -1,0 +1,103 @@
+#include "time.h"
+#include "string.h"
+
+static int fmt_int(char *buf, size_t size, int val, int width)
+{
+    char tmp[16];
+    int pos = 0;
+    if (val < 0)
+        val = -val;
+    do {
+        tmp[pos++] = '0' + (val % 10);
+        val /= 10;
+    } while (val && pos < (int)sizeof(tmp));
+    while (pos < width && pos < (int)sizeof(tmp))
+        tmp[pos++] = '0';
+    if (pos > (int)size)
+        pos = (int)size;
+    for (int i = 0; i < pos; ++i)
+        buf[i] = tmp[pos - i - 1];
+    return pos;
+}
+
+size_t strftime(char *s, size_t max, const char *format, const struct tm *tm)
+{
+    if (!s || !format || !tm || max == 0)
+        return 0;
+    size_t pos = 0;
+    for (const char *p = format; *p; ++p) {
+        if (*p != '%') {
+            if (pos + 1 >= max)
+                return 0;
+            s[pos++] = *p;
+            continue;
+        }
+        ++p;
+        if (!*p)
+            break;
+        char buf[16];
+        int len = 0;
+        switch (*p) {
+        case '%':
+            if (pos + 1 >= max)
+                return 0;
+            s[pos++] = '%';
+            break;
+        case 'Y':
+            len = fmt_int(buf, sizeof(buf), tm->tm_year + 1900, 4);
+            if (pos + (size_t)len >= max)
+                return 0;
+            memcpy(s + pos, buf, (size_t)len);
+            pos += (size_t)len;
+            break;
+        case 'm':
+            len = fmt_int(buf, sizeof(buf), tm->tm_mon + 1, 2);
+            if (pos + (size_t)len >= max)
+                return 0;
+            memcpy(s + pos, buf, (size_t)len);
+            pos += (size_t)len;
+            break;
+        case 'd':
+            len = fmt_int(buf, sizeof(buf), tm->tm_mday, 2);
+            if (pos + (size_t)len >= max)
+                return 0;
+            memcpy(s + pos, buf, (size_t)len);
+            pos += (size_t)len;
+            break;
+        case 'H':
+            len = fmt_int(buf, sizeof(buf), tm->tm_hour, 2);
+            if (pos + (size_t)len >= max)
+                return 0;
+            memcpy(s + pos, buf, (size_t)len);
+            pos += (size_t)len;
+            break;
+        case 'M':
+            len = fmt_int(buf, sizeof(buf), tm->tm_min, 2);
+            if (pos + (size_t)len >= max)
+                return 0;
+            memcpy(s + pos, buf, (size_t)len);
+            pos += (size_t)len;
+            break;
+        case 'S':
+            len = fmt_int(buf, sizeof(buf), tm->tm_sec, 2);
+            if (pos + (size_t)len >= max)
+                return 0;
+            memcpy(s + pos, buf, (size_t)len);
+            pos += (size_t)len;
+            break;
+        default:
+            if (pos + 1 >= max)
+                return 0;
+            s[pos++] = '%';
+            if (pos + 1 >= max)
+                return 0;
+            s[pos++] = *p;
+            break;
+        }
+    }
+    if (pos >= max)
+        return 0;
+    s[pos] = '\0';
+    return pos;
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -317,6 +317,23 @@ static const char *test_sleep_functions(void)
     return 0;
 }
 
+static const char *test_strftime_basic(void)
+{
+    struct tm tm = {
+        .tm_year = 123,
+        .tm_mon = 4,
+        .tm_mday = 6,
+        .tm_hour = 7,
+        .tm_min = 8,
+        .tm_sec = 9
+    };
+    char buf[32];
+    size_t n = strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &tm);
+    mu_assert("strftime len", n == strlen("2023-05-06 07:08:09"));
+    mu_assert("strftime str", strcmp(buf, "2023-05-06 07:08:09") == 0);
+    return 0;
+}
+
 static const char *test_environment(void)
 {
     env_init(NULL);
@@ -384,6 +401,7 @@ static const char *all_tests(void)
     mu_run_test(test_printf_functions);
     mu_run_test(test_pthread);
     mu_run_test(test_sleep_functions);
+    mu_run_test(test_strftime_basic);
     mu_run_test(test_environment);
     mu_run_test(test_system_fn);
     mu_run_test(test_dirent);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -119,6 +119,10 @@ The **string** module provides fundamental operations needed by most C programs:
 - Utility functions for tokenizing and simple formatting.
 - Simple number conversion helpers `atoi` and `strtol`.
 
+Basic time formatting is available via `strftime`. Only a small subset of
+conversions is implemented (`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`) and the
+output always uses the C locale.
+
 The goal is to offer just enough functionality for common tasks without the complexity of full locale-aware libraries.
 
 ## Process Control


### PR DESCRIPTION
## Summary
- add `struct tm` and `strftime` prototype
- implement minimal `strftime`
- test formatting results
- document time formatting support

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68573a4f61f883249e4b86c61425c3a1