### PR TITLE
Add inet_pton/ntop IPv4 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ SRC := \
     src/rand.c \
     src/socket.c \
     src/netdb.c \
+    src/inet_pton.c \
+    src/inet_ntop.c \
     src/fd.c \
     src/file.c \
     src/file_perm.c \

--- a/include/arpa/inet.h
+++ b/include/arpa/inet.h
@@ -1,0 +1,9 @@
+#ifndef ARPA_INET_H
+#define ARPA_INET_H
+
+#include <netinet/in.h>
+
+int inet_pton(int af, const char *src, void *dst);
+const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
+
+#endif /* ARPA_INET_H */

--- a/src/inet_ntop.c
+++ b/src/inet_ntop.c
@@ -1,0 +1,28 @@
+#include "arpa/inet.h"
+#include "errno.h"
+#include "stdio.h"
+#include <arpa/inet.h>
+
+const char *inet_ntop(int af, const void *src, char *dst, socklen_t size)
+{
+    if (af != AF_INET) {
+        errno = EAFNOSUPPORT;
+        return NULL;
+    }
+    if (!src || !dst || size == 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (size < INET_ADDRSTRLEN) {
+        errno = ENOSPC;
+        return NULL;
+    }
+    const struct in_addr *in = src;
+    uint32_t addr = ntohl(in->s_addr);
+    unsigned char a = (addr >> 24) & 0xFF;
+    unsigned char b = (addr >> 16) & 0xFF;
+    unsigned char c = (addr >> 8) & 0xFF;
+    unsigned char d = addr & 0xFF;
+    snprintf(dst, size, "%u.%u.%u.%u", a, b, c, d);
+    return dst;
+}

--- a/src/inet_pton.c
+++ b/src/inet_pton.c
@@ -1,0 +1,46 @@
+#include "arpa/inet.h"
+#include "errno.h"
+#include "stdlib.h"
+#include <stdint.h>
+#include <arpa/inet.h>
+
+static int parse_ipv4(const char *s, uint32_t *out)
+{
+    char *end;
+    long a = strtol(s, &end, 10);
+    if (a < 0 || a > 255 || *end != '.')
+        return -1;
+    s = end + 1;
+    long b = strtol(s, &end, 10);
+    if (b < 0 || b > 255 || *end != '.')
+        return -1;
+    s = end + 1;
+    long c = strtol(s, &end, 10);
+    if (c < 0 || c > 255 || *end != '.')
+        return -1;
+    s = end + 1;
+    long d = strtol(s, &end, 10);
+    if (d < 0 || d > 255 || (*end && *end != ' ' && *end != '\t'))
+        return -1;
+    *out = ((uint32_t)a << 24) | ((uint32_t)b << 16) |
+           ((uint32_t)c << 8) | (uint32_t)d;
+    return 0;
+}
+
+int inet_pton(int af, const char *src, void *dst)
+{
+    if (af != AF_INET) {
+        errno = EAFNOSUPPORT;
+        return -1;
+    }
+    if (!src || !dst) {
+        errno = EINVAL;
+        return -1;
+    }
+    uint32_t ip;
+    if (parse_ipv4(src, &ip) != 0)
+        return 0;
+    struct in_addr *in = dst;
+    in->s_addr = htonl(ip);
+    return 1;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3,6 +3,7 @@
 #include "../include/io.h"
 #include "../include/sys/socket.h"
 #include <netinet/in.h>
+#include "../include/arpa/inet.h"
 #include <stdint.h>
 #include "../include/sys/stat.h"
 #include "../include/stdio.h"
@@ -270,6 +271,20 @@ static const char *test_udp_send_recv(void)
 
     close(s1);
     close(s2);
+    return 0;
+}
+
+static const char *test_inet_pton_ntop(void)
+{
+    struct in_addr addr;
+    int r = inet_pton(AF_INET, "127.2.3.4", &addr);
+    mu_assert("inet_pton", r == 1);
+    char buf[INET_ADDRSTRLEN];
+    const char *p = inet_ntop(AF_INET, &addr, buf, sizeof(buf));
+    mu_assert("inet_ntop", p && strcmp(buf, "127.2.3.4") == 0);
+    struct in_addr back;
+    r = inet_pton(AF_INET, buf, &back);
+    mu_assert("inet_pton round", r == 1 && back.s_addr == addr.s_addr);
     return 0;
 }
 
@@ -1041,6 +1056,7 @@ static const char *all_tests(void)
     mu_run_test(test_pipe2_cloexec);
     mu_run_test(test_socket);
     mu_run_test(test_udp_send_recv);
+    mu_run_test(test_inet_pton_ntop);
     mu_run_test(test_errno_open);
     mu_run_test(test_errno_stat);
     mu_run_test(test_stat_wrappers);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -149,6 +149,7 @@ locale.h     - locale helpers
 math.h       - basic math routines
 memory.h     - heap allocation
 netdb.h      - address resolution helpers
+arpa/inet.h  - IPv4 presentation conversion helpers
 poll.h       - I/O multiplexing helpers
 process.h    - process creation and control
 pthread.h    - minimal threading support
@@ -534,6 +535,9 @@ The socket layer exposes thin wrappers around the kernel's networking
 syscalls including `socket`, `bind`, `listen`, `accept`, `connect`,
 `send`, `recv`, `sendto`, and `recvfrom`. Address resolution is handled
 via `getaddrinfo`, `freeaddrinfo`, and `getnameinfo`.
+
+Utilities `inet_pton` and `inet_ntop` convert between dotted IPv4 strings
+and binary network format.
 
 ```c
 struct addrinfo *ai;


### PR DESCRIPTION
## Summary
- add `arpa/inet.h` header
- implement IPv4 `inet_pton` and `inet_ntop`
- compile new sources
- document networking helpers and header
- test address conversion routines

## Testing
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_685878e7ca848324b169fbee219b7628