### PR TITLE
Add minimal locale handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ SRC := \
     src/ctype.c \
     src/select.c \
     src/qsort.c \
-    src/getopt.c
+    src/getopt.c \
+    src/locale.c
 
 OBJ := $(SRC:.c=.o)
 LIB := libvlibc.a

--- a/README.md
+++ b/README.md
@@ -238,9 +238,14 @@ pclose(f);
 ## Time Formatting
 
 The library includes a minimal `strftime` implementation for producing
-human-readable timestamps. Supported conversion sequences are `%Y`, `%m`,
-`%d`, `%H`, `%M`, and `%S`. All other specifiers are copied verbatim and
-no locale handling is performed.
+human-readable timestamps. Supported conversion sequences are `%Y`, `%m`, `%d`,
+`%H`, `%M`, and `%S`. Locale handling is extremely limited and only the default
+`"C"` and `"POSIX"` locales can be selected.
+
+## Locale Support
+
+`setlocale` can switch between the built-in `"C"` and `"POSIX"` locales.
+`localeconv` returns formatting information for these locales only.
 
 
 ## Limitations
@@ -256,3 +261,4 @@ no locale handling is performed.
 - `perror` and `strerror` cover only common error codes.
 - Basic thread support is implemented using the `clone` syscall. Only
   `pthread_create`, `pthread_join`, and simple mutexes are provided.
+- Locale data is minimal: only the `"C"` and `"POSIX"` locales are supported.

--- a/include/locale.h
+++ b/include/locale.h
@@ -1,0 +1,30 @@
+#ifndef LOCALE_H
+#define LOCALE_H
+
+struct lconv {
+    char *decimal_point;
+    char *thousands_sep;
+    char *grouping;
+    char *int_curr_symbol;
+    char *currency_symbol;
+    char *mon_decimal_point;
+    char *mon_thousands_sep;
+    char *mon_grouping;
+    char *positive_sign;
+    char *negative_sign;
+    char int_frac_digits;
+    char frac_digits;
+    char p_cs_precedes;
+    char p_sep_by_space;
+    char n_cs_precedes;
+    char n_sep_by_space;
+    char p_sign_posn;
+    char n_sign_posn;
+};
+
+#define LC_ALL 0
+
+char *setlocale(int category, const char *locale);
+struct lconv *localeconv(void);
+
+#endif /* LOCALE_H */

--- a/src/locale.c
+++ b/src/locale.c
@@ -1,0 +1,45 @@
+#include "locale.h"
+#include "string.h"
+
+static char current_locale[6] = "C";
+
+static struct lconv c_lconv = {
+    .decimal_point = ".",
+    .thousands_sep = "",
+    .grouping = "",
+    .int_curr_symbol = "",
+    .currency_symbol = "",
+    .mon_decimal_point = ".",
+    .mon_thousands_sep = "",
+    .mon_grouping = "",
+    .positive_sign = "",
+    .negative_sign = "",
+    .int_frac_digits = 127,
+    .frac_digits = 127,
+    .p_cs_precedes = 127,
+    .p_sep_by_space = 127,
+    .n_cs_precedes = 127,
+    .n_sep_by_space = 127,
+    .p_sign_posn = 127,
+    .n_sign_posn = 127,
+};
+
+char *setlocale(int category, const char *locale)
+{
+    (void)category;
+    if (!locale)
+        return current_locale;
+
+    if (strcmp(locale, "C") == 0 || strcmp(locale, "POSIX") == 0) {
+        strncpy(current_locale, locale, sizeof(current_locale) - 1);
+        current_locale[sizeof(current_locale) - 1] = '\0';
+        return current_locale;
+    }
+
+    return NULL;
+}
+
+struct lconv *localeconv(void)
+{
+    return &c_lconv;
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -139,7 +139,9 @@ The **string** module provides fundamental operations needed by most C programs:
 - `vstrlen`, `vstrcpy`, `vstrncmp`, `strnlen`, `strcat` and `strncat` equivalents.
 - Conventional memory routines (`memcpy`, `memmove`, `memset`, `memcmp`) map to
   the internal `v` implementations.
-- Minimal locale or encoding support; all strings are treated as byte sequences.
+ - Basic locale handling is limited to the built-in `"C"` and `"POSIX"` locales.
+   `setlocale` switches between them and `localeconv` exposes formatting data.
+   All strings are treated as byte sequences.
 - Utility functions for tokenizing and simple formatting.
 - `strtok` and `strtok_r` split a string into tokens based on a set of
   delimiter characters. `strtok` stores its parsing state in static
@@ -148,8 +150,8 @@ The **string** module provides fundamental operations needed by most C programs:
 - Simple number conversion helpers `atoi`, `strtol`, `strtod`, and `atof`.
 
 Basic time formatting is available via `strftime`. Only a small subset of
-conversions is implemented (`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`) and the
-output always uses the C locale.
+ conversions is implemented (`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`) and the
+ output uses the current locale (only `"C"`/`"POSIX"` are available).
 
 The goal is to offer just enough functionality for common tasks without the complexity of full locale-aware libraries.
 


### PR DESCRIPTION
## Summary
- implement `setlocale` and `localeconv` stubs
- support selecting between "C" and "POSIX" locales
- document locale functions and limitations

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857448adc348324b6a8ab1d011b90c0