### PR TITLE
Add basic buffering to stdio

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -6,7 +6,19 @@
 
 typedef struct {
     int fd;
+    unsigned char *buf;
+    size_t bufsize;
+    size_t bufpos;
+    size_t buflen;
+    int buf_owned;
 } FILE;
+
+#define _IOFBF 0
+#define _IOLBF 1
+#define _IONBF 2
+#ifndef BUFSIZ
+#define BUFSIZ 1024
+#endif
 
 extern FILE *stdin;
 extern FILE *stdout;
@@ -24,6 +36,8 @@ int fputc(int c, FILE *stream);
 char *fgets(char *s, int size, FILE *stream);
 int fputs(const char *s, FILE *stream);
 int fflush(FILE *stream);
+int setvbuf(FILE *stream, char *buf, int mode, size_t size);
+void setbuf(FILE *stream, char *buf);
 
 int printf(const char *format, ...);
 int fprintf(FILE *stream, const char *format, ...);

--- a/src/init.c
+++ b/src/init.c
@@ -1,18 +1,25 @@
 #include "vlibc.h"
 #include "stdio.h"
 #include "memory.h"
+#include "string.h"
 
 void vlibc_init(void)
 {
     stdin = malloc(sizeof(FILE));
-    if (stdin)
+    if (stdin) {
+        memset(stdin, 0, sizeof(FILE));
         stdin->fd = 0;
+    }
 
     stdout = malloc(sizeof(FILE));
-    if (stdout)
+    if (stdout) {
+        memset(stdout, 0, sizeof(FILE));
         stdout->fd = 1;
+    }
 
     stderr = malloc(sizeof(FILE));
-    if (stderr)
+    if (stderr) {
+        memset(stderr, 0, sizeof(FILE));
         stderr->fd = 2;
+    }
 }

--- a/src/popen.c
+++ b/src/popen.c
@@ -54,6 +54,7 @@ FILE *popen(const char *command, const char *mode)
         close(pipefd[1]);
         return NULL;
     }
+    memset(&pf->file, 0, sizeof(FILE));
     pf->pid = pid;
     if (read_mode) {
         pf->file.fd = pipefd[0];
@@ -71,7 +72,10 @@ int pclose(FILE *stream)
         return -1;
     struct popen_file *pf = (struct popen_file *)stream;
     pid_t pid = pf->pid;
+    fflush(stream);
     close(stream->fd);
+    if (stream->buf && stream->buf_owned)
+        free(stream->buf);
     free(pf);
     int status = 0;
     if (waitpid(pid, &status, 0) < 0)

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -544,6 +544,10 @@ descriptors 0, 1 and 2. They can be used with the provided `fread`,
 `fflush(stream)` succeeds
 and invokes `fsync` on the descriptor when one is present.
 
+Streams may be given a custom buffer with `setvbuf` or the simpler
+`setbuf`. When buffered, I/O operates on that memory until it is filled
+or explicitly flushed.
+
 ```c
 int a;
 unsigned b;
@@ -691,8 +695,8 @@ state.
 
 ## Limitations
 
- - The I/O routines perform no buffering and provide only basic error
-   reporting.
+ - The I/O routines perform simple optional buffering and provide only
+   basic error reporting.
  - Process creation currently relies on Linux-specific syscalls.
  - BSD support is experimental and some subsystems may not compile yet.
  - The `system()` helper spawns `/bin/sh -c` and lacks detailed status


### PR DESCRIPTION
## Summary
- extend `FILE` with buffer data
- implement `setvbuf`/`setbuf` and internal buffering
- hook buffer flushing into stdio helpers
- document buffering in vlibcdoc

## Testing
- `make test` *(fails: `open should fail`)*

------
https://chatgpt.com/codex/tasks/task_e_6858a49533dc83248f82b36dd02a20eb