### PR TITLE
Add strerror_r implementation and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ SRC := \
     src/system.c \
     src/string.c \
     src/string_extra.c \
+    src/strerror_r.c \
     src/strto.c \
     src/rand.c \
     src/socket.c \

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -36,6 +36,7 @@ int vsprintf(char *str, const char *format, va_list ap);
 
 /* Basic error helpers */
 char *strerror(int errnum);
+int strerror_r(int errnum, char *buf, size_t buflen);
 void perror(const char *s);
 
 FILE *popen(const char *command, const char *mode);

--- a/src/error.c
+++ b/src/error.c
@@ -6,7 +6,7 @@ struct err_entry {
     const char *msg;
 };
 
-static struct err_entry err_table[] = {
+const struct err_entry __vlibc_err_table[] = {
     { EPERM, "Operation not permitted" },
     { ENOENT, "No such file or directory" },
     { ESRCH, "No such process" },
@@ -85,9 +85,9 @@ static struct err_entry err_table[] = {
 
 char *strerror(int errnum)
 {
-    for (size_t i = 0; err_table[i].msg; ++i) {
-        if (err_table[i].code == errnum)
-            return err_table[i].msg;
+    for (size_t i = 0; __vlibc_err_table[i].msg; ++i) {
+        if (__vlibc_err_table[i].code == errnum)
+            return (char *)__vlibc_err_table[i].msg;
     }
     static char unknown[32];
     snprintf(unknown, sizeof(unknown), "Unknown error %d", errnum);

--- a/src/strerror_r.c
+++ b/src/strerror_r.c
@@ -1,0 +1,25 @@
+#include "stdio.h"
+#include "string.h"
+
+struct err_entry {
+    int code;
+    const char *msg;
+};
+
+extern const struct err_entry __vlibc_err_table[];
+
+int strerror_r(int errnum, char *buf, size_t buflen)
+{
+    if (!buf || buflen == 0)
+        return -1;
+    for (size_t i = 0; __vlibc_err_table[i].msg; ++i) {
+        if (__vlibc_err_table[i].code == errnum) {
+            size_t len = strnlen(__vlibc_err_table[i].msg, buflen - 1);
+            memcpy(buf, __vlibc_err_table[i].msg, len);
+            buf[len] = '\0';
+            return 0;
+        }
+    }
+    snprintf(buf, buflen, "Unknown error %d", errnum);
+    return 0;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -64,6 +64,19 @@ static void *thread_fn(void *arg)
     return (void *)123;
 }
 
+static void *strerror_r_worker(void *arg)
+{
+    int err = *(int *)arg;
+    char buf[64];
+    if (strerror_r(err, buf, sizeof(buf)) != 0)
+        return (void *)1;
+    if (err == ENOENT)
+        return (void *)(strcmp(buf, "No such file or directory") != 0);
+    char expect[32];
+    snprintf(expect, sizeof(expect), "Unknown error %d", err);
+    return (void *)(strcmp(buf, expect) != 0);
+}
+
 static const char *test_malloc(void)
 {
     void *p = malloc(16);
@@ -713,6 +726,18 @@ static const char *test_error_reporting(void)
     const char *exp = "test: No such file or directory\n";
     mu_assert("perror output", (size_t)n == strlen(exp) && memcmp(buf, exp, n) == 0);
 
+    pthread_t t1, t2;
+    int e1 = ENOENT;
+    int e2 = 9999;
+    pthread_create(&t1, NULL, strerror_r_worker, &e1);
+    pthread_create(&t2, NULL, strerror_r_worker, &e2);
+    void *r1 = (void *)1;
+    void *r2 = (void *)1;
+    pthread_join(t1, &r1);
+    pthread_join(t2, &r2);
+    mu_assert("strerror_r thread1", r1 == NULL);
+    mu_assert("strerror_r thread2", r2 == NULL);
+
     return 0;
 }
 
@@ -1017,6 +1042,7 @@ static const char *all_tests(void)
     mu_run_test(test_strftime_basic);
     mu_run_test(test_time_conversions);
     mu_run_test(test_environment);
+    mu_run_test(test_error_reporting);
     mu_run_test(test_system_fn);
     mu_run_test(test_execvp_fn);
     mu_run_test(test_popen_fn);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -368,12 +368,14 @@ vlibc provides minimal helpers to report errors:
 
 ```c
 const char *strerror(int errnum);
+int strerror_r(int errnum, char *buf, size_t buflen);
 void perror(const char *s);
 ```
 
 
 `strerror()` returns a string describing `errnum` or "Unknown error" for
-codes it does not recognize. `perror()` writes a message to `stderr`
+codes it does not recognize. `strerror_r()` is a thread-safe variant that
+writes the message into `buf`. `perror()` writes a message to `stderr`
 combining the optional prefix with the text for the current `errno`.
 
 ## Errno Access


### PR DESCRIPTION
## Summary
- declare `strerror_r` in `stdio.h`
- export error table and use it to implement `strerror_r`
- test error reporting from multiple threads
- document thread-safe variant in docs

## Testing
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6858789f751c8324b36b6e17c53ac46e