### PR TITLE
Remove include_next from headers

### DIFF
--- a/include/setjmp.h
+++ b/include/setjmp.h
@@ -1,6 +1,10 @@
 #ifndef SETJMP_H
 #define SETJMP_H
 
-#include_next <setjmp.h>
+#if defined(__has_include)
+#  if __has_include("/usr/include/setjmp.h")
+#    include "/usr/include/setjmp.h"
+#  endif
+#endif
 
 #endif /* SETJMP_H */

--- a/include/string.h
+++ b/include/string.h
@@ -3,6 +3,12 @@
 
 #include <stddef.h>
 
+#if defined(__has_include)
+#  if __has_include("/usr/include/string.h")
+#    include "/usr/include/string.h"
+#  endif
+#endif
+
 size_t vstrlen(const char *s);
 size_t strnlen(const char *s, size_t maxlen);
 char *vstrcpy(char *dest, const char *src);
@@ -29,5 +35,3 @@ char *strtok(char *str, const char *delim);
 char *strtok_r(char *str, const char *delim, char **saveptr);
 
 #endif /* STRING_H */
-
-#include_next <string.h>

--- a/include/sys/file.h
+++ b/include/sys/file.h
@@ -3,10 +3,16 @@
 
 #include <sys/types.h>
 
+#if defined(__has_include)
+#  if __has_include("/usr/include/x86_64-linux-gnu/sys/file.h")
+#    include "/usr/include/x86_64-linux-gnu/sys/file.h"
+#  elif __has_include("/usr/include/sys/file.h")
+#    include "/usr/include/sys/file.h"
+#  endif
+#endif
+
 int chmod(const char *path, mode_t mode);
 int chown(const char *path, uid_t owner, gid_t group);
 mode_t umask(mode_t mask);
 
 #endif /* SYS_FILE_H */
-
-#include_next <sys/file.h>

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -4,13 +4,17 @@
 #include <sys/types.h>
 #include <stddef.h>
 
+#if defined(__has_include)
+#  if __has_include("/usr/include/x86_64-linux-gnu/sys/mman.h")
+#    include "/usr/include/x86_64-linux-gnu/sys/mman.h"
+#  elif __has_include("/usr/include/sys/mman.h")
+#    include "/usr/include/sys/mman.h"
+#  endif
+#endif
+
 void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
 int munmap(void *addr, size_t length);
 int mprotect(void *addr, size_t length, int prot);
-
-#endif /* MMAN_H */
-
-#include_next <sys/mman.h>
 
 /*
  * Some BSD systems expose MAP_ANON instead of MAP_ANONYMOUS.  Provide
@@ -23,3 +27,29 @@ int mprotect(void *addr, size_t length, int prot);
 #if defined(MAP_ANONYMOUS) && !defined(MAP_ANON)
 #define MAP_ANON MAP_ANONYMOUS
 #endif
+
+/* Provide basic memory protection and mapping flags when missing. */
+#ifndef PROT_READ
+#define PROT_READ 0x1
+#endif
+#ifndef PROT_WRITE
+#define PROT_WRITE 0x2
+#endif
+#ifndef PROT_EXEC
+#define PROT_EXEC 0x4
+#endif
+#ifndef MAP_PRIVATE
+#define MAP_PRIVATE 0x02
+#endif
+#ifndef MAP_FAILED
+#define MAP_FAILED ((void *)-1)
+#endif
+
+#ifndef MAP_ANONYMOUS
+#define MAP_ANONYMOUS 0x20
+#endif
+#ifndef MAP_ANON
+#define MAP_ANON MAP_ANONYMOUS
+#endif
+
+#endif /* MMAN_H */

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -3,6 +3,14 @@
 
 #include <sys/types.h>
 
+#if defined(__has_include)
+#  if __has_include("/usr/include/x86_64-linux-gnu/sys/stat.h")
+#    include "/usr/include/x86_64-linux-gnu/sys/stat.h"
+#  elif __has_include("/usr/include/sys/stat.h")
+#    include "/usr/include/sys/stat.h"
+#  endif
+#endif
+
 struct stat;
 
 int stat(const char *path, struct stat *buf);
@@ -10,5 +18,3 @@ int fstat(int fd, struct stat *buf);
 int lstat(const char *path, struct stat *buf);
 
 #endif /* SYS_STAT_H */
-
-#include_next <sys/stat.h>


### PR DESCRIPTION
## Summary
- use guarded system includes instead of `#include_next`
- define fallback mmap constants when missing

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_685791ad3b608324ae7506eca612536b