### PR TITLE
Add pthread_mutex_destroy implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,5 +280,7 @@ behaves identically to `gmtime`.
   It does not handle complex quoting or return detailed status codes.
 - `perror` and `strerror` cover only common error codes.
 - Basic thread support is implemented using the `clone` syscall. Only
-  `pthread_create`, `pthread_join`, and simple mutexes are provided.
+  `pthread_create`, `pthread_join`, and simple mutexes
+  (`pthread_mutex_init`, `pthread_mutex_destroy`,
+  `pthread_mutex_lock`, `pthread_mutex_unlock`) are provided.
 - Locale data is minimal: only the `"C"` and `"POSIX"` locales are supported.

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -20,6 +20,7 @@ int pthread_create(pthread_t *thread, const void *attr,
 int pthread_join(pthread_t *thread, void **retval);
 
 int pthread_mutex_init(pthread_mutex_t *mutex, void *attr);
+int pthread_mutex_destroy(pthread_mutex_t *mutex);
 int pthread_mutex_lock(pthread_mutex_t *mutex);
 int pthread_mutex_unlock(pthread_mutex_t *mutex);
 

--- a/src/pthread.c
+++ b/src/pthread.c
@@ -91,3 +91,9 @@ int pthread_mutex_unlock(pthread_mutex_t *mutex)
     __sync_lock_release(&mutex->locked);
     return 0;
 }
+
+int pthread_mutex_destroy(pthread_mutex_t *mutex)
+{
+    (void)mutex;
+    return 0;
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -284,6 +284,7 @@ int pthread_create(pthread_t *thread, const void *attr,
 int pthread_join(pthread_t *thread, void **retval);
 
 int pthread_mutex_init(pthread_mutex_t *mutex, void *attr);
+int pthread_mutex_destroy(pthread_mutex_t *mutex);
 int pthread_mutex_lock(pthread_mutex_t *mutex);
 int pthread_mutex_unlock(pthread_mutex_t *mutex);
 ```


### PR DESCRIPTION
## Summary
- add trivial `pthread_mutex_destroy`
- declare `pthread_mutex_destroy` in pthread.h
- document mutex destruction in README and vlibcdoc

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685746fa68c48324a0fe8cbb88e02a70