### PR TITLE
Implement strtok and add tests

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -19,6 +19,8 @@ void *memcpy(void *dest, const void *src, size_t n);
 void *memmove(void *dest, const void *src, size_t n);
 void *memset(void *s, int c, size_t n);
 int memcmp(const void *s1, const void *s2, size_t n);
+char *strtok(char *str, const char *delim);
+char *strtok_r(char *str, const char *delim, char **saveptr);
 
 #endif /* STRING_H */
 

--- a/src/string.c
+++ b/src/string.c
@@ -72,3 +72,48 @@ char *strncpy(char *dest, const char *src, size_t n)
     }
     return dest;
 }
+
+static char *strtok_static;
+
+char *strtok_r(char *str, const char *delim, char **saveptr)
+{
+    char *s;
+
+    if (str)
+        s = str;
+    else if (saveptr && *saveptr)
+        s = *saveptr;
+    else
+        return NULL;
+
+    /* skip leading delimiters */
+    while (*s && strchr(delim, *s))
+        s++;
+
+    if (*s == '\0') {
+        if (saveptr)
+            *saveptr = NULL;
+        return NULL;
+    }
+
+    char *token = s;
+
+    while (*s && !strchr(delim, *s))
+        s++;
+
+    if (*s) {
+        *s = '\0';
+        s++;
+        if (saveptr)
+            *saveptr = s;
+    } else if (saveptr) {
+        *saveptr = NULL;
+    }
+
+    return token;
+}
+
+char *strtok(char *str, const char *delim)
+{
+    return strtok_r(str, delim, &strtok_static);
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -308,6 +308,35 @@ static const char *test_string_helpers(void)
     return 0;
 }
 
+static const char *test_strtok_basic(void)
+{
+    char buf[] = "a,b,c";
+    char *tok = strtok(buf, ",");
+    mu_assert("tok1", tok && strcmp(tok, "a") == 0);
+    tok = strtok(NULL, ",");
+    mu_assert("tok2", tok && strcmp(tok, "b") == 0);
+    tok = strtok(NULL, ",");
+    mu_assert("tok3", tok && strcmp(tok, "c") == 0);
+    tok = strtok(NULL, ",");
+    mu_assert("tok end", tok == NULL);
+    return 0;
+}
+
+static const char *test_strtok_r_basic(void)
+{
+    char buf[] = "1 2 3";
+    char *save = NULL;
+    char *tok = strtok_r(buf, " ", &save);
+    mu_assert("tok_r1", tok && strcmp(tok, "1") == 0);
+    tok = strtok_r(NULL, " ", &save);
+    mu_assert("tok_r2", tok && strcmp(tok, "2") == 0);
+    tok = strtok_r(NULL, " ", &save);
+    mu_assert("tok_r3", tok && strcmp(tok, "3") == 0);
+    tok = strtok_r(NULL, " ", &save);
+    mu_assert("tok_r end", tok == NULL);
+    return 0;
+}
+
 static const char *test_printf_functions(void)
 {
     char buf[32];
@@ -581,6 +610,8 @@ static const char *all_tests(void)
     mu_run_test(test_errno_stat);
     mu_run_test(test_stat_wrappers);
     mu_run_test(test_string_helpers);
+    mu_run_test(test_strtok_basic);
+    mu_run_test(test_strtok_r_basic);
     mu_run_test(test_printf_functions);
     mu_run_test(test_fseek_rewind);
     mu_run_test(test_fgetc_fputc);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -120,6 +120,9 @@ The **string** module provides fundamental operations needed by most C programs:
   the internal `v` implementations.
 - Minimal locale or encoding support; all strings are treated as byte sequences.
 - Utility functions for tokenizing and simple formatting.
+- `strtok` and `strtok_r` split a string into tokens based on a set of
+  delimiter characters. `strtok` uses internal static storage while
+  `strtok_r` lets the caller maintain context.
 - Simple number conversion helpers `atoi` and `strtol`.
 
 Basic time formatting is available via `strftime`. Only a small subset of


### PR DESCRIPTION
## Summary
- add `strtok` and `strtok_r` prototypes
- implement tokenization helpers
- document usage in the manual
- test basic `strtok` and `strtok_r` operation

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68573e3287808324a5453302701df704