### PR TITLE
Document non-local jump helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,26 @@ usleep(200000);           /* 200 ms */
 unsigned left = sleep(1); /* may be non-zero if interrupted */
 ```
 
+## Non-local Jumps
+
+The [include/setjmp.h](include/setjmp.h) header exposes minimal helpers for
+performing non-local jumps:
+
+```c
+int setjmp(jmp_buf env);
+void longjmp(jmp_buf env, int val);
+```
+
+`setjmp` stores the current register state in `env` and returns `0`. A later
+call to `longjmp` restores those registers and resumes execution as if
+`setjmp` returned `val` (or `1` when `val` is `0`).
+
+This implementation only targets x86_64 where `jmp_buf` holds the
+callee-saved registers. The process's signal mask is **not** preserved, so
+jumping across signal handlers may leave blocked signals in an undefined
+state. Code that relies on portable or POSIX-compliant semantics should use a
+full-featured libc.
+
 
 ## Limitations
 


### PR DESCRIPTION
## Summary
- document `setjmp` and `longjmp`
- call out the x86-64 limitation and lack of signal mask restoration

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68576f595ac48324bb66de6882c1e8f5