### PR TITLE
Implement abort and add tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ SRC := \
     src/memory_ops.c \
     src/atexit.c \
     src/process.c \
+    src/abort.c \
     src/system.c \
     src/string.c \
     src/strto.c \

--- a/README.md
+++ b/README.md
@@ -235,10 +235,12 @@ prints the current `errno` value with an optional prefix.
 
 ## Process Control
 
-The process module forwards common process-management calls directly to the kernel. Wrappers are available for `fork`, `execve`, `execvp`, `waitpid`, `kill`, `getpid`, `getppid`, and `signal`. A simple `system()` convenience function is also included.
+The process module forwards common process-management calls directly to the kernel. Wrappers are available for `fork`, `execve`, `execvp`, `waitpid`, `kill`, `getpid`, `getppid`, `signal`, and `abort`. A simple `system()` convenience function is also included.
 
-`execvp` searches the directories listed in the `PATH` environment variable and then invokes `execve` on the first matching program.
+`execvp` searches the directories listed in the `PATH` environment variable and
+then invokes `execve` on the first matching program.
 
+A call to `abort()` sends `SIGABRT` to the process and terminates it immediately.
 A lightweight `popen`/`pclose` pair runs a shell command with a pipe
 connected to the child. Use mode `"r"` to read the command's output or
 `"w"` to send data to its stdin:

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -32,4 +32,7 @@ void srand(unsigned seed);
 /* Register a function to run at normal process exit */
 int atexit(void (*fn)(void));
 
+/* Terminate the process with SIGABRT */
+void abort(void);
+
 #endif /* STDLIB_H */

--- a/src/abort.c
+++ b/src/abort.c
@@ -1,0 +1,8 @@
+#include "stdlib.h"
+#include "process.h"
+
+void abort(void)
+{
+    kill(getpid(), SIGABRT);
+    _exit(1);
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <sys/wait.h>
+#include <signal.h>
 #include "../include/time.h"
 #include "../include/sys/mman.h"
 
@@ -718,6 +719,18 @@ static const char *test_rand_fn(void)
     return 0;
 }
 
+static const char *test_abort_fn(void)
+{
+    pid_t pid = fork();
+    mu_assert("fork", pid >= 0);
+    if (pid == 0)
+        abort();
+    int status = 0;
+    waitpid(pid, &status, 0);
+    mu_assert("abort", WIFSIGNALED(status) && WTERMSIG(status) == SIGABRT);
+    return 0;
+}
+
 static const char *test_mprotect_anon(void)
 {
     size_t len = 4096;
@@ -890,6 +903,7 @@ static const char *all_tests(void)
     mu_run_test(test_execvp_fn);
     mu_run_test(test_popen_fn);
     mu_run_test(test_rand_fn);
+    mu_run_test(test_abort_fn);
     mu_run_test(test_mprotect_anon);
     mu_run_test(test_atexit_handler);
     mu_run_test(test_dirent);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -192,6 +192,7 @@ pid_t getppid(void);
 sighandler_t signal(int signum, sighandler_t handler);
 int system(const char *command);
 int atexit(void (*fn)(void));
+void abort(void);
 void exit(int status);
 ```
 
@@ -217,6 +218,8 @@ kill(getpid(), SIGINT);
 The convenience `system()` call executes a shell command by forking and
 invoking `/bin/sh -c command`. It returns the raw status from `waitpid`
 and is intended only for simple helper tasks.
+`abort()` sends `SIGABRT` to the current process and does not invoke
+`atexit` handlers.
 `exit()` terminates the process after running any handlers registered with `atexit()`. The handlers execute in reverse registration order. `_exit()` bypasses them.
 The design favors straightforward semantics over comprehensive POSIX
 conformance.


### PR DESCRIPTION
## Summary
- implement `abort()` that raises `SIGABRT`
- expose the declaration in `stdlib.h`
- include `abort` in build
- document `abort` behaviour in README and documentation
- test the new function

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68574718c1ac8324a70cf968f9c75e52