### PR TITLE
Implement fflush and document behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ vlibc's stdio layer exposes global pointers `stdin`, `stdout`, and
 `stderr`. These lightweight streams wrap file descriptors 0, 1 and 2 and
 are initialized when `vlibc_init()` is called. They can be used with the
 provided `fread`, `fwrite`, `fseek`, `ftell`, `rewind`, `fgetc`,
-`fputc`, `fgets`, `fputs`, `fprintf`, and `printf` functions.
+`fputc`, `fgets`, `fputs`, `fflush`, `fprintf`, and `printf` functions.
+Although I/O is unbuffered, `fflush(stream)` succeeds and invokes
+`fsync` on the stream's file descriptor when one is supplied.
 
 ## Networking
 

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -22,6 +22,7 @@ int fgetc(FILE *stream);
 int fputc(int c, FILE *stream);
 char *fgets(char *s, int size, FILE *stream);
 int fputs(const char *s, FILE *stream);
+int fflush(FILE *stream);
 
 int printf(const char *format, ...);
 int fprintf(FILE *stream, const char *format, ...);

--- a/src/stdio.c
+++ b/src/stdio.c
@@ -5,6 +5,8 @@
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/syscall.h>
+#include "syscall.h"
 
 FILE *stdin = NULL;
 FILE *stdout = NULL;
@@ -151,5 +153,19 @@ int fputs(const char *s, FILE *stream)
     if (w != (ssize_t)len)
         return -1;
     return (int)w;
+}
+
+int fflush(FILE *stream)
+{
+    if (!stream)
+        return 0;
+#ifdef SYS_fsync
+    long ret = vlibc_syscall(SYS_fsync, stream->fd, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+#endif
+    return 0;
 }
 

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -434,6 +434,23 @@ static const char *test_fgets_fputs(void)
     return 0;
 }
 
+static const char *test_fflush(void)
+{
+    FILE *f = fopen("tmp_flush", "w");
+    mu_assert("fopen flush", f != NULL);
+    mu_assert("write", fwrite("abc", 1, 3, f) == 3);
+    mu_assert("fflush", fflush(f) == 0);
+    fclose(f);
+
+    int fd = open("tmp_flush", O_RDONLY);
+    char buf[4] = {0};
+    ssize_t r = read(fd, buf, 3);
+    close(fd);
+    unlink("tmp_flush");
+    mu_assert("fflush content", r == 3 && strncmp(buf, "abc", 3) == 0);
+    return 0;
+}
+
 
 static const char *test_pthread(void)
 {
@@ -555,8 +572,8 @@ static const char *test_error_reporting(void)
     mu_assert("strerror", msg && *msg != '\0');
     perror("test");
     vlibc_init();
-    const char *msg = strerror(ENOENT);
-    mu_assert("strerror", strcmp(msg, "No such file or directory") == 0);
+    const char *msg2 = strerror(ENOENT);
+    mu_assert("strerror", strcmp(msg2, "No such file or directory") == 0);
 
     int p[2];
     mu_assert("pipe", pipe(p) == 0);
@@ -736,6 +753,7 @@ static const char *all_tests(void)
     mu_run_test(test_fseek_rewind);
     mu_run_test(test_fgetc_fputc);
     mu_run_test(test_fgets_fputs);
+    mu_run_test(test_fflush);
     mu_run_test(test_pthread);
     mu_run_test(test_select_pipe);
     mu_run_test(test_sleep_functions);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -122,8 +122,11 @@ The stdio module also exposes `stdin`, `stdout`, and `stderr` as global
 pointers. These streams wrap file descriptors 0, 1 and 2 and are
 initialized in `vlibc_init()` so they can be used with the basic FILE
 APIs. Available helpers include `fopen`, `fread`, `fwrite`, `fseek`,
-`ftell`, `rewind`, `fclose`, `fgetc`, `fputc`, `fgets`, `fputs`, and
-simple formatted output via `fprintf` and `printf`.
+`ftell`, `rewind`, `fclose`, `fgetc`, `fputc`, `fgets`, `fputs`,
+`fflush`, and simple formatted output via `fprintf` and `printf`.
+Because the library does not buffer stream data, `fflush` simply
+performs an `fsync` on the given stream when it is non-`NULL` and
+otherwise returns success.
 
 ## String Handling
 


### PR DESCRIPTION
## Summary
- implement `fflush` in stdio
- declare it in the public header
- document the call in README and vlibcdoc
- add unit test for `fflush`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685741650e548324b975660310e812f8