### PR TITLE
Add time conversion helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ SRC := \
     src/env.c \
     src/sleep.c \
     src/time.c \
+    src/time_conv.c \
     src/strftime.c \
     src/stat.c \
     src/pthread.c \

--- a/README.md
+++ b/README.md
@@ -242,6 +242,11 @@ human-readable timestamps. Supported conversion sequences are `%Y`, `%m`,
 `%d`, `%H`, `%M`, and `%S`. All other specifiers are copied verbatim and
 no locale handling is performed.
 
+Basic conversion helpers `gmtime`, `localtime`, `mktime`, and `ctime` are
+provided for transforming between `time_t` values and `struct tm` or
+human-readable strings. `localtime` does not apply any timezone logic and
+behaves identically to `gmtime`.
+
 
 ## Limitations
 

--- a/include/time.h
+++ b/include/time.h
@@ -40,4 +40,10 @@ int nanosleep(const struct timespec *req, struct timespec *rem);
 
 size_t strftime(char *s, size_t max, const char *format, const struct tm *tm);
 
+/* basic time conversion helpers */
+struct tm *gmtime(const time_t *timep);
+struct tm *localtime(const time_t *timep);
+time_t mktime(struct tm *tm);
+char *ctime(const time_t *timep);
+
 #endif /* TIME_H */

--- a/src/time_conv.c
+++ b/src/time_conv.c
@@ -1,0 +1,113 @@
+#include "time.h"
+#include "stdio.h"
+
+static int is_leap(int year)
+{
+    if ((year % 4) != 0)
+        return 0;
+    if ((year % 100) != 0)
+        return 1;
+    return (year % 400) == 0;
+}
+
+static const int days_per_month[2][12] = {
+    {31,28,31,30,31,30,31,31,30,31,30,31},
+    {31,29,31,30,31,30,31,31,30,31,30,31}
+};
+
+static struct tm tm_buf;
+
+struct tm *gmtime(const time_t *timep)
+{
+    time_t t = timep ? *timep : time(NULL);
+    if (t < 0)
+        t = 0;
+
+    int sec = t % 60; t /= 60;
+    int min = t % 60; t /= 60;
+    int hour = t % 24; t /= 24;
+    int days = (int)t;
+
+    int wday = (days + 4) % 7; /* 1970-01-01 was Thursday */
+    int year = 1970;
+    while (1) {
+        int ydays = is_leap(year) ? 366 : 365;
+        if (days >= ydays) {
+            days -= ydays;
+            year++;
+        } else {
+            break;
+        }
+    }
+    int yday = days;
+    const int *month_lengths = days_per_month[is_leap(year)];
+    int mon = 0;
+    while (days >= month_lengths[mon]) {
+        days -= month_lengths[mon];
+        mon++;
+    }
+    int mday = days + 1;
+
+    tm_buf.tm_sec = sec;
+    tm_buf.tm_min = min;
+    tm_buf.tm_hour = hour;
+    tm_buf.tm_mday = mday;
+    tm_buf.tm_mon = mon;
+    tm_buf.tm_year = year - 1900;
+    tm_buf.tm_wday = wday;
+    tm_buf.tm_yday = yday;
+    tm_buf.tm_isdst = 0;
+    return &tm_buf;
+}
+
+struct tm *localtime(const time_t *timep)
+{
+    /* no timezone handling, just use gmtime */
+    return gmtime(timep);
+}
+
+time_t mktime(struct tm *tm)
+{
+    if (!tm)
+        return (time_t)-1;
+
+    int year = tm->tm_year + 1900;
+    time_t days = 0;
+    for (int y = 1970; y < year; y++)
+        days += is_leap(y) ? 366 : 365;
+
+    const int *ml = days_per_month[is_leap(year)];
+    for (int m = 0; m < tm->tm_mon; m++)
+        days += ml[m];
+    days += tm->tm_mday - 1;
+
+    tm->tm_yday = (int)days;
+    tm->tm_wday = (int)((days + 4) % 7);
+    tm->tm_isdst = 0;
+
+    time_t t = days * 86400 + tm->tm_hour * 3600 + tm->tm_min * 60 + tm->tm_sec;
+    return t;
+}
+
+char *ctime(const time_t *timep)
+{
+    static char buf[32];
+    struct tm *tm = localtime(timep);
+    static const char *wd[7] = {"Sun","Mon","Tue","Wed","Thu","Fri","Sat"};
+    static const char *mn[12] = {"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"};
+    if (!tm)
+        return NULL;
+    char dd[3] = {0}, hh[3] = {0}, mm[3] = {0}, ss[3] = {0};
+    dd[0] = '0' + (tm->tm_mday / 10);
+    dd[1] = '0' + (tm->tm_mday % 10);
+    hh[0] = '0' + (tm->tm_hour / 10);
+    hh[1] = '0' + (tm->tm_hour % 10);
+    mm[0] = '0' + (tm->tm_min / 10);
+    mm[1] = '0' + (tm->tm_min % 10);
+    ss[0] = '0' + (tm->tm_sec / 10);
+    ss[1] = '0' + (tm->tm_sec % 10);
+    snprintf(buf, sizeof(buf), "%s %s %s %s:%s:%s %d\n",
+             wd[tm->tm_wday], mn[tm->tm_mon], dd, hh, mm, ss,
+             tm->tm_year + 1900);
+    return buf;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -570,6 +570,30 @@ static const char *test_strftime_basic(void)
     return 0;
 }
 
+static const char *test_time_conversions(void)
+{
+    time_t t = 1700000000;
+    struct tm *gm = gmtime(&t);
+    mu_assert("gm year", gm->tm_year == 123);
+    mu_assert("gm mon", gm->tm_mon == 10);
+    mu_assert("gm mday", gm->tm_mday == 14);
+    mu_assert("gm hour", gm->tm_hour == 22);
+    mu_assert("gm min", gm->tm_min == 13);
+    mu_assert("gm sec", gm->tm_sec == 20);
+    mu_assert("gm wday", gm->tm_wday == 2);
+
+    struct tm *loc = localtime(&t);
+    mu_assert("localtime", loc->tm_yday == gm->tm_yday && loc->tm_mon == gm->tm_mon);
+
+    struct tm tmp = *gm;
+    time_t r = mktime(&tmp);
+    mu_assert("mktime", r == 1700000000);
+
+    char *s = ctime(&t);
+    mu_assert("ctime", strcmp(s, "Tue Nov 14 22:13:20 2023\n") == 0);
+    return 0;
+}
+
 static const char *test_environment(void)
 {
     env_init(NULL);
@@ -847,6 +871,7 @@ static const char *all_tests(void)
     mu_run_test(test_poll_pipe);
     mu_run_test(test_sleep_functions);
     mu_run_test(test_strftime_basic);
+    mu_run_test(test_time_conversions);
     mu_run_test(test_environment);
     mu_run_test(test_system_fn);
     mu_run_test(test_execvp_fn);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -151,6 +151,11 @@ Basic time formatting is available via `strftime`. Only a small subset of
 conversions is implemented (`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`) and the
 output always uses the C locale.
 
+The library also includes simple conversion routines `gmtime`, `localtime`,
+`mktime`, and `ctime`. They convert between `time_t` and `struct tm` or
+produce a readable string. `localtime` ignores the system timezone so the
+result is identical to `gmtime`.
+
 The goal is to offer just enough functionality for common tasks without the complexity of full locale-aware libraries.
 
 ## Random Numbers


### PR DESCRIPTION
## Summary
- expose `localtime`, `gmtime`, `mktime` and `ctime` in the public header
- implement minimal versions in `src/time_conv.c`
- build new file and add coverage to the test suite
- document usage and timezone limitations in README and vlibcdoc

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857449dd99c83249645326be6dd0774