### PR TITLE
Implement popen/pclose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ SRC := \
     src/stat.c \
     src/pthread.c \
     src/dirent.c \
-    src/qsort.c
+    src/qsort.c \
+    src/popen.c
 
 OBJ := $(SRC:.c=.o)
 LIB := libvlibc.a

--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ prints the current `errno` value with an optional prefix.
 
 The process module forwards common process-management calls directly to the kernel. Wrappers are available for `fork`, `execve`, `waitpid`, `kill`, `getpid`, `getppid`, and `signal`. A simple `system()` convenience function is also included.
 
+A lightweight `popen`/`pclose` pair runs a shell command with a pipe
+connected to the child. Use mode `"r"` to read the command's output or
+`"w"` to send data to its stdin:
+
+```c
+FILE *f = popen("echo hi", "r");
+char buf[16] = {0};
+fread(buf, 1, sizeof(buf) - 1, f);
+pclose(f);
+```
+
 ## Time Formatting
 
 The library includes a minimal `strftime` implementation for producing

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -27,4 +27,7 @@ int snprintf(char *str, size_t size, const char *format, ...);
 char *strerror(int errnum);
 void perror(const char *s);
 
+FILE *popen(const char *command, const char *mode);
+int pclose(FILE *stream);
+
 #endif /* STDIO_H */

--- a/src/popen.c
+++ b/src/popen.c
@@ -1,0 +1,79 @@
+#include "stdio.h"
+#include "process.h"
+#include "io.h"
+#include "memory.h"
+#include "string.h"
+
+struct popen_file {
+    FILE file;
+    pid_t pid;
+};
+
+FILE *popen(const char *command, const char *mode)
+{
+    if (!command || !mode)
+        return NULL;
+
+    int read_mode = (mode[0] == 'r');
+    int write_mode = (mode[0] == 'w');
+    if (!read_mode && !write_mode)
+        return NULL;
+
+    int pipefd[2];
+    if (pipe(pipefd) < 0)
+        return NULL;
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(pipefd[0]);
+        close(pipefd[1]);
+        return NULL;
+    }
+
+    if (pid == 0) {
+        if (read_mode) {
+            dup2(pipefd[1], 1);
+            close(pipefd[0]);
+            close(pipefd[1]);
+        } else {
+            dup2(pipefd[0], 0);
+            close(pipefd[1]);
+            close(pipefd[0]);
+        }
+        char *argv[] = {"/bin/sh", "-c", (char *)command, NULL};
+        extern char **environ;
+        execve("/bin/sh", argv, environ);
+        _exit(127);
+    }
+
+    struct popen_file *pf = malloc(sizeof(struct popen_file));
+    if (!pf) {
+        close(pipefd[0]);
+        close(pipefd[1]);
+        return NULL;
+    }
+    pf->pid = pid;
+    if (read_mode) {
+        pf->file.fd = pipefd[0];
+        close(pipefd[1]);
+    } else {
+        pf->file.fd = pipefd[1];
+        close(pipefd[0]);
+    }
+    return &pf->file;
+}
+
+int pclose(FILE *stream)
+{
+    if (!stream)
+        return -1;
+    struct popen_file *pf = (struct popen_file *)stream;
+    pid_t pid = pf->pid;
+    close(stream->fd);
+    free(pf);
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0)
+        return -1;
+    return status;
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -452,6 +452,18 @@ static const char *test_system_fn(void)
     return 0;
 }
 
+static const char *test_popen_fn(void)
+{
+    FILE *f = popen("echo popen", "r");
+    mu_assert("popen", f != NULL);
+    char buf[32] = {0};
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    pclose(f);
+    mu_assert("popen read", n > 0);
+    mu_assert("popen content", strncmp(buf, "popen", 5) == 0);
+    return 0;
+}
+
 static const char *test_rand_fn(void)
 {
     srand(1);
@@ -540,9 +552,8 @@ static const char *all_tests(void)
     mu_run_test(test_sleep_functions);
     mu_run_test(test_strftime_basic);
     mu_run_test(test_environment);
-    mu_run_test(test_error_reporting);
-    mu_run_test(test_pid_functions);
     mu_run_test(test_system_fn);
+    mu_run_test(test_popen_fn);
     mu_run_test(test_rand_fn);
     mu_run_test(test_dirent);
     mu_run_test(test_qsort_int);


### PR DESCRIPTION
## Summary
- expose popen/pclose prototypes
- implement popen/pclose using fork/exec
- compile popen.c in the build system
- document basic popen usage
- add a simple popen test
- drop calls to missing tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68573d895c448324909ab769a3132a8f