### PR TITLE
Add mprotect wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pthread.h    - minimal threading support
 stdio.h      - simple stream I/O
 stdlib.h     - basic utilities
 string.h     - string manipulation
-sys/mman.h   - memory mapping helpers
+sys/mman.h   - memory mapping helpers (mmap, munmap, mprotect)
 sys/socket.h - networking wrappers
 sys/stat.h   - file status functions
 syscall.h    - raw syscall interface

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -6,5 +6,8 @@
 
 void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
 int munmap(void *addr, size_t length);
+int mprotect(void *addr, size_t length, int prot);
 
 #endif /* MMAN_H */
+
+#include_next <sys/mman.h>

--- a/src/mmap.c
+++ b/src/mmap.c
@@ -23,3 +23,13 @@ int munmap(void *addr, size_t length)
     }
     return (int)ret;
 }
+
+int mprotect(void *addr, size_t length, int prot)
+{
+    long ret = vlibc_syscall(SYS_mprotect, (long)addr, length, prot, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include "../include/time.h"
+#include "../include/sys/mman.h"
 
 /* use host printf for test output */
 int printf(const char *fmt, ...);
@@ -584,6 +585,25 @@ static const char *test_rand_fn(void)
     return 0;
 }
 
+static const char *test_mprotect_anon(void)
+{
+    size_t len = 4096;
+    void *p = mmap(NULL, len, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    mu_assert("mmap", p != (void *)-1);
+
+    ((char *)p)[0] = 'a';
+
+    int r = mprotect(p, len, PROT_READ);
+    mu_assert("mprotect read", r == 0);
+
+    r = mprotect(p, len, PROT_READ | PROT_WRITE);
+    mu_assert("mprotect rw", r == 0);
+
+    munmap(p, len);
+    return 0;
+}
+
 static const char *test_dirent(void)
 {
     DIR *d = opendir("tests");
@@ -670,6 +690,7 @@ static const char *all_tests(void)
     mu_run_test(test_system_fn);
     mu_run_test(test_popen_fn);
     mu_run_test(test_rand_fn);
+    mu_run_test(test_mprotect_anon);
     mu_run_test(test_dirent);
     mu_run_test(test_qsort_int);
     mu_run_test(test_qsort_strings);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -79,6 +79,20 @@ allocate many objects may still eventually exhaust the heap. These routines are
 sufficient for
 small examples but should not be considered production quality.
 
+## Memory Mapping
+
+The `sys/mman.h` header exposes wrappers for interacting with the kernel's
+memory mapping facilities. Available functions are:
+
+```c
+void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
+int munmap(void *addr, size_t length);
+int mprotect(void *addr, size_t length, int prot);
+```
+
+`mmap` creates new mappings, `munmap` releases them and `mprotect` changes
+their access protections.
+
 ## Input/Output
 
 vlibc includes simple wrappers for the fundamental POSIX file APIs:


### PR DESCRIPTION
## Summary
- add `mprotect` prototype to `sys/mman.h`
- implement `mprotect` wrapper
- document memory protection API in README and vlibcdoc
- test anonymous mapping protection changes

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68573fc19ff88324a1aa642d3a617f01