### PR TITLE
Implement poll wrapper and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ io.h         - unbuffered I/O primitives
 memory.h     - heap allocation
 process.h    - process creation and control
 pthread.h    - minimal threading support
+poll.h       - I/O multiplexing helpers
 stdio.h      - simple stream I/O
 stdlib.h     - basic utilities
 string.h     - string manipulation
@@ -163,8 +164,8 @@ provided `fread`, `fwrite`, `fseek`, `ftell`, `rewind`, `fgetc`,
 
 The socket layer exposes thin wrappers around the kernel's networking
 syscalls. Available functions include `socket`, `bind`, `listen`,
-`accept`, `connect`, `send`, `recv`, `sendto`, `recvfrom`, and
-`select`.
+`accept`, `connect`, `send`, `recv`, `sendto`, `recvfrom`, as well as
+the I/O multiplexing helpers `select` and `poll`.
 These calls accept the same arguments as their POSIX counterparts and
 translate directly to the underlying `socket`, `bind`, `connect`, and
 `sendto`/`recvfrom` syscalls.

--- a/include/poll.h
+++ b/include/poll.h
@@ -1,0 +1,23 @@
+#ifndef POLL_H
+#define POLL_H
+
+#include <sys/types.h>
+
+typedef unsigned long nfds_t;
+
+struct pollfd {
+    int fd;
+    short events;
+    short revents;
+};
+
+#define POLLIN  0x0001
+#define POLLPRI 0x0002
+#define POLLOUT 0x0004
+#define POLLERR 0x0008
+#define POLLHUP 0x0010
+#define POLLNVAL 0x0020
+
+int poll(struct pollfd *fds, nfds_t nfds, int timeout);
+
+#endif /* POLL_H */

--- a/src/select.c
+++ b/src/select.c
@@ -41,3 +41,35 @@ int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
     return -1;
 #endif
 }
+
+#include "poll.h"
+
+int poll(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+#ifdef SYS_poll
+    long ret = vlibc_syscall(SYS_poll, (long)fds, (long)nfds, timeout, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#elif defined(SYS_ppoll)
+    struct timespec ts;
+    struct timespec *pts = NULL;
+    if (timeout >= 0) {
+        ts.tv_sec = timeout / 1000;
+        ts.tv_nsec = (timeout % 1000) * 1000000;
+        pts = &ts;
+    }
+    long ret = vlibc_syscall(SYS_ppoll, (long)fds, (long)nfds, (long)pts, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#else
+    (void)fds; (void)nfds; (void)timeout;
+    errno = ENOSYS;
+    return -1;
+#endif
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -6,6 +6,7 @@
 #include "../include/stdio.h"
 #include "../include/pthread.h"
 #include "../include/sys/select.h"
+#include "../include/poll.h"
 #include "../include/dirent.h"
 #include "../include/vlibc.h"
 
@@ -482,6 +483,31 @@ static const char *test_select_pipe(void)
     return 0;
 }
 
+static const char *test_poll_pipe(void)
+{
+    int p[2];
+    mu_assert("pipe", pipe(p) == 0);
+
+    pthread_t t;
+    pthread_create(&t, NULL, delayed_write, &p[1]);
+
+    struct pollfd fds[1];
+    fds[0].fd = p[0];
+    fds[0].events = POLLIN;
+
+    int r = poll(fds, 1, 2000);
+    pthread_join(&t, NULL);
+    mu_assert("poll ret", r == 1);
+    mu_assert("poll event", fds[0].revents & POLLIN);
+
+    char c;
+    mu_assert("read", read(p[0], &c, 1) == 1 && c == 'z');
+
+    close(p[0]);
+    close(p[1]);
+    return 0;
+}
+
 static const char *test_sleep_functions(void)
 {
     time_t t1 = time(NULL);
@@ -554,8 +580,8 @@ static const char *test_error_reporting(void)
     mu_assert("strerror", msg && *msg != '\0');
     perror("test");
     vlibc_init();
-    const char *msg = strerror(ENOENT);
-    mu_assert("strerror", strcmp(msg, "No such file or directory") == 0);
+    const char *msg2 = strerror(ENOENT);
+    mu_assert("strerror", strcmp(msg2, "No such file or directory") == 0);
 
     int p[2];
     mu_assert("pipe", pipe(p) == 0);
@@ -717,6 +743,7 @@ static const char *all_tests(void)
     mu_run_test(test_fgets_fputs);
     mu_run_test(test_pthread);
     mu_run_test(test_select_pipe);
+    mu_run_test(test_poll_pipe);
     mu_run_test(test_sleep_functions);
     mu_run_test(test_strftime_basic);
     mu_run_test(test_environment);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -204,6 +204,9 @@ ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,
                const struct sockaddr *dest, socklen_t addrlen);
 ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
                  struct sockaddr *src, socklen_t *addrlen);
+int select(int nfds, fd_set *readfds, fd_set *writefds,
+           fd_set *exceptfds, struct timeval *timeout);
+int poll(struct pollfd *fds, nfds_t nfds, int timeout);
 ```
 
 These wrappers directly invoke the underlying `socket`, `bind`,


### PR DESCRIPTION
## Summary
- add new `poll` API and definitions
- implement `poll` syscall wrapper alongside `select`
- document the new I/O multiplexing helpers
- test `poll` using a pipe
- fix a variable clash in error reporting test

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685740b86b5c8324af211a877314f241