### PR TITLE
Use system setjmp with arch fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PREFIX ?= /usr/local
 CC ?= cc
 CFLAGS ?= -O2 -std=c11 -Wall -Wextra -fno-stack-protector -fno-builtin -Iinclude
 AR ?= ar
+ARCH ?= $(shell uname -m)
 
 SRC := \
     src/errno.c \
@@ -47,8 +48,10 @@ SRC := \
     src/getopt_long.c \
     src/locale.c \
     src/wchar.c \
-    src/math.c \
-    src/setjmp.c
+    src/math.c
+
+ARCH_SRC := $(wildcard src/arch/$(ARCH)/*.c)
+SRC += $(if $(ARCH_SRC),$(ARCH_SRC),src/setjmp.c)
 
 OBJ := $(SRC:.c=.o)
 LIB := libvlibc.a

--- a/include/setjmp.h
+++ b/include/setjmp.h
@@ -1,10 +1,6 @@
 #ifndef SETJMP_H
 #define SETJMP_H
 
-/* simple jump buffer for x86_64 */
-typedef unsigned long jmp_buf[8];
-
-int setjmp(jmp_buf env);
-void longjmp(jmp_buf env, int val) __attribute__((noreturn));
+#include_next <setjmp.h>
 
 #endif /* SETJMP_H */

--- a/src/arch/x86_64/setjmp.c
+++ b/src/arch/x86_64/setjmp.c
@@ -1,0 +1,45 @@
+#include "setjmp.h"
+
+int setjmp(jmp_buf env)
+{
+    int r;
+    __asm__ volatile(
+        "mov %%rbx,0(%1)\n"
+        "mov %%rbp,8(%1)\n"
+        "mov %%r12,16(%1)\n"
+        "mov %%r13,24(%1)\n"
+        "mov %%r14,32(%1)\n"
+        "mov %%r15,40(%1)\n"
+        "mov %%rsp,48(%1)\n"
+        "mov $1f,%%rax\n"
+        "mov %%rax,56(%1)\n"
+        "xor %%eax,%%eax\n"
+        "1: mov %%eax,%0\n"
+        : "=r"(r)
+        : "r"(env)
+        : "memory","rax"
+    );
+    return r;
+}
+
+void longjmp(jmp_buf env, int val)
+{
+    if (val == 0)
+        val = 1;
+    __asm__ volatile(
+        "mov %0,%%rax\n"
+        "mov 0(%1),%%rbx\n"
+        "mov 8(%1),%%rbp\n"
+        "mov 16(%1),%%r12\n"
+        "mov 24(%1),%%r13\n"
+        "mov 32(%1),%%r14\n"
+        "mov 40(%1),%%r15\n"
+        "mov 48(%1),%%rsp\n"
+        "mov 56(%1),%%rdx\n"
+        "jmp *%%rdx\n"
+        :
+        : "r"((long)val), "r"(env)
+        : "rax","rbx","rdx","r12","r13","r14","r15","memory"
+    );
+    __builtin_unreachable();
+}

--- a/src/setjmp.c
+++ b/src/setjmp.c
@@ -1,45 +1,19 @@
 #include "setjmp.h"
+#include <setjmp.h>
+
+#ifdef setjmp
+#undef setjmp
+#endif
+#ifdef longjmp
+#undef longjmp
+#endif
 
 int setjmp(jmp_buf env)
 {
-    int r;
-    __asm__ volatile(
-        "mov %%rbx,0(%1)\n"
-        "mov %%rbp,8(%1)\n"
-        "mov %%r12,16(%1)\n"
-        "mov %%r13,24(%1)\n"
-        "mov %%r14,32(%1)\n"
-        "mov %%r15,40(%1)\n"
-        "mov %%rsp,48(%1)\n"
-        "mov $1f,%%rax\n"
-        "mov %%rax,56(%1)\n"
-        "xor %%eax,%%eax\n"
-        "1: mov %%eax,%0\n"
-        : "=r"(r)
-        : "r"(env)
-        : "memory","rax"
-    );
-    return r;
+    return _setjmp(env);
 }
 
 void longjmp(jmp_buf env, int val)
 {
-    if (val == 0)
-        val = 1;
-    __asm__ volatile(
-        "mov %0,%%rax\n"
-        "mov 0(%1),%%rbx\n"
-        "mov 8(%1),%%rbp\n"
-        "mov 16(%1),%%r12\n"
-        "mov 24(%1),%%r13\n"
-        "mov 32(%1),%%r14\n"
-        "mov 40(%1),%%r15\n"
-        "mov 48(%1),%%rsp\n"
-        "mov 56(%1),%%rdx\n"
-        "jmp *%%rdx\n"
-        :
-        : "r"((long)val), "r"(env)
-        : "rax","rbx","rdx","r12","r13","r14","r15","memory"
-    );
-    __builtin_unreachable();
+    _longjmp(env, val);
 }

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -606,7 +606,9 @@ directly when no wrapper exists.
 
 ## Non-local Jumps
 
-Minimal `setjmp`/`longjmp` helpers save and restore register state:
+When possible vlibc defers to the host C library's `setjmp` and `longjmp`.
+For targets lacking a native implementation, custom versions live under
+`src/arch/<arch>/setjmp.c`.
 
 ```c
 int setjmp(jmp_buf env);
@@ -614,7 +616,7 @@ void longjmp(jmp_buf env, int val);
 ```
 
 Jumping across signal handlers may leave blocked signals in an undefined
-state and only x86_64 is supported.
+state.
 
 ## Limitations
 
@@ -626,7 +628,8 @@ state and only x86_64 is supported.
  - `perror` and `strerror` cover only common errors.
  - Thread support is limited to basic mutexes and join/detach.
  - Only the `"C"` and `"POSIX"` locales are built in.
- - `setjmp`/`longjmp` do not preserve signal masks and target x86_64.
+ - `setjmp`/`longjmp` rely on the host C library when available.
+   Only an x86_64 fallback implementation is provided.
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary
- wrap system setjmp/longjmp instead of inline asm
- keep x86_64 asm version under `src/arch`
- detect architecture in Makefile
- document new behavior and limitation

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685781300370832493d787504b5bb451