### PR TITLE
Implement execvp helper and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,9 @@ prints the current `errno` value with an optional prefix.
 
 ## Process Control
 
-The process module forwards common process-management calls directly to the kernel. Wrappers are available for `fork`, `execve`, `waitpid`, `kill`, `getpid`, `getppid`, and `signal`. A simple `system()` convenience function is also included.
+The process module forwards common process-management calls directly to the kernel. Wrappers are available for `fork`, `execve`, `execvp`, `waitpid`, `kill`, `getpid`, `getppid`, and `signal`. A simple `system()` convenience function is also included.
+
+`execvp` searches the directories listed in the `PATH` environment variable and then invokes `execve` on the first matching program.
 
 A lightweight `popen`/`pclose` pair runs a shell command with a pipe
 connected to the child. Use mode `"r"` to read the command's output or

--- a/include/process.h
+++ b/include/process.h
@@ -7,6 +7,7 @@
 
 pid_t fork(void);
 int execve(const char *pathname, char *const argv[], char *const envp[]);
+int execvp(const char *file, char *const argv[]);
 pid_t waitpid(pid_t pid, int *status, int options);
 int kill(pid_t pid, int sig);
 pid_t getpid(void);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -155,6 +155,7 @@ and installing signal handlers:
 ```c
 pid_t fork(void);
 int execve(const char *pathname, char *const argv[], char *const envp[]);
+int execvp(const char *file, char *const argv[]);
 pid_t waitpid(pid_t pid, int *status, int options);
 int kill(pid_t pid, int sig);
 pid_t getpid(void);
@@ -181,6 +182,8 @@ void on_int(int signo) { (void)signo; }
 signal(SIGINT, on_int);
 kill(getpid(), SIGINT);
 ```
+
+`execvp` performs the same operation as `execve` but searches the directories in the `PATH` environment variable when the program name does not contain a slash.
 
 The convenience `system()` call executes a shell command by forking and
 invoking `/bin/sh -c command`. It returns the raw status from `waitpid`


### PR DESCRIPTION
## Summary
- add `execvp` wrapper searching `PATH`
- expose the function through process.h
- document `execvp` usage
- test launching a program via `execvp`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685740c042a48324977a0cf0462ca971