### PR TITLE
Add getopt_long option parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ SRC := \
     src/select.c \
     src/qsort.c \
     src/getopt.c \
+    src/getopt_long.c \
     src/locale.c \
     src/wchar.c \
     src/math.c

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ while ((c = getopt(argc, argv, "fa:")) != -1) {
 }
 ```
 
+`getopt_long()` provides basic GNU-style long option handling. It accepts an
+array of `struct option` entries describing the long names and whether they
+take arguments.
+
 ## Standard Streams
 
 vlibc's stdio layer exposes global pointers `stdin`, `stdout`, and

--- a/include/getopt.h
+++ b/include/getopt.h
@@ -8,4 +8,20 @@ extern int optopt;
 
 int getopt(int argc, char * const argv[], const char *optstring);
 
+struct option {
+    const char *name;
+    int has_arg;
+    int *flag;
+    int val;
+};
+
+enum {
+    no_argument = 0,
+    required_argument = 1,
+    optional_argument = 2
+};
+
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex);
+
 #endif /* GETOPT_H */

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -858,6 +858,55 @@ static const char *test_getopt_missing(void)
     return 0;
 }
 
+static const char *test_getopt_long_missing(void)
+{
+    char *argv[] = {"prog", "--bar", NULL};
+    int argc = 2;
+    struct option longopts[] = {
+        {"bar", required_argument, NULL, 'b'},
+        {0, 0, 0, 0}
+    };
+    optind = 1;
+    opterr = 0;
+    int r = getopt_long(argc, argv, "b:", longopts, NULL);
+    mu_assert("missing ret", r == '?');
+    mu_assert("optopt", optopt == 'b');
+    mu_assert("index", optind == 2);
+    return 0;
+}
+
+static const char *test_getopt_long_basic(void)
+{
+    char *argv[] = {"prog", "--foo", "--bar=val", "rest", NULL};
+    int argc = 4;
+    int foo = 0;
+    char *bar = NULL;
+    struct option longopts[] = {
+        {"foo", no_argument, &foo, 1},
+        {"bar", required_argument, NULL, 'b'},
+        {0, 0, 0, 0}
+    };
+    optind = 1;
+    opterr = 0;
+    int c;
+    while ((c = getopt_long(argc, argv, "b:", longopts, NULL)) != -1) {
+        switch (c) {
+        case 0:
+            break;
+        case 'b':
+            bar = optarg;
+            break;
+        default:
+            return "unexpected long opt";
+        }
+    }
+    mu_assert("foo", foo == 1);
+    mu_assert("bar", bar && strcmp(bar, "val") == 0);
+    mu_assert("optind", optind == 3);
+    mu_assert("rest", strcmp(argv[optind], "rest") == 0);
+    return 0;
+}
+
 static const char *all_tests(void)
 {
     mu_run_test(test_malloc);
@@ -897,6 +946,8 @@ static const char *all_tests(void)
     mu_run_test(test_qsort_strings);
     mu_run_test(test_getopt_basic);
     mu_run_test(test_getopt_missing);
+    mu_run_test(test_getopt_long_missing);
+    mu_run_test(test_getopt_long_basic);
 
     return 0;
 }

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -175,6 +175,14 @@ Calling `srand()` initializes the internal state. Reusing the same seed
 produces the identical sequence of numbers, each in the range `0` to
 `32767`.
 
+## Option Parsing
+
+Command line processing mirrors the familiar `getopt` interface. The
+extended `getopt_long()` handles GNU-style long options described by an
+array of `struct option` entries. Both functions update `optind`, set
+`optarg` when an option takes an argument and return `?` for unknown
+options.
+
 ## Process Control
 
 Process-related functionality resides in the **process** module. It provides


### PR DESCRIPTION
## Summary
- support GNU-style long options in `getopt_long`
- export `struct option` and related constants
- cover long option parsing in the tests
- document the new API in README and vlibcdoc

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857464655b083249813e3803837a636