### PR TITLE
Implement strnlen and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The repository uses a straightforward layout:
 Common memory routines (`memcpy`, `memmove`, `memset`, `memcmp`) are available
 as wrappers around the internal `v*` implementations so existing code can use
 the familiar names.
+Basic string helpers like `strcmp`, `strchr`, `strncpy`, `strdup`, and
+`strnlen` are also provided.
 
 ## Provided Headers
 

--- a/include/string.h
+++ b/include/string.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 
 size_t vstrlen(const char *s);
+size_t strnlen(const char *s, size_t maxlen);
 char *vstrcpy(char *dest, const char *src);
 int vstrncmp(const char *s1, const char *s2, size_t n);
 int strcmp(const char *s1, const char *s2);

--- a/src/string.c
+++ b/src/string.c
@@ -9,6 +9,14 @@ size_t vstrlen(const char *s)
     return (size_t)(p - s);
 }
 
+size_t strnlen(const char *s, size_t maxlen)
+{
+    const char *p = s;
+    while (maxlen-- && *p)
+        p++;
+    return (size_t)(p - s);
+}
+
 char *vstrcpy(char *dest, const char *src)
 {
     char *d = dest;

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -306,6 +306,10 @@ static const char *test_string_helpers(void)
     mu_assert("strtol hex", strtol("ff", &end, 16) == 255 && *end == '\0');
     mu_assert("strtol partial", strtol("12xy", &end, 10) == 12 && strcmp(end, "xy") == 0);
 
+    mu_assert("strnlen zero", strnlen("abc", 0) == 0);
+    mu_assert("strnlen short", strnlen("hello", 3) == 3);
+    mu_assert("strnlen full", strnlen("hi", 10) == 2);
+
     return 0;
 }
 

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -115,7 +115,7 @@ and `printf`.
 
 The **string** module provides fundamental operations needed by most C programs:
 
-- `vstrlen`, `vstrcpy`, and `vstrncmp` equivalents.
+- `vstrlen`, `vstrcpy`, `vstrncmp`, and `strnlen` equivalents.
 - Conventional memory routines (`memcpy`, `memmove`, `memset`, `memcmp`) map to
   the internal `v` implementations.
 - Minimal locale or encoding support; all strings are treated as byte sequences.


### PR DESCRIPTION
## Summary
- add `strnlen` declaration and implementation
- mention string helpers in README and docs
- test `strnlen` in unit tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68573fabffd0832480a8284fff103592