### PR TITLE
Add basic getopt support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ SRC := \
     src/popen.c \
     src/ctype.c \
     src/select.c \
-    src/qsort.c
+    src/qsort.c \
+    src/getopt.c
 
 OBJ := $(SRC:.c=.o)
 LIB := libvlibc.a

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ pthread.h    - minimal threading support
 stdio.h      - simple stream I/O
 stdlib.h     - basic utilities
 string.h     - string manipulation
+getopt.h     - option parsing
 sys/mman.h   - memory mapping helpers
 sys/socket.h - networking wrappers
 sys/stat.h   - file status functions
@@ -149,6 +150,30 @@ int values[] = {4, 2, 7};
 qsort(values, 3, sizeof(int), cmp_int);
 int key = 7;
 int *found = bsearch(&key, values, 3, sizeof(int), cmp_int);
+```
+
+## Option Parsing
+
+`getopt()` iterates over command-line options. A character followed by `:` in the
+option string expects an argument. Parsing stops at the first non-option or `--`.
+
+```c
+int flag = 0;
+char *arg = NULL;
+int c;
+while ((c = getopt(argc, argv, "fa:")) != -1) {
+    switch (c) {
+    case 'f':
+        flag = 1;
+        break;
+    case 'a':
+        arg = optarg;
+        break;
+    default:
+        /* unknown option */
+        break;
+    }
+}
 ```
 
 ## Standard Streams

--- a/include/getopt.h
+++ b/include/getopt.h
@@ -1,0 +1,11 @@
+#ifndef GETOPT_H
+#define GETOPT_H
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+
+int getopt(int argc, char * const argv[], const char *optstring);
+
+#endif /* GETOPT_H */

--- a/src/getopt.c
+++ b/src/getopt.c
@@ -1,0 +1,55 @@
+#include "getopt.h"
+#include "stdio.h"
+#include "string.h"
+
+char *optarg = NULL;
+int optind = 1;
+int opterr = 1;
+int optopt = 0;
+
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+    static const char *next = NULL;
+
+    if (!next || *next == '\0') {
+        if (optind >= argc)
+            return -1;
+        const char *arg = argv[optind];
+        if (arg[0] != '-' || arg[1] == '\0')
+            return -1;
+        if (strcmp(arg, "--") == 0) {
+            optind++;
+            return -1;
+        }
+        next = arg + 1;
+        optind++;
+    }
+
+    char c = *next++;
+    const char *pos = strchr(optstring, c);
+    if (!pos) {
+        optopt = c;
+        if (opterr && optstring[0] != ':')
+            fprintf(stderr, "unknown option -%c\n", c);
+        return '?';
+    }
+
+    if (pos[1] == ':') {
+        if (*next != '\0') {
+            optarg = (char *)next;
+            next = NULL;
+        } else if (optind < argc) {
+            optarg = argv[optind++];
+            next = NULL;
+        } else {
+            optopt = c;
+            if (opterr && optstring[0] != ':')
+                fprintf(stderr, "option -%c requires argument\n", c);
+            return optstring[0] == ':' ? ':' : '?';
+        }
+    } else {
+        optarg = NULL;
+    }
+
+    return c;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -14,6 +14,7 @@
 #include "../include/stdlib.h"
 #include "../include/env.h"
 #include "../include/process.h"
+#include "../include/getopt.h"
 #include <unistd.h>
 #include <stdio.h>
 #include <errno.h>
@@ -554,8 +555,8 @@ static const char *test_error_reporting(void)
     mu_assert("strerror", msg && *msg != '\0');
     perror("test");
     vlibc_init();
-    const char *msg = strerror(ENOENT);
-    mu_assert("strerror", strcmp(msg, "No such file or directory") == 0);
+    const char *msg2 = strerror(ENOENT);
+    mu_assert("strerror", strcmp(msg2, "No such file or directory") == 0);
 
     int p[2];
     mu_assert("pipe", pipe(p) == 0);
@@ -696,6 +697,47 @@ static const char *test_qsort_strings(void)
     return 0;
 }
 
+static const char *test_getopt_basic(void)
+{
+    char *argv[] = {"prog", "-f", "-a", "val", "rest", NULL};
+    int argc = 5;
+    int flag = 0;
+    char *arg = NULL;
+    optind = 1;
+    opterr = 0;
+    int c;
+    while ((c = getopt(argc, argv, "fa:")) != -1) {
+        switch (c) {
+        case 'f':
+            flag = 1;
+            break;
+        case 'a':
+            arg = optarg;
+            break;
+        default:
+            return "unexpected opt";
+        }
+    }
+    mu_assert("flag", flag == 1);
+    mu_assert("arg", arg && strcmp(arg, "val") == 0);
+    mu_assert("optind", optind == 4);
+    mu_assert("rest", strcmp(argv[optind], "rest") == 0);
+    return 0;
+}
+
+static const char *test_getopt_missing(void)
+{
+    char *argv[] = {"prog", "-a", NULL};
+    int argc = 2;
+    optind = 1;
+    opterr = 0;
+    int r = getopt(argc, argv, "a:");
+    mu_assert("missing ret", r == '?');
+    mu_assert("optopt", optopt == 'a');
+    mu_assert("index", optind == 2);
+    return 0;
+}
+
 static const char *all_tests(void)
 {
     mu_run_test(test_malloc);
@@ -727,6 +769,8 @@ static const char *all_tests(void)
     mu_run_test(test_dirent);
     mu_run_test(test_qsort_int);
     mu_run_test(test_qsort_strings);
+    mu_run_test(test_getopt_basic);
+    mu_run_test(test_getopt_missing);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- implement a small `getopt` with globals
- expose API via new `getopt.h`
- document option parsing usage in README
- compile `getopt.c` and test it with new unit tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685740ae88548324b84cb4b9da050f5c