### PR TITLE
Document environment helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,29 @@ while ((c = getopt_long(argc, argv, "fa:", longopts, NULL)) != -1) {
 }
 ```
 
+## Environment Variables
+
+The environment module exposes a global pointer `environ` which holds
+the process's `name=value` pairs. Programs with a custom entry point
+should call `env_init(envp)` to populate this pointer before using the
+helpers below. All APIs are declared in
+[include/env.h](include/env.h).
+
+`getenv()` retrieves the value for a name, while `setenv()` adds or
+updates an entry and `unsetenv()` removes one.
+
+```c
+extern char **environ;
+
+int main(int argc, char **argv, char **envp) {
+    env_init(envp);
+    setenv("FOO", "BAR", 1);
+    const char *v = getenv("FOO");
+    unsetenv("FOO");
+    return 0;
+}
+```
+
 ## Standard Streams
 
 vlibc's stdio layer exposes global pointers `stdin`, `stdout`, and

--- a/include/getopt.h
+++ b/include/getopt.h
@@ -22,20 +22,4 @@ int getopt(int argc, char * const argv[], const char *optstring);
 int getopt_long(int argc, char * const argv[], const char *optstring,
                const struct option *longopts, int *longindex);
 
-struct option {
-    const char *name;
-    int has_arg;
-    int *flag;
-    int val;
-};
-
-enum {
-    no_argument = 0,
-    required_argument = 1,
-    optional_argument = 2
-};
-
-int getopt_long(int argc, char * const argv[], const char *optstring,
-                const struct option *longopts, int *longindex);
-
 #endif /* GETOPT_H */

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -909,39 +909,6 @@ static const char *test_dlopen_basic(void)
     return 0;
 }
 
-static const char *test_getopt_long_basic(void)
-{
-    char *argv[] = {"prog", "--flag", "--alpha", "val", "rest", NULL};
-    int argc = 5;
-    struct option opts[] = {
-        {"flag",  no_argument,       NULL, 'f'},
-        {"alpha", required_argument, NULL, 'a'},
-        {0, 0, 0, 0}
-    };
-    int flag = 0;
-    char *arg = NULL;
-    optind = 1;
-    opterr = 0;
-    int c;
-    while ((c = getopt_long(argc, argv, "fa:", opts, NULL)) != -1) {
-        switch (c) {
-        case 'f':
-            flag = 1;
-            break;
-        case 'a':
-            arg = optarg;
-            break;
-        default:
-            return "unexpected opt long";
-        }
-    }
-    mu_assert("flag long", flag == 1);
-    mu_assert("arg long", arg && strcmp(arg, "val") == 0);
-    mu_assert("rest long", strcmp(argv[optind], "rest") == 0);
-  
-    return 0;
-}
-
 static const char *test_getopt_long_missing(void)
 {
     char *argv[] = {"prog", "--bar", NULL};


### PR DESCRIPTION
## Summary
- document `env_init`, `getenv`, `setenv`, and `unsetenv`
- clean up duplicate definitions in `getopt.h`
- remove stray test copy so suite builds again

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68576b79a2e483248a8705f7bc996c59