### PR TITLE
Add basic wide-character support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ SRC := \
     src/ctype.c \
     src/select.c \
     src/qsort.c \
-    src/getopt.c
+    src/getopt.c \
+    src/wchar.c
 
 OBJ := $(SRC:.c=.o)
 LIB := libvlibc.a

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ poll.h       - I/O multiplexing helpers
 stdio.h      - simple stream I/O
 stdlib.h     - basic utilities
 string.h     - string manipulation
+wchar.h     - wide character helpers
 getopt.h     - option parsing
 sys/mman.h   - memory mapping helpers
 sys/socket.h - networking wrappers

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -1,0 +1,17 @@
+#ifndef WCHAR_H
+#define WCHAR_H
+
+#include <stddef.h>
+
+#ifndef __wchar_t_defined
+typedef int wchar_t;
+#define __wchar_t_defined
+#endif
+
+typedef struct { int __dummy; } mbstate_t;
+
+int mbtowc(wchar_t *pwc, const char *s, size_t n);
+int wctomb(char *s, wchar_t wc);
+size_t wcslen(const wchar_t *s);
+
+#endif /* WCHAR_H */

--- a/src/wchar.c
+++ b/src/wchar.c
@@ -1,0 +1,30 @@
+#include "wchar.h"
+
+int mbtowc(wchar_t *pwc, const char *s, size_t n)
+{
+    if (!s)
+        return 0;
+    if (n == 0)
+        return -1;
+    if (pwc)
+        *pwc = (unsigned char)*s;
+    return *s ? 1 : 0;
+}
+
+int wctomb(char *s, wchar_t wc)
+{
+    if (!s)
+        return 0;
+    if (wc < 0 || wc > 0xFF)
+        return -1;
+    *s = (char)wc;
+    return 1;
+}
+
+size_t wcslen(const wchar_t *s)
+{
+    const wchar_t *p = s;
+    while (*p)
+        p++;
+    return (size_t)(p - s);
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -13,6 +13,7 @@
 #include <fcntl.h>
 #include "../include/string.h"
 #include "../include/stdlib.h"
+#include "../include/wchar.h"
 #include "../include/env.h"
 #include "../include/process.h"
 #include "../include/getopt.h"
@@ -324,6 +325,17 @@ static const char *test_string_helpers(void)
     mu_assert("strnlen short", strnlen("hello", 3) == 3);
     mu_assert("strnlen full", strnlen("hi", 10) == 2);
 
+    return 0;
+}
+
+static const char *test_widechar_basic(void)
+{
+    wchar_t wc = 0;
+    mu_assert("mbtowc ascii", mbtowc(&wc, "A", 1) == 1 && wc == L'A');
+    char buf[2] = {0};
+    mu_assert("wctomb ascii", wctomb(buf, wc) == 1 && buf[0] == 'A');
+    mu_assert("wcslen", wcslen(L"abc") == 3);
+    mu_assert("mbtowc reset", mbtowc(NULL, NULL, 0) == 0);
     return 0;
 }
 
@@ -835,6 +847,7 @@ static const char *all_tests(void)
     mu_run_test(test_errno_stat);
     mu_run_test(test_stat_wrappers);
     mu_run_test(test_string_helpers);
+    mu_run_test(test_widechar_basic);
     mu_run_test(test_strtok_basic);
     mu_run_test(test_strtok_r_basic);
     mu_run_test(test_printf_functions);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -140,6 +140,8 @@ The **string** module provides fundamental operations needed by most C programs:
 - Conventional memory routines (`memcpy`, `memmove`, `memset`, `memcmp`) map to
   the internal `v` implementations.
 - Minimal locale or encoding support; all strings are treated as byte sequences.
+- Basic wide-character helpers `mbtowc`, `wctomb`, and `wcslen` operate on ASCII
+  characters only.
 - Utility functions for tokenizing and simple formatting.
 - `strtok` and `strtok_r` split a string into tokens based on a set of
   delimiter characters. `strtok` stores its parsing state in static


### PR DESCRIPTION
## Summary
- provide `wchar.h` with minimal wide-char definitions
- implement `mbtowc`, `wctomb` and `wcslen`
- build wide-char code and test the new helpers
- document the new header and functionality

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857449542088324ae44452c8252f478