### PR TITLE
Update string docs for memory helpers

### DIFF
--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -219,6 +219,7 @@ The **string** module provides fundamental operations needed by most C programs:
 - Search helpers `strstr`, `strrchr`, and `memchr` for locating substrings or bytes.
 - Conventional memory routines (`memcpy`, `memmove`, `memset`, `memcmp`) map to
   the internal `v` implementations.
+- The low-level memory helpers `vmemcpy`, `vmemmove`, `vmemset`, and `vmemcmp` operate on raw byte buffers. `vmemcpy` copies bytes from a source to a destination, `vmemmove` handles overlaps safely, `vmemset` fills a region with a byte value, and `vmemcmp` compares two buffers. The standard `memcpy`, `memmove`, `memset`, and `memcmp` functions simply call these implementations.
 - Basic locale handling is limited to the built-in `"C"` and `"POSIX"` locales.
    `setlocale` switches between them and `localeconv` exposes formatting data.
    All strings are treated as byte sequences.


### PR DESCRIPTION
## Summary
- document vmemcpy, vmemmove, vmemset and vmemcmp in the String Handling section
- clarify that standard memory functions call these implementations

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68577c27febc83249b00fe48bb1749c6