### PR TITLE
Improve syscall fallbacks

### DIFF
--- a/src/stdio.c
+++ b/src/stdio.c
@@ -159,12 +159,15 @@ int fflush(FILE *stream)
 {
     if (!stream)
         return 0;
-#ifdef SYS_fsync
+#if defined(__linux__) && defined(SYS_fsync)
     long ret = vlibc_syscall(SYS_fsync, stream->fd, 0, 0, 0, 0, 0);
     if (ret < 0) {
         errno = -ret;
         return -1;
     }
+#else
+    if (fsync(stream->fd) < 0)
+        return -1;
 #endif
     return 0;
 }

--- a/src/time.c
+++ b/src/time.c
@@ -3,6 +3,13 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 #include "syscall.h"
+#if !defined(SYS_time) && !defined(SYS_clock_gettime)
+#include_next <time.h>
+#include <sys/time.h>
+extern time_t host_time(time_t *t) __asm__("time");
+extern int host_gettimeofday(struct timeval *tv, void *tz)
+    __asm__("gettimeofday");
+#endif
 
 #ifdef SYS_clock_gettime
 #ifndef CLOCK_REALTIME
@@ -33,8 +40,7 @@ time_t time(time_t *t)
         *t = ts.tv_sec;
     return ts.tv_sec;
 #else
-    (void)t;
-    return (time_t)-1;
+    return host_time(t);
 #endif
 }
 
@@ -66,7 +72,6 @@ int gettimeofday(struct timeval *tv, void *tz)
     }
     return 0;
 #else
-    (void)tv;
-    return -1;
+    return host_gettimeofday(tv, tz);
 #endif
 }


### PR DESCRIPTION
## Summary
- allow building on platforms that lack SYS_time or SYS_clock_gettime
- use host fsync() when SYS_fsync is not available

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_68578aa9647083248830b2b3f1df78d4