### PR TITLE
Add portable syscall feature detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,20 @@ ifeq ($(HAVE_SBRK),1)
 CFLAGS += -DHAVE_SBRK
 endif
 
+# Detect optional syscalls used by vlibc
+HAVE_ACCEPT4 := $(shell printf '#include <sys/syscall.h>\nint main(){return SYS_accept4;}' | $(CC) -x c - -Werror -c -o /dev/null 2>/dev/null && echo 1 || echo 0)
+ifeq ($(HAVE_ACCEPT4),1)
+CFLAGS += -DVLIBC_HAVE_ACCEPT4=1
+endif
+HAVE_PIPE2 := $(shell printf '#include <sys/syscall.h>\nint main(){return SYS_pipe2;}' | $(CC) -x c - -Werror -c -o /dev/null 2>/dev/null && echo 1 || echo 0)
+ifeq ($(HAVE_PIPE2),1)
+CFLAGS += -DVLIBC_HAVE_PIPE2=1
+endif
+HAVE_DUP3 := $(shell printf '#include <sys/syscall.h>\nint main(){return SYS_dup3;}' | $(CC) -x c - -Werror -c -o /dev/null 2>/dev/null && echo 1 || echo 0)
+ifeq ($(HAVE_DUP3),1)
+CFLAGS += -DVLIBC_HAVE_DUP3=1
+endif
+
 TARGET_OS ?= $(OS)
 ifeq ($(TARGET_OS),)
 TARGET_OS := $(shell uname -s)

--- a/include/vlibc_features.h
+++ b/include/vlibc_features.h
@@ -1,18 +1,24 @@
 #ifndef VLIBC_FEATURES_H
 #define VLIBC_FEATURES_H
 
-#include <sys/syscall.h>
+/*
+ * Feature detection macros for optional syscalls.
+ * The build system defines VLIBC_HAVE_ACCEPT4, VLIBC_HAVE_PIPE2 and
+ * VLIBC_HAVE_DUP3 when the respective system calls are available.
+ * If a macro is not provided, it defaults to 0 so the code can fall
+ * back to portable implementations.
+ */
 
-#ifdef SYS_accept4
-#define VLIBC_HAVE_ACCEPT4 1
+#ifndef VLIBC_HAVE_ACCEPT4
+#define VLIBC_HAVE_ACCEPT4 0
 #endif
 
-#ifdef SYS_pipe2
-#define VLIBC_HAVE_PIPE2 1
+#ifndef VLIBC_HAVE_PIPE2
+#define VLIBC_HAVE_PIPE2 0
 #endif
 
-#ifdef SYS_dup3
-#define VLIBC_HAVE_DUP3 1
+#ifndef VLIBC_HAVE_DUP3
+#define VLIBC_HAVE_DUP3 0
 #endif
 
 #endif /* VLIBC_FEATURES_H */

--- a/src/fd.c
+++ b/src/fd.c
@@ -28,7 +28,7 @@ int dup(int oldfd)
 
 int dup2(int oldfd, int newfd)
 {
-#ifdef SYS_dup3
+#if VLIBC_HAVE_DUP3
     long ret = vlibc_syscall(SYS_dup3, oldfd, newfd, 0, 0, 0, 0);
 #else
     long ret = vlibc_syscall(SYS_dup2, oldfd, newfd, 0, 0, 0, 0);
@@ -42,7 +42,7 @@ int dup2(int oldfd, int newfd)
 
 int pipe(int pipefd[2])
 {
-#ifdef SYS_pipe2
+#if VLIBC_HAVE_PIPE2
     long ret = vlibc_syscall(SYS_pipe2, (long)pipefd, 0, 0, 0, 0, 0);
 #else
     long ret = vlibc_syscall(SYS_pipe, (long)pipefd, 0, 0, 0, 0, 0);
@@ -56,7 +56,7 @@ int pipe(int pipefd[2])
 
 int dup3(int oldfd, int newfd, int flags)
 {
-#ifdef VLIBC_HAVE_DUP3
+#if VLIBC_HAVE_DUP3
     long ret = vlibc_syscall(SYS_dup3, oldfd, newfd, flags, 0, 0, 0);
     if (ret < 0) {
         errno = -ret;
@@ -74,7 +74,7 @@ int dup3(int oldfd, int newfd, int flags)
 
 int pipe2(int pipefd[2], int flags)
 {
-#ifdef VLIBC_HAVE_PIPE2
+#if VLIBC_HAVE_PIPE2
     long ret = vlibc_syscall(SYS_pipe2, (long)pipefd, flags, 0, 0, 0, 0);
     if (ret < 0) {
         errno = -ret;

--- a/src/socket.c
+++ b/src/socket.c
@@ -37,7 +37,7 @@ int listen(int sockfd, int backlog)
 
 int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 {
-#ifdef SYS_accept4
+#if VLIBC_HAVE_ACCEPT4
     long ret = vlibc_syscall(SYS_accept4, sockfd, (long)addr, (long)addrlen, 0, 0, 0);
 #else
     long ret = vlibc_syscall(SYS_accept, sockfd, (long)addr, (long)addrlen, 0, 0, 0);
@@ -51,7 +51,7 @@ int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 
 int accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags)
 {
-#ifdef VLIBC_HAVE_ACCEPT4
+#if VLIBC_HAVE_ACCEPT4
     long ret = vlibc_syscall(SYS_accept4, sockfd, (long)addr, (long)addrlen, flags, 0, 0);
     if (ret < 0) {
         errno = -ret;


### PR DESCRIPTION
## Summary
- probe optional syscalls in Makefile instead of relying on SYS_* macros
- default optional feature macros in `vlibc_features.h`
- use the probed macros in fd and socket wrappers

## Testing
- `make clean`
- `make`
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6857881d7690832488998f764987aad7