### PR TITLE
Use system dirent

### DIFF
--- a/include/dirent.h
+++ b/include/dirent.h
@@ -4,23 +4,14 @@
 #include <sys/types.h>
 #include <stddef.h>
 
-/* BSD style directory entry */
-struct dirent {
-    ino_t          d_fileno;   /* file number */
-    off_t          d_off;      /* seek offset to next entry */
-    unsigned short d_reclen;   /* length of this record */
-    unsigned char  d_type;     /* file type */
-    unsigned char  d_namlen;   /* length of name */
-    char           d_name[256];/* null terminated file name */
-};
+/*
+ * Pull in the system definitions of DIR and struct dirent. This header sits
+ * ahead of the system directories on the include path, so use
+ * include_next to reach the real header.
+ */
+#include_next <dirent.h>
 
-#define d_ino d_fileno
-
-typedef struct {
-    void *impl;               /* pointer to system DIR structure */
-    struct dirent ent;        /* storage for returned entry */
-} DIR;
-
+/* Wrapper prototypes for the system directory functions. */
 DIR *vlibc_opendir(const char *name);
 struct dirent *vlibc_readdir(DIR *dirp);
 int vlibc_closedir(DIR *dirp);

--- a/src/dirent.c
+++ b/src/dirent.c
@@ -4,60 +4,18 @@
 #undef opendir
 #undef readdir
 #undef closedir
-#include "memory.h"
-#include "io.h"
-#include "errno.h"
-#include <string.h>
-#include <fcntl.h>
-#ifndef O_DIRECTORY
-#define O_DIRECTORY 0200000
-#endif
-
-typedef struct __dirstream sys_DIR;
-
-/* Declare the system directory functions we wrap. */
-extern DIR *fdopendir(int);
-extern struct dirent *readdir(sys_DIR *);
-extern int closedir(sys_DIR *);
 
 DIR *vlibc_opendir(const char *name)
 {
-    int fd = open(name, O_RDONLY | O_DIRECTORY);
-    if (fd < 0)
-        return NULL;
-
-    DIR *d = malloc(sizeof(DIR));
-    if (!d) {
-        close(fd);
-        errno = ENOMEM;
-        return NULL;
-    }
-    d->impl = fdopendir(fd);
-    if (!d->impl) {
-        close(fd);
-        free(d);
-        return NULL;
-    }
-    return d;
+    return opendir(name);
 }
 
 struct dirent *vlibc_readdir(DIR *dirp)
 {
-    if (!dirp || !dirp->impl)
-        return NULL;
-
-    struct dirent *e = readdir((sys_DIR *)dirp->impl);
-    if (!e)
-        return NULL;
-    memcpy(&dirp->ent, e, sizeof(struct dirent));
-    return &dirp->ent;
+    return readdir(dirp);
 }
 
 int vlibc_closedir(DIR *dirp)
 {
-    if (!dirp)
-        return -1;
-    int r = closedir((sys_DIR *)dirp->impl);
-    free(dirp);
-    return r;
+    return closedir(dirp);
 }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -7,7 +7,7 @@
 #include "../include/pthread.h"
 #include "../include/sys/select.h"
 #include "../include/poll.h"
-#include "../include/dirent.h"
+#include <dirent.h>
 #include "../include/vlibc.h"
 #include "../include/dlfcn.h"
 


### PR DESCRIPTION
## Summary
- rely on the system `dirent.h`
- simplify directory wrapper implementation
- adjust tests to include system header

## Testing
- `make test` *(fails: `open should fail`)*

------
https://chatgpt.com/codex/tasks/task_e_685797c673748324bd20536a16ea9b6f