### PR TITLE
Improve docs on platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ programs. Key features include:
 - Dynamic loading
 - Environment variable handling
 
-**Note**: vlibc provides only a small subset of the standard C library, and
-some functions rely on Linux-specific system calls.
+**Note**: vlibc provides only a small subset of the standard C library. Some
+functions depend on system calls that are currently implemented for Linux. BSD
+support is planned, but a few features may still rely on platform-specific
+interfaces.
 
 Build the static library with:
 
@@ -61,6 +63,13 @@ cc -Iinclude hello.c libvlibc.a -o hello
 ```
 
 For detailed documentation, see [vlibcdoc.md](vlibcdoc.md).
+
+## Platform Support
+
+The library currently targets Linux but aims to run on other POSIX systems as
+well. BSD compatibility is on the roadmap. Some modules still rely on
+platform-specific system calls, so non-Linux builds may require additional
+work.
 
 ## Running Tests
 

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -51,8 +51,9 @@ Public License v3.0.
 - Offer consistent behavior for statically linked or embedded programs.
 
 ### Target Platforms
-- Linux (x86_64, aarch64, armv7).
-- Other POSIX systems with minimal porting effort.
+- Linux (x86_64, aarch64, armv7) is currently the primary platform.
+- *BSD variants are planned and patches are welcome.
+- Other POSIX systems should work with minimal porting effort.
 - Lightweight containers or small research kernels implementing POSIX system
   calls.
 
@@ -631,7 +632,8 @@ state.
 
  - The I/O routines perform no buffering and provide only basic error
    reporting.
- - Process creation relies on Linux specific syscalls.
+ - Process creation currently relies on Linux-specific syscalls.
+ - BSD support is in progress and some subsystems may not compile yet.
  - The `system()` helper spawns `/bin/sh -c` and lacks detailed status
    codes.
  - `perror` and `strerror` cover only common errors.


### PR DESCRIPTION
## Summary
- reword Linux-specific notes in documentation
- describe upcoming BSD compatibility and platform limitations

## Testing
- `make test` *(fails: "make: *** [Makefile:95: test] Error 1")*

------
https://chatgpt.com/codex/tasks/task_e_685786a44f108324b5ba80f1e28311a0