### PR TITLE
Implement chdir wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ behaves identically to `gmtime`.
 
 ## Limitations
 
-- The I/O routines (`open`, `read`, `write`, `close`, `unlink`, `rename`, `mkdir`, `rmdir`) are thin wrappers around
+ - The I/O routines (`open`, `read`, `write`, `close`, `unlink`, `rename`, `mkdir`, `rmdir`, `chdir`) are thin wrappers around
   the corresponding system calls. They perform no buffering and provide only
   basic error reporting.
 - Process creation and signal functions rely on Linux `fork`, `execve`,

--- a/include/io.h
+++ b/include/io.h
@@ -15,5 +15,6 @@ int unlink(const char *pathname);
 int rename(const char *oldpath, const char *newpath);
 int mkdir(const char *pathname, mode_t mode);
 int rmdir(const char *pathname);
+int chdir(const char *path);
 
 #endif /* IO_H */

--- a/src/file.c
+++ b/src/file.c
@@ -29,3 +29,13 @@ int rename(const char *oldpath, const char *newpath)
     }
     return (int)ret;
 }
+
+int chdir(const char *path)
+{
+    long ret = vlibc_syscall(SYS_chdir, (long)path, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -109,6 +109,7 @@ int unlink(const char *pathname);
 int rename(const char *oldpath, const char *newpath);
 int mkdir(const char *pathname, mode_t mode);
 int rmdir(const char *pathname);
+int chdir(const char *path);
 ```
 
 These functions forward their arguments directly to the kernel using the syscall interface. No buffering or stream abstraction is performed.


### PR DESCRIPTION
## Summary
- add `chdir` wrapper implementation
- expose `chdir` in `io.h`
- document `chdir` in README limitations
- mention `chdir` in the Input/Output API list

## Testing
- `make test` *(fails: conflicting types for `getopt_long`)*

------
https://chatgpt.com/codex/tasks/task_e_68574978a6408324874aee7cfcefd26c