### PR TITLE
Implement strcasecmp/strncasecmp

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -33,5 +33,7 @@ char *strrchr(const char *s, int c);
 char *strstr(const char *haystack, const char *needle);
 char *strtok(char *str, const char *delim);
 char *strtok_r(char *str, const char *delim, char **saveptr);
+int strcasecmp(const char *s1, const char *s2);
+int strncasecmp(const char *s1, const char *s2, size_t n);
 
 #endif /* STRING_H */

--- a/src/string_extra.c
+++ b/src/string_extra.c
@@ -1,4 +1,5 @@
 #include "string.h"
+#include "ctype.h"
 
 void *memchr(const void *s, int c, size_t n)
 {
@@ -37,4 +38,23 @@ char *strstr(const char *haystack, const char *needle)
         haystack++;
     }
     return NULL;
+}
+
+int strncasecmp(const char *s1, const char *s2, size_t n)
+{
+    while (n--) {
+        unsigned char c1 = (unsigned char)*s1++;
+        unsigned char c2 = (unsigned char)*s2++;
+        int diff = tolower(c1) - tolower(c2);
+        if (diff)
+            return diff;
+        if (c1 == '\0')
+            break;
+    }
+    return 0;
+}
+
+int strcasecmp(const char *s1, const char *s2)
+{
+    return strncasecmp(s1, s2, (size_t)-1);
 }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -428,6 +428,14 @@ static const char *test_string_helpers(void)
     return 0;
 }
 
+static const char *test_string_casecmp(void)
+{
+    mu_assert("strcasecmp eq", strcasecmp("HeLLo", "hello") == 0);
+    mu_assert("strcasecmp diff", strcasecmp("abc", "Abd") < 0);
+    mu_assert("strncasecmp n4", strncasecmp("TestX", "testY", 4) == 0);
+    return 0;
+}
+
 static const char *test_widechar_basic(void)
 {
     wchar_t wc = 0;
@@ -1118,6 +1126,7 @@ static const char *all_tests(void)
     mu_run_test(test_stat_wrappers);
     mu_run_test(test_link_readlink);
     mu_run_test(test_string_helpers);
+    mu_run_test(test_string_casecmp);
     mu_run_test(test_widechar_basic);
     mu_run_test(test_strtok_basic);
     mu_run_test(test_strtok_r_basic);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -225,6 +225,7 @@ The **string** module provides fundamental operations needed by most C programs:
 
 - `vstrlen`, `vstrcpy`, `vstrncmp`, `strnlen`, `strcat` and `strncat` equivalents.
 - Search helpers `strstr`, `strrchr`, and `memchr` for locating substrings or bytes.
+- Case-insensitive comparisons `strcasecmp` and `strncasecmp`.
 - Conventional memory routines (`memcpy`, `memmove`, `memset`, `memcmp`) map to
   the internal `v` implementations.
 - The low-level memory helpers `vmemcpy`, `vmemmove`, `vmemset`, and `vmemcmp` operate on raw byte buffers. `vmemcpy` copies bytes from a source to a destination, `vmemmove` handles overlaps safely, `vmemset` fills a region with a byte value, and `vmemcmp` compares two buffers. The standard `memcpy`, `memmove`, `memset`, and `memcmp` functions simply call these implementations.


### PR DESCRIPTION
## Summary
- add `strcasecmp` and `strncasecmp` prototypes
- implement the functions
- test case-insensitive comparisons
- mention the new helpers in docs

## Testing
- `make`
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68587a87cd0483248e0c7d4bf98934a7