### PR TITLE
Add directory creation and removal wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ SRC := \
     src/socket.c \
     src/fd.c \
     src/file.c \
+    src/dir.c \
     src/syscall.c \
     src/mmap.c \
     src/env.c \

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ no locale handling is performed.
 
 ## Limitations
 
-- The I/O routines (`open`, `read`, `write`, `close`, `unlink`, `rename`) are thin wrappers around
+- The I/O routines (`open`, `read`, `write`, `close`, `unlink`, `rename`, `mkdir`, `rmdir`) are thin wrappers around
   the corresponding system calls. They perform no buffering and provide only
   basic error reporting.
 - Process creation and signal functions rely on Linux `fork`, `execve`,

--- a/include/io.h
+++ b/include/io.h
@@ -13,5 +13,7 @@ int dup2(int oldfd, int newfd);
 int pipe(int pipefd[2]);
 int unlink(const char *pathname);
 int rename(const char *oldpath, const char *newpath);
+int mkdir(const char *pathname, mode_t mode);
+int rmdir(const char *pathname);
 
 #endif /* IO_H */

--- a/src/dir.c
+++ b/src/dir.c
@@ -1,0 +1,35 @@
+#include "io.h"
+#include "errno.h"
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+#ifndef AT_FDCWD
+#define AT_FDCWD -100
+#endif
+
+int mkdir(const char *pathname, mode_t mode)
+{
+#ifdef SYS_mkdir
+    long ret = vlibc_syscall(SYS_mkdir, (long)pathname, mode, 0, 0, 0, 0);
+#else
+    long ret = vlibc_syscall(SYS_mkdirat, AT_FDCWD, (long)pathname, mode, 0, 0, 0);
+#endif
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+}
+
+int rmdir(const char *pathname)
+{
+    long ret = vlibc_syscall(SYS_rmdir, (long)pathname, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+}
+

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -104,6 +104,8 @@ ssize_t write(int fd, const void *buf, size_t count);
 int close(int fd);
 int unlink(const char *pathname);
 int rename(const char *oldpath, const char *newpath);
+int mkdir(const char *pathname, mode_t mode);
+int rmdir(const char *pathname);
 ```
 
 These functions forward their arguments directly to the kernel using the syscall interface. No buffering or stream abstraction is performed.


### PR DESCRIPTION
## Summary
- expose `mkdir` and `rmdir` prototypes in `io.h`
- implement wrappers for `SYS_mkdir`/`SYS_rmdir`
- compile new source by updating the Makefile
- document directory management in README and vlibcdoc

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685742648b208324928618022db1c204