### PR TITLE
Add realpath implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ SRC := \
     src/truncate.c \
     src/dir.c \
     src/getcwd.c \
+    src/realpath.c \
     $(SYS_SRC) \
     src/mmap.c \
     src/env.c \

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -11,6 +11,7 @@ int unsetenv(const char *name);
 
 /* Current working directory */
 char *getcwd(char *buf, size_t size);
+char *realpath(const char *path, char *resolved_path);
 
 /* Execute a shell command */
 int system(const char *command);

--- a/src/realpath.c
+++ b/src/realpath.c
@@ -1,0 +1,82 @@
+#include "stdlib.h"
+#include "string.h"
+#include "memory.h"
+#include "errno.h"
+
+char *realpath(const char *path, char *resolved_path)
+{
+    if (!path) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    char cwd[256];
+    char *full = NULL;
+    if (path[0] != '/') {
+        if (!getcwd(cwd, sizeof(cwd)))
+            return NULL;
+        size_t cwd_len = strlen(cwd);
+        size_t add_slash = (cwd_len > 1 && cwd[cwd_len-1] != '/') ? 1 : 0;
+        size_t len = cwd_len + add_slash + strlen(path) + 1;
+        full = malloc(len + 1);
+        if (!full)
+            return NULL;
+        strcpy(full, cwd);
+        if (add_slash)
+            strcat(full, "/");
+        strcat(full, path);
+    } else {
+        full = strdup(path);
+        if (!full)
+            return NULL;
+    }
+
+    size_t out_cap = strlen(full) + 2;
+    char *outbuf = resolved_path ? resolved_path : malloc(out_cap);
+    if (!outbuf) {
+        free(full);
+        return NULL;
+    }
+
+    size_t out_len = 1;
+    outbuf[0] = '/';
+    outbuf[1] = '\0';
+
+    char *p = full;
+    if (*p == '/')
+        ++p;
+    while (*p) {
+        while (*p == '/')
+            ++p;
+        if (!*p)
+            break;
+        char *start = p;
+        while (*p && *p != '/')
+            ++p;
+        size_t seg_len = p - start;
+        if (seg_len == 1 && start[0] == '.') {
+            /* ignore */
+        } else if (seg_len == 2 && start[0] == '.' && start[1] == '.') {
+            if (out_len > 1) {
+                while (out_len > 1 && outbuf[out_len-1] != '/')
+                    --out_len;
+                if (out_len > 1)
+                    --out_len; /* drop trailing '/' */
+            }
+        } else {
+            if (out_len > 1)
+                outbuf[out_len++] = '/';
+            memcpy(outbuf + out_len, start, seg_len);
+            out_len += seg_len;
+            outbuf[out_len] = '\0';
+        }
+    }
+
+    if (out_len > 1 && outbuf[out_len-1] == '/') {
+        outbuf[out_len-1] = '\0';
+    }
+
+    free(full);
+    return outbuf;
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -996,6 +996,27 @@ static const char *test_getcwd_chdir(void)
     return 0;
 }
 
+static const char *test_realpath_basic(void)
+{
+    char cwd[256];
+    mu_assert("cwd", getcwd(cwd, sizeof(cwd)) != NULL);
+
+    char buf[256];
+    mu_assert("realpath dot", realpath(".", buf) != NULL);
+    mu_assert("dot eq", strcmp(buf, cwd) == 0);
+
+    mu_assert("realpath parent", realpath("tests/..", buf) != NULL);
+    mu_assert("parent eq", strcmp(buf, cwd) == 0);
+
+    char expect[256];
+    strcpy(expect, cwd);
+    strcat(expect, "/tests");
+    mu_assert("realpath nested", realpath("tests/../tests", buf) != NULL);
+    mu_assert("nested eq", strcmp(buf, expect) == 0);
+
+    return 0;
+}
+
 static const char *test_dirent(void)
 {
     DIR *d = opendir("tests");
@@ -1203,6 +1224,7 @@ static const char *all_tests(void)
     mu_run_test(test_mprotect_anon);
     mu_run_test(test_atexit_handler);
     mu_run_test(test_getcwd_chdir);
+    mu_run_test(test_realpath_basic);
     mu_run_test(test_dirent);
     mu_run_test(test_qsort_int);
     mu_run_test(test_qsort_strings);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -29,14 +29,15 @@ This document outlines the architecture, planned modules, and API design for **v
 23. [File Permissions](#file-permissions)
 24. [File Status](#file-status)
 25. [Directory Iteration](#directory-iteration)
-26. [Time Formatting](#time-formatting)
-27. [Locale Support](#locale-support)
-28. [Time Retrieval](#time-retrieval)
-29. [Sleep Functions](#sleep-functions)
-30. [Raw System Calls](#raw-system-calls)
-31. [Non-local Jumps](#non-local-jumps)
-32. [Limitations](#limitations)
-33. [Conclusion](#conclusion)
+26. [Path Canonicalization](#path-canonicalization)
+27. [Time Formatting](#time-formatting)
+28. [Locale Support](#locale-support)
+29. [Time Retrieval](#time-retrieval)
+30. [Sleep Functions](#sleep-functions)
+31. [Raw System Calls](#raw-system-calls)
+32. [Non-local Jumps](#non-local-jumps)
+33. [Limitations](#limitations)
+34. [Conclusion](#conclusion)
 
 ## Overview
 
@@ -611,6 +612,18 @@ if (d) {
     }
     closedir(d);
 }
+```
+
+## Path Canonicalization
+
+`realpath` converts a pathname into an absolute canonical form. It
+resolves `.` and `..` segments without consulting `/proc` so it works on
+any POSIX system. Relative paths are expanded using the current working
+directory.
+
+```c
+char buf[256];
+realpath("tests/../", buf); // buf now holds the absolute path to the repository
 ```
 
 ## Time Formatting


### PR DESCRIPTION
## Summary
- support `realpath` in the headers
- implement portable path canonicalizer
- document canonicalization details
- test relative path resolution

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_68587db5302083248f22be60c5b4c40f