### PR TITLE
Add symlink wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ behaves identically to `gmtime`.
 
 ## Limitations
 
- - The I/O routines (`open`, `read`, `write`, `close`, `unlink`, `rename`, `mkdir`, `rmdir`, `chdir`) are thin wrappers around
+ - The I/O routines (`open`, `read`, `write`, `close`, `unlink`, `rename`, `symlink`, `mkdir`, `rmdir`, `chdir`) are thin wrappers around
   the corresponding system calls. They perform no buffering and provide only
   basic error reporting.
 - Process creation and signal functions rely on Linux `fork`, `execve`,

--- a/include/io.h
+++ b/include/io.h
@@ -13,6 +13,7 @@ int dup2(int oldfd, int newfd);
 int pipe(int pipefd[2]);
 int unlink(const char *pathname);
 int rename(const char *oldpath, const char *newpath);
+int symlink(const char *target, const char *linkpath);
 int mkdir(const char *pathname, mode_t mode);
 int rmdir(const char *pathname);
 int chdir(const char *path);

--- a/src/file.c
+++ b/src/file.c
@@ -30,6 +30,17 @@ int rename(const char *oldpath, const char *newpath)
     return (int)ret;
 }
 
+int symlink(const char *target, const char *linkpath)
+{
+    long ret = vlibc_syscall(SYS_symlinkat, (long)target, AT_FDCWD,
+                             (long)linkpath, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+}
+
 int chdir(const char *path)
 {
     long ret = vlibc_syscall(SYS_chdir, (long)path, 0, 0, 0, 0, 0);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -107,6 +107,7 @@ ssize_t write(int fd, const void *buf, size_t count);
 int close(int fd);
 int unlink(const char *pathname);
 int rename(const char *oldpath, const char *newpath);
+int symlink(const char *target, const char *linkpath);
 int mkdir(const char *pathname, mode_t mode);
 int rmdir(const char *pathname);
 int chdir(const char *path);


### PR DESCRIPTION
## Summary
- implement `symlink` wrapper in `file.c`
- expose `symlink` through `io.h`
- document the new wrapper in README and vlibcdoc

## Testing
- `make test` *(fails: redefinition of `struct option` in `include/getopt.h`)*

------
https://chatgpt.com/codex/tasks/task_e_68574a9292e48324af4507c646c4954c