### PR TITLE
Use host syscall wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,16 @@ CC ?= cc
 CFLAGS ?= -O2 -std=c11 -Wall -Wextra -fno-stack-protector -fno-builtin -Iinclude
 AR ?= ar
 
+TARGET_OS ?= $(OS)
+ifeq ($(TARGET_OS),)
+TARGET_OS := $(shell uname -s)
+endif
+
+SYS_SRC := src/syscall.c
+ifeq ($(TARGET_OS),Windows_NT)
+SYS_SRC := src/arch/win32/syscall.c
+endif
+
 SRC := \
     src/errno.c \
     src/error.c \
@@ -28,7 +38,7 @@ SRC := \
     src/file.c \
     src/file_perm.c \
     src/dir.c \
-    src/syscall.c \
+    $(SYS_SRC) \
     src/mmap.c \
     src/env.c \
     src/sleep.c \

--- a/src/arch/win32/syscall.c
+++ b/src/arch/win32/syscall.c
@@ -1,0 +1,10 @@
+#include <stdarg.h>
+#include <errno.h>
+#include "syscall.h"
+
+long vlibc_syscall(long number, ...)
+{
+    (void)number;
+    errno = ENOSYS;
+    return -1;
+}

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -1,5 +1,8 @@
+#define _GNU_SOURCE
 #include <stdarg.h>
-#include <stdint.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <errno.h>
 
 long vlibc_syscall(long number, ...)
 {
@@ -13,14 +16,8 @@ long vlibc_syscall(long number, ...)
     unsigned long a6 = va_arg(ap, unsigned long);
     va_end(ap);
 
-    register unsigned long r10 __asm__("r10") = a4;
-    register unsigned long r8 __asm__("r8") = a5;
-    register unsigned long r9 __asm__("r9") = a6;
-    unsigned long ret;
-    __asm__ volatile("syscall"
-                     : "=a"(ret)
-                     : "a"(number), "D"(a1), "S"(a2), "d"(a3),
-                       "r"(r10), "r"(r8), "r"(r9)
-                     : "rcx", "r11", "memory");
-    return (long)ret;
+    long ret = syscall(number, a1, a2, a3, a4, a5, a6);
+    if (ret < 0)
+        return -errno;
+    return ret;
 }

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -601,8 +601,9 @@ int nanosleep(const struct timespec *req, struct timespec *rem);
 
 ## Raw System Calls
 
-The `syscall` function from `syscall.h` invokes Linux system calls
-directly when no wrapper exists.
+The `syscall` function from `syscall.h` invokes the host's `syscall()`
+wrapper when available. Platform specific implementations may override
+this if the operating system lacks a compatible interface.
 
 ## Non-local Jumps
 


### PR DESCRIPTION
## Summary
- implement `vlibc_syscall` using the host `syscall()` function
- add a Win32 stub implementation under `src/arch`
- select the syscall implementation in the Makefile
- document the syscall mechanism

## Testing
- `make test` *(fails: `open should fail`)*

------
https://chatgpt.com/codex/tasks/task_e_685780de460c8324b7a5e97ef842e0ed