### PR TITLE
Fix pthread usage

### DIFF
--- a/src/pthread.c
+++ b/src/pthread.c
@@ -1,4 +1,5 @@
 #include "pthread.h"
+#include_next <pthread.h>
 #include <errno.h>
 
 /* simple spinlock based mutex */
@@ -25,45 +26,5 @@ int pthread_mutex_unlock(pthread_mutex_t *mutex)
 int pthread_mutex_destroy(pthread_mutex_t *mutex)
 {
     (void)mutex;
-    return 0;
-}
-
-/* wrappers around host pthread implementation */
-extern int host_pthread_create(pthread_t *t, const void *a,
-                               void *(*fn)(void *), void *arg)
-    __asm__("pthread_create");
-extern int host_pthread_join(pthread_t t, void **ret)
-    __asm__("pthread_join");
-extern int host_pthread_detach(pthread_t t)
-    __asm__("pthread_detach");
-
-int pthread_create(pthread_t *thread, const void *attr,
-                   void *(*start_routine)(void *), void *arg)
-{
-    int r = host_pthread_create(thread, attr, start_routine, arg);
-    if (r != 0) {
-        errno = r;
-        return -1;
-    }
-    return 0;
-}
-
-int pthread_join(pthread_t thread, void **retval)
-{
-    int r = host_pthread_join(thread, retval);
-    if (r != 0) {
-        errno = r;
-        return -1;
-    }
-    return 0;
-}
-
-int pthread_detach(pthread_t thread)
-{
-    int r = host_pthread_detach(thread);
-    if (r != 0) {
-        errno = r;
-        return -1;
-    }
     return 0;
 }


### PR DESCRIPTION
## Summary
- use `<pthread.h>` normally and rely on host library implementation
- drop assembly aliases and thread wrapper functions

## Testing
- `make`
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_685788e5d9e883248e6f18352f31cf36