### PR TITLE
Add pthread detach support

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -9,6 +9,7 @@ typedef struct pthread {
     void *(*start_routine)(void *);
     void *arg;
     void *retval;
+    int detached;
 } pthread_t;
 
 typedef struct {
@@ -18,6 +19,7 @@ typedef struct {
 int pthread_create(pthread_t *thread, const void *attr,
                    void *(*start_routine)(void *), void *arg);
 int pthread_join(pthread_t *thread, void **retval);
+int pthread_detach(pthread_t *thread);
 
 int pthread_mutex_init(pthread_mutex_t *mutex, void *attr);
 int pthread_mutex_destroy(pthread_mutex_t *mutex);

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -495,6 +495,20 @@ static const char *test_pthread(void)
     return 0;
 }
 
+static const char *test_pthread_detach(void)
+{
+    pthread_t t;
+    int val = 0;
+    int r = pthread_create(&t, NULL, thread_fn, &val);
+    mu_assert("pthread_create", r == 0);
+    pthread_detach(&t);
+    waitpid(t.tid, NULL, 0);
+    mu_assert("shared value", val == 42);
+    mu_assert("join fails", pthread_join(&t, NULL) == -1);
+
+    return 0;
+}
+
 static void *delayed_write(void *arg)
 {
     int fd = *(int *)arg;
@@ -941,6 +955,7 @@ static const char *all_tests(void)
     mu_run_test(test_fgets_fputs);
     mu_run_test(test_fflush);
     mu_run_test(test_pthread);
+    mu_run_test(test_pthread_detach);
     mu_run_test(test_select_pipe);
     mu_run_test(test_poll_pipe);
     mu_run_test(test_sleep_functions);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -291,6 +291,7 @@ Only a handful of functions are provided:
 int pthread_create(pthread_t *thread, const void *attr,
                    void *(*start)(void *), void *arg);
 int pthread_join(pthread_t *thread, void **retval);
+int pthread_detach(pthread_t *thread);
 
 int pthread_mutex_init(pthread_mutex_t *mutex, void *attr);
 int pthread_mutex_destroy(pthread_mutex_t *mutex);
@@ -300,6 +301,9 @@ int pthread_mutex_unlock(pthread_mutex_t *mutex);
 
 Threads share the process address space and use a simple spinlock-based
 mutex for synchronization.
+
+`pthread_detach()` marks a thread so that its stack is freed automatically
+when the start routine returns. Detached threads cannot be joined.
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary
- extend `pthread_t` with `detached` flag
- free thread stack automatically when detached
- implement `pthread_detach` API
- describe detach behavior in docs
- test detach semantics

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685747b751908324be8ee5df74dc9846