### PR TITLE
Switch to stdatomic spinlock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 PREFIX ?= /usr/local
 CC ?= cc
-CFLAGS ?= -O2 -std=c11 -Wall -Wextra -fno-stack-protector -fno-builtin -Iinclude
+CFLAGS ?= -O2 -Wall -Wextra -fno-stack-protector -fno-builtin -Iinclude
+CFLAGS += -std=c11
 AR ?= ar
 ARCH ?= $(shell uname -m)
 

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -2,6 +2,7 @@
 #define PTHREAD_H
 
 #include <sys/types.h>
+#include <stdatomic.h>
 
 /*
  * vlibc threads are thin wrappers around the host pthread
@@ -11,7 +12,7 @@
 typedef unsigned long pthread_t;
 
 typedef struct {
-    volatile int locked;
+    atomic_flag locked;
 } pthread_mutex_t;
 
 int pthread_create(pthread_t *thread, const void *attr,

--- a/src/pthread.c
+++ b/src/pthread.c
@@ -1,25 +1,27 @@
 #include "pthread.h"
 #include_next <pthread.h>
 #include <errno.h>
+#include <stdatomic.h>
 
 /* simple spinlock based mutex */
 int pthread_mutex_init(pthread_mutex_t *mutex, void *attr)
 {
     (void)attr;
-    mutex->locked = 0;
+    atomic_flag_clear(&mutex->locked);
     return 0;
 }
 
 int pthread_mutex_lock(pthread_mutex_t *mutex)
 {
-    while (__sync_lock_test_and_set(&mutex->locked, 1))
+    while (atomic_flag_test_and_set_explicit(&mutex->locked,
+                                             memory_order_acquire))
         ;
     return 0;
 }
 
 int pthread_mutex_unlock(pthread_mutex_t *mutex)
 {
-    __sync_lock_release(&mutex->locked);
+    atomic_flag_clear_explicit(&mutex->locked, memory_order_release);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- use `atomic_flag` instead of `__sync_*` intrinsics for the simple mutex
- include `<stdatomic.h>` in `pthread.h`
- enforce `-std=c11` in the Makefile

## Testing
- `make test` *(fails: "open should fail")*

------
https://chatgpt.com/codex/tasks/task_e_685799c0e5208324afa2ae778ca0eb58