### PR TITLE
Implement thread-local errno

### DIFF
--- a/include/errno.h
+++ b/include/errno.h
@@ -76,7 +76,7 @@
 #define ESTALE           116
 #define ECANCELED        125
 
-extern int errno;
+extern __thread int errno;
 int *__errno_location(void);
 
 #endif /* ERRNO_H */

--- a/src/arch/bsd/syscall.c
+++ b/src/arch/bsd/syscall.c
@@ -1,7 +1,7 @@
 #include <stdarg.h>
 #include <unistd.h>
 #include <sys/syscall.h>
-#include <errno.h>
+#include_next <errno.h>
 
 long vlibc_syscall(long number, ...)
 {

--- a/src/arch/win32/syscall.c
+++ b/src/arch/win32/syscall.c
@@ -1,5 +1,5 @@
 #include <stdarg.h>
-#include <errno.h>
+#include_next <errno.h>
 #include "syscall.h"
 
 long vlibc_syscall(long number, ...)

--- a/src/errno.c
+++ b/src/errno.c
@@ -1,6 +1,7 @@
 #include "errno.h"
 
-int errno;
+/* each thread maintains its own errno value */
+__thread int errno;
 
 int *__errno_location(void)
 {

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -2,7 +2,7 @@
 #include <stdarg.h>
 #include <unistd.h>
 #include <sys/syscall.h>
-#include <errno.h>
+#include_next <errno.h>
 
 long vlibc_syscall(long number, ...)
 {

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -378,12 +378,12 @@ combining the optional prefix with the text for the current `errno`.
 
 ## Errno Access
 
-The global `errno` variable stores the last failure code. The helper
-`__errno_location()` returns a pointer to this value so that macros can
-reference it directly.
+The `errno` variable is thread‑local and stores the last failure code.
+The helper `__errno_location()` returns a pointer to this value so that
+macros can reference it directly.
 
 ```c
-extern int errno;
+extern __thread int errno;
 int *__errno_location(void);
 ```
 


### PR DESCRIPTION
## Summary
- update errno global to be thread-local
- return TLS errno from `__errno_location`
- declare thread-local errno in headers
- mention thread-local storage in docs
- adjust syscall sources to use `include_next` for errno

## Testing
- `make clean >/dev/null && make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_685799ccccd88324b1637f993062b59f