### PR TITLE
Add configurable default shell helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ SRC := \
     src/stat.c \
     src/pthread.c \
     src/dirent.c \
+    src/default_shell.c \
     src/popen.c \
     src/ctype.c \
     src/select.c \

--- a/include/vlibc.h
+++ b/include/vlibc.h
@@ -4,4 +4,7 @@
 /* Minimal entry point for the library. */
 void vlibc_init(void);
 
+/* Return default shell path used by system/popen */
+const char *vlibc_default_shell(void);
+
 #endif /* VLIBC_H */

--- a/src/default_shell.c
+++ b/src/default_shell.c
@@ -1,0 +1,13 @@
+#include "stdlib.h"
+
+#ifndef VLIBC_SHELL_PATH
+#define VLIBC_SHELL_PATH "/bin/sh"
+#endif
+
+const char *vlibc_default_shell(void)
+{
+    const char *s = getenv("VLIBC_SHELL");
+    if (s && *s)
+        return s;
+    return VLIBC_SHELL_PATH;
+}

--- a/src/popen.c
+++ b/src/popen.c
@@ -3,6 +3,7 @@
 #include "io.h"
 #include "memory.h"
 #include "string.h"
+#include "vlibc.h"
 
 struct popen_file {
     FILE file;
@@ -40,9 +41,10 @@ FILE *popen(const char *command, const char *mode)
             close(pipefd[1]);
             close(pipefd[0]);
         }
-        char *argv[] = {"/bin/sh", "-c", (char *)command, NULL};
+        const char *shell = vlibc_default_shell();
+        char *argv[] = {(char *)shell, "-c", (char *)command, NULL};
         extern char **environ;
-        execve("/bin/sh", argv, environ);
+        execve(shell, argv, environ);
         _exit(127);
     }
 

--- a/src/system.c
+++ b/src/system.c
@@ -1,6 +1,7 @@
 #include "process.h"
 #include "stdlib.h"
 #include "string.h"
+#include "vlibc.h"
 
 /* Simple implementation of system(3) using fork/execve/waitpid */
 int system(const char *command)
@@ -12,9 +13,10 @@ int system(const char *command)
     if (pid < 0)
         return -1;
     if (pid == 0) {
-        char *argv[] = {"/bin/sh", "-c", (char *)command, NULL};
+        const char *shell = vlibc_default_shell();
+        char *argv[] = {(char *)shell, "-c", (char *)command, NULL};
         extern char **environ;
-        execve("/bin/sh", argv, environ);
+        execve(shell, argv, environ);
         _exit(127);
     }
 


### PR DESCRIPTION
## Summary
- add `vlibc_default_shell()` helper
- use helper in `system()` and `popen()`
- compile new helper in build
- expose API via `vlibc.h`

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_68578280684c8324ade942aeac8e54da