### PR TITLE
Fix header block syntax highlighting

### DIFF
--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -135,7 +135,7 @@ routine simple and avoid complex features like C++ static constructors.
 
 vlibc installs a small set of public headers for application use:
 
-```
+```c
 ctype.h      - character classification helpers
 dirent.h     - directory iteration
 dlfcn.h      - runtime loading of shared libraries


### PR DESCRIPTION
## Summary
- add a `c` language hint for the header list in `vlibcdoc.md`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68577dd437d88324b823262deb75f3d6