### PR TITLE
Add extra string search helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ SRC := \
     src/process.c \
     src/system.c \
     src/string.c \
+    src/string_extra.c \
     src/strto.c \
     src/rand.c \
     src/socket.c \

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ double f = strtod("3.14", NULL); /* f == 3.14 */
 ```
 
 Use `strcat()` or `strncat()` to append one string to another.
+Search helpers `strstr()`, `strrchr()`, and `memchr()` locate substrings or
+individual bytes within a buffer.
 
 ## String Tokenization
 

--- a/include/string.h
+++ b/include/string.h
@@ -22,6 +22,9 @@ void *memcpy(void *dest, const void *src, size_t n);
 void *memmove(void *dest, const void *src, size_t n);
 void *memset(void *s, int c, size_t n);
 int memcmp(const void *s1, const void *s2, size_t n);
+void *memchr(const void *s, int c, size_t n);
+char *strrchr(const char *s, int c);
+char *strstr(const char *haystack, const char *needle);
 char *strtok(char *str, const char *delim);
 char *strtok_r(char *str, const char *delim, char **saveptr);
 

--- a/src/string_extra.c
+++ b/src/string_extra.c
@@ -1,0 +1,40 @@
+#include "string.h"
+
+void *memchr(const void *s, int c, size_t n)
+{
+    const unsigned char *p = s;
+    unsigned char ch = (unsigned char)c;
+    while (n--) {
+        if (*p == ch)
+            return (void *)p;
+        p++;
+    }
+    return NULL;
+}
+
+char *strrchr(const char *s, int c)
+{
+    const char *ret = NULL;
+    unsigned char ch = (unsigned char)c;
+    while (1) {
+        if (*s == ch)
+            ret = s;
+        if (*s == '\0')
+            break;
+        s++;
+    }
+    return (char *)ret;
+}
+
+char *strstr(const char *haystack, const char *needle)
+{
+    if (!*needle)
+        return (char *)haystack;
+    size_t nlen = vstrlen(needle);
+    while (*haystack) {
+        if (*haystack == *needle && vstrncmp(haystack, needle, nlen) == 0)
+            return (char *)haystack;
+        haystack++;
+    }
+    return NULL;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -325,6 +325,18 @@ static const char *test_string_helpers(void)
     mu_assert("strnlen short", strnlen("hello", 3) == 3);
     mu_assert("strnlen full", strnlen("hi", 10) == 2);
 
+    const char *h = "abcabc";
+    const char *s = strstr(h, "cab");
+    mu_assert("strstr", s && s - h == 2);
+
+    const char *r = strrchr("abca", 'a');
+    mu_assert("strrchr", r && r - "abca" == 3);
+
+    char mbuf[4] = {1, 2, 3, 4};
+    void *m = memchr(mbuf, 3, sizeof(mbuf));
+    mu_assert("memchr", m == &mbuf[2]);
+    mu_assert("memchr none", memchr(mbuf, 5, sizeof(mbuf)) == NULL);
+
     return 0;
 }
 

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -138,6 +138,7 @@ otherwise returns success.
 The **string** module provides fundamental operations needed by most C programs:
 
 - `vstrlen`, `vstrcpy`, `vstrncmp`, `strnlen`, `strcat` and `strncat` equivalents.
+- Search helpers `strstr`, `strrchr`, and `memchr` for locating substrings or bytes.
 - Conventional memory routines (`memcpy`, `memmove`, `memset`, `memcmp`) map to
   the internal `v` implementations.
 - Basic locale handling is limited to the built-in `"C"` and `"POSIX"` locales.


### PR DESCRIPTION
## Summary
- expose memchr, strrchr and strstr in the public string header
- implement the search helpers in new `string_extra.c`
- test the new routines
- document the additions in README and vlibcdoc

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857468a86748324aad130e273ba7075