### PR TITLE
Add setjmp/longjmp support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ SRC := \
     src/getopt_long.c \
     src/locale.c \
     src/wchar.c \
-    src/math.c
+    src/math.c \
+    src/setjmp.c
 
 OBJ := $(SRC:.c=.o)
 LIB := libvlibc.a

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ netdb.h      - address resolution helpers
 sys/stat.h   - file status functions
 syscall.h    - raw syscall interface
 time.h       - time related helpers
+setjmp.h     - non-local jump helpers
 vlibc.h      - library initialization
 ```
 
@@ -301,3 +302,4 @@ behaves identically to `gmtime`.
   (`pthread_mutex_init`, `pthread_mutex_destroy`,
   `pthread_mutex_lock`, `pthread_mutex_unlock`) are provided.
 - Locale data is minimal: only the `"C"` and `"POSIX"` locales are supported.
+- `setjmp`/`longjmp` only work on x86_64 and do not preserve signal masks.

--- a/include/setjmp.h
+++ b/include/setjmp.h
@@ -1,0 +1,10 @@
+#ifndef SETJMP_H
+#define SETJMP_H
+
+/* simple jump buffer for x86_64 */
+typedef unsigned long jmp_buf[8];
+
+int setjmp(jmp_buf env);
+void longjmp(jmp_buf env, int val) __attribute__((noreturn));
+
+#endif /* SETJMP_H */

--- a/src/setjmp.c
+++ b/src/setjmp.c
@@ -1,0 +1,45 @@
+#include "setjmp.h"
+
+int setjmp(jmp_buf env)
+{
+    int r;
+    __asm__ volatile(
+        "mov %%rbx,0(%1)\n"
+        "mov %%rbp,8(%1)\n"
+        "mov %%r12,16(%1)\n"
+        "mov %%r13,24(%1)\n"
+        "mov %%r14,32(%1)\n"
+        "mov %%r15,40(%1)\n"
+        "mov %%rsp,48(%1)\n"
+        "mov $1f,%%rax\n"
+        "mov %%rax,56(%1)\n"
+        "xor %%eax,%%eax\n"
+        "1: mov %%eax,%0\n"
+        : "=r"(r)
+        : "r"(env)
+        : "memory","rax"
+    );
+    return r;
+}
+
+void longjmp(jmp_buf env, int val)
+{
+    if (val == 0)
+        val = 1;
+    __asm__ volatile(
+        "mov %0,%%rax\n"
+        "mov 0(%1),%%rbx\n"
+        "mov 8(%1),%%rbp\n"
+        "mov 16(%1),%%r12\n"
+        "mov 24(%1),%%r13\n"
+        "mov 32(%1),%%r14\n"
+        "mov 40(%1),%%r15\n"
+        "mov 48(%1),%%rsp\n"
+        "mov 56(%1),%%rdx\n"
+        "jmp *%%rdx\n"
+        :
+        : "r"((long)val), "r"(env)
+        : "rax","rbx","rdx","r12","r13","r14","r15","memory"
+    );
+    __builtin_unreachable();
+}


### PR DESCRIPTION
## Summary
- implement basic `setjmp`/`longjmp` for x86_64
- expose `setjmp.h` in the public headers
- note the feature and limitations in the documentation

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685746db9ff88324afb81cedee16c555