### PR TITLE
Move docs to dedicated directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,8 @@
 # vlibc
 
-vlibc is a minimal libc replacement targeted at UNIX-like systems. It
-provides a small subset of the standard C library with an emphasis on
-simplicity and predictability. The project is distributed under the
-terms of the GNU General Public License v3.0.
-
-## Goals
-- Keep the code base small and auditable.
-- Supply only the essential C runtime facilities.
-- Offer consistent behavior for statically linked or embedded programs.
-
-## Target Platforms
-- Linux (x86_64, aarch64, armv7).
-- Other POSIX systems with minimal porting effort.
-- Lightweight containers or small research kernels that implement POSIX
-  style system calls.
-
-## Guiding Principles
-- Minimalism: implement just enough functionality for common use.
-- Readability over clever micro-optimizations.
-- Prefer direct system calls and avoid heavy runtime features.
-- Encourage static linking to reduce external dependencies.
-
-## Motivation and Use Cases
-vlibc was created for developers who need a tiny C runtime for
-experiments, educational operating systems, or compact container
-images. It serves as a foundation for projects that require libc
-functionality but do not want the complexity of larger implementations.
-
-## Differences from Existing Solutions
-While glibc and musl provide comprehensive POSIX support, vlibc focuses
-on a much smaller API surface. It is **not** a drop-in replacement for
-the full standard library. Instead, vlibc offers a minimal set of
-wrappers and utilities that can be easily inspected, modified, or
-extended. This makes it suitable for specialized applications where the
-complete feature set of other libcs is unnecessary.
-
-## Project Structure
-
-The repository uses a straightforward layout:
-
-- `src/` contains the library's source files.
-- `include/` holds public header files.
-- `tests/` contains unit tests.
-
-Common memory routines (`memcpy`, `memmove`, `memset`, `memcmp`) are available
-as wrappers around the internal `v*` implementations so existing code can use
-the familiar names.
-Basic string helpers like `strcmp`, `strchr`, `strncpy`, `strdup`, and
-`strnlen` are also provided.
+A minimal libc replacement for UNIX-like systems.
+See [docs/overview.md](docs/overview.md) for usage and build details.
+Architectural notes are in [docs/architecture.md](docs/architecture.md).
 
 ## Provided Headers
 
@@ -82,41 +36,6 @@ setjmp.h     - non-local jump helpers
 vlibc.h      - library initialization
 ```
 
-## Building the Library
-
-The project uses a simple `make`-based build system. To compile the
-static library, run:
-
-```sh
-make
-```
-
-This produces `libvlibc.a` in the repository root. You can optionally
-install the headers and library with:
-
-```sh
-make install PREFIX=/usr/local
-```
-
-`PREFIX` controls the installation path and defaults to `/usr/local`.
-
-To link against vlibc in your application, add the following flags when
-compiling:
-
-```sh
-cc your_app.c -I/path/to/vlibc/include -L/path/to/vlibc -lvlibc
-```
-
-## Running Tests
-
-Unit tests live in `tests/` and use a tiny test harness. The suite aims to
-exercise the library's core functions. Build and execute the tests with:
-
-```sh
-make test
-```
-
-This command builds `tests/run_tests` and runs it automatically.
 
 ## String Conversion
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,38 @@
+# Architecture
+
+vlibc aims to implement a minimal subset of the standard C library. The project is structured around small, easily auditable modules. Each module exposes a minimal API and relies on direct system calls whenever possible. The code is written in a straightforward C style without complex build systems.
+
+The overall repository layout is described in the README. In short, source code
+lives in `src/`, public headers in `include/`, and tests will be placed in
+`tests/`.
+
+### Planned Modules
+
+- **startup**: Program entry, stack setup, and initialization routines.
+- **memory**: Basic heap management using `brk`/`sbrk` or a small memory allocator.
+- **io**: Simple wrappers around read/write system calls for file descriptors.
+- **string**: Common string operations such as length checks and copying.
+- **process**: Functions for spawning and waiting on child processes.
+- **math**: Elementary math routines like `sin` and `sqrt`.
+
+## API Design
+
+vlibc strives for a consistent API surface inspired by the C standard library. Functions are prefixed with `v` (e.g., `vmalloc`) to differentiate them from their libc counterparts. Where appropriate, functions mirror POSIX signatures so users can easily migrate existing code.
+
+### Naming Conventions
+
+- `v` prefix for all exported functions.
+- Lowercase with underscores for function names and variables.
+- Keep parameter lists short and intuitive.
+
+## Initialization
+
+Initialization code lives in the **startup** module. It performs the following tasks:
+
+1. Set up the runtime stack and registers.
+2. Parse arguments and environment variables.
+3. Call `v_main()` as the program entry point.
+4. Provide a minimal exit routine to flush data and terminate the process.
+
+Programs using vlibc are expected to define a `v_main()` function that receives the traditional `argc`, `argv`, and `envp` parameters. This keeps the startup routine simple and avoids pulling in complex features like C++ static constructors.
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,72 @@
+# Overview
+
+vlibc is a minimal libc replacement targeted at UNIX-like systems. It
+provides a small subset of the standard C library with an emphasis on
+simplicity and predictability. The project is distributed under the
+terms of the GNU General Public License v3.0.
+
+## Goals
+- Keep the code base small and auditable.
+- Supply only the essential C runtime facilities.
+- Offer consistent behavior for statically linked or embedded programs.
+
+## Target Platforms
+- Linux (x86_64, aarch64, armv7).
+- Other POSIX systems with minimal porting effort.
+- Lightweight containers or small research kernels that implement POSIX
+  style system calls.
+
+## Guiding Principles
+- Minimalism: implement just enough functionality for common use.
+- Readability over clever micro-optimizations.
+- Prefer direct system calls and avoid heavy runtime features.
+- Encourage static linking to reduce external dependencies.
+
+## Motivation and Use Cases
+vlibc was created for developers who need a tiny C runtime for
+experiments, educational operating systems, or compact container
+images. It serves as a foundation for projects that require libc
+functionality but do not want the complexity of larger implementations.
+
+## Differences from Existing Solutions
+While glibc and musl provide comprehensive POSIX support, vlibc focuses
+on a much smaller API surface. It is **not** a drop-in replacement for
+the full standard library. Instead, vlibc offers a minimal set of
+wrappers and utilities that can be easily inspected, modified, or
+extended. This makes it suitable for specialized applications where the
+complete feature set of other libcs is unnecessary.
+## Building the Library
+
+The project uses a simple `make`-based build system. To compile the
+static library, run:
+
+```sh
+make
+```
+
+This produces `libvlibc.a` in the repository root. You can optionally
+install the headers and library with:
+
+```sh
+make install PREFIX=/usr/local
+```
+
+`PREFIX` controls the installation path and defaults to `/usr/local`.
+
+To link against vlibc in your application, add the following flags when
+compiling:
+
+```sh
+cc your_app.c -I/path/to/vlibc/include -L/path/to/vlibc -lvlibc
+```
+
+## Running Tests
+
+Unit tests live in `tests/` and use a tiny test harness. The suite aims to
+exercise the library's core functions. Build and execute the tests with:
+
+```sh
+make test
+```
+
+This command builds `tests/run_tests` and runs it automatically.

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -3,53 +3,14 @@
 This document outlines the architecture, planned modules, and API design for **vlibc**. The goal is to provide a clear overview for contributors and users who wish to understand how the library is organized.
 
 ## Table of Contents
+1. [Memory Management](#memory-management)
+2. [Input/Output](#inputoutput)
+3. [String Handling](#string-handling)
+4. [Process Control](#process-control)
+5. [Error Reporting](#error-reporting)
+6. [Threading](#threading)
+7. [Dynamic Loading](#dynamic-loading)
 
-1. [Initialization](#initialization)
-2. [Memory Management](#memory-management)
-3. [Input/Output](#inputoutput)
-4. [String Handling](#string-handling)
-5. [Process Control](#process-control)
-6. [Error Reporting](#error-reporting)
-7. [Threading](#threading)
-8. [Dynamic Loading](#dynamic-loading)
-
-## Architecture
-
-vlibc aims to implement a minimal subset of the standard C library. The project is structured around small, easily auditable modules. Each module exposes a minimal API and relies on direct system calls whenever possible. The code is written in a straightforward C style without complex build systems.
-
-The overall repository layout is described in the README. In short, source code
-lives in `src/`, public headers in `include/`, and tests will be placed in
-`tests/`.
-
-### Planned Modules
-
-- **startup**: Program entry, stack setup, and initialization routines.
-- **memory**: Basic heap management using `brk`/`sbrk` or a small memory allocator.
-- **io**: Simple wrappers around read/write system calls for file descriptors.
-- **string**: Common string operations such as length checks and copying.
-- **process**: Functions for spawning and waiting on child processes.
-- **math**: Elementary math routines like `sin` and `sqrt`.
-
-## API Design
-
-vlibc strives for a consistent API surface inspired by the C standard library. Functions are prefixed with `v` (e.g., `vmalloc`) to differentiate them from their libc counterparts. Where appropriate, functions mirror POSIX signatures so users can easily migrate existing code.
-
-### Naming Conventions
-
-- `v` prefix for all exported functions.
-- Lowercase with underscores for function names and variables.
-- Keep parameter lists short and intuitive.
-
-## Initialization
-
-Initialization code lives in the **startup** module. It performs the following tasks:
-
-1. Set up the runtime stack and registers.
-2. Parse arguments and environment variables.
-3. Call `v_main()` as the program entry point.
-4. Provide a minimal exit routine to flush data and terminate the process.
-
-Programs using vlibc are expected to define a `v_main()` function that receives the traditional `argc`, `argv`, and `envp` parameters. This keeps the startup routine simple and avoids pulling in complex features like C++ static constructors.
 
 ## Memory Management
 


### PR DESCRIPTION
## Summary
- create `docs/` directory with project overview and build instructions
- add architecture notes from `vlibcdoc.md`
- trim introductory and build sections from `README.md`
- link to the new docs
- update `vlibcdoc.md` table of contents

## Testing
- `make test` *(fails: conflicting types for `getopt_long`)*

------
https://chatgpt.com/codex/tasks/task_e_68576988d4c083248e7249ddd3bd7b0a