### PR TITLE
Use system select on BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,14 @@ else ifeq ($(TARGET_OS),Windows_NT)
 SYS_SRC := src/arch/win32/syscall.c
 endif
 
+# Use the system implementations of select(2) and poll(2) on the BSD
+# family. These wrappers are only needed on Linux where direct
+# syscalls are issued.
+SELECT_SRC := src/select.c
+ifneq (,$(filter $(TARGET_OS),FreeBSD NetBSD OpenBSD DragonFly))
+SELECT_SRC :=
+endif
+
 SRC := \
     src/errno.c \
     src/error.c \
@@ -78,7 +86,7 @@ SRC := \
     src/default_shell.c \
     src/popen.c \
     src/ctype.c \
-    src/select.c \
+    $(SELECT_SRC) \
     src/qsort.c \
     src/getopt.c \
     src/dlfcn.c \

--- a/include/poll.h
+++ b/include/poll.h
@@ -18,6 +18,11 @@ struct pollfd {
 #define POLLHUP 0x0010
 #define POLLNVAL 0x0020
 
+/*
+ * Wait for events on multiple file descriptors. On BSD systems this
+ * wrapper delegates to the host C library's poll(2) instead of issuing a
+ * raw system call which may have different semantics.
+ */
 int poll(struct pollfd *fds, nfds_t nfds, int timeout);
 
 #endif /* POLL_H */

--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -21,7 +21,11 @@ typedef struct {
 #define FD_CLR(fd, set) ((set)->fds_bits[(fd) / (8 * sizeof(unsigned long))] &= ~(1UL << ((fd) % (8 * sizeof(unsigned long)))))
 #define FD_ISSET(fd, set) (((set)->fds_bits[(fd) / (8 * sizeof(unsigned long))] >> ((fd) % (8 * sizeof(unsigned long)))) & 1UL)
 
-/* wrapper */
+/*
+ * Wait for activity on file descriptors. On BSD targets this function
+ * simply calls the C library's select(2) as the raw syscall interface may
+ * differ.
+ */
 int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
            struct timeval *timeout);
 

--- a/src/select.c
+++ b/src/select.c
@@ -1,3 +1,8 @@
+/*
+ * Linux wrappers for select(2) and poll(2) using raw syscalls. On BSD the
+ * build relies on the system C library versions instead.
+ */
+
 #include "sys/select.h"
 #include "time.h"
 #include "errno.h"

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -547,6 +547,10 @@ FD_SET(fd, &set);
 select(fd + 1, &set, NULL, NULL, NULL);
 ```
 
+On BSD systems these wrappers simply call the host C library's
+implementations which may exhibit slightly different semantics than the
+Linux syscall-based versions.
+
 ## File Permissions
 
 Simple helpers adjust permissions and ownership:


### PR DESCRIPTION
## Summary
- avoid building `src/select.c` on BSD so libc versions are used
- document that BSD builds call out to libc for `select` and `poll`

## Testing
- `make clean`
- `make test` *(fails: `open should fail`)*

------
https://chatgpt.com/codex/tasks/task_e_68578aa1dec88324ac27e330370762b1