### PR TITLE
Add missing strto variants

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -18,6 +18,9 @@ int system(const char *command);
 
 /* String conversion */
 long strtol(const char *nptr, char **endptr, int base);
+unsigned long strtoul(const char *nptr, char **endptr, int base);
+long long strtoll(const char *nptr, char **endptr, int base);
+unsigned long long strtoull(const char *nptr, char **endptr, int base);
 int atoi(const char *nptr);
 double strtod(const char *nptr, char **endptr);
 double atof(const char *nptr);

--- a/src/strto.c
+++ b/src/strto.c
@@ -62,6 +62,157 @@ long strtol(const char *nptr, char **endptr, int base)
     return result;
 }
 
+unsigned long strtoul(const char *nptr, char **endptr, int base)
+{
+    const char *s = nptr;
+    while (*s == ' ' || *s == '\t' || *s == '\n' || *s == '\r' || *s == '\f' ||
+           *s == '\v')
+        s++;
+
+    int neg = 0;
+    if (*s == '+' || *s == '-') {
+        if (*s == '-')
+            neg = 1;
+        s++;
+    }
+
+    if (base == 0) {
+        if (*s == '0') {
+            if (s[1] == 'x' || s[1] == 'X') {
+                base = 16;
+                s += 2;
+            } else {
+                base = 8;
+                s += 1;
+            }
+        } else {
+            base = 10;
+        }
+    } else if (base == 16) {
+        if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X'))
+            s += 2;
+    }
+
+    unsigned long val = 0;
+    const char *start = s;
+    int d;
+    while ((d = digit_val(*s)) >= 0 && d < base) {
+        val = val * (unsigned long)base + (unsigned long)d;
+        s++;
+    }
+
+    if (endptr)
+        *endptr = (char *)(s != start ? s : nptr);
+
+    if (s == start)
+        return 0;
+
+    if (neg)
+        return (unsigned long)(-(long)val);
+    return val;
+}
+
+long long strtoll(const char *nptr, char **endptr, int base)
+{
+    const char *s = nptr;
+    while (*s == ' ' || *s == '\t' || *s == '\n' || *s == '\r' || *s == '\f' ||
+           *s == '\v')
+        s++;
+
+    int neg = 0;
+    if (*s == '+' || *s == '-') {
+        if (*s == '-')
+            neg = 1;
+        s++;
+    }
+
+    if (base == 0) {
+        if (*s == '0') {
+            if (s[1] == 'x' || s[1] == 'X') {
+                base = 16;
+                s += 2;
+            } else {
+                base = 8;
+                s += 1;
+            }
+        } else {
+            base = 10;
+        }
+    } else if (base == 16) {
+        if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X'))
+            s += 2;
+    }
+
+    unsigned long long val = 0;
+    const char *start = s;
+    int d;
+    while ((d = digit_val(*s)) >= 0 && d < base) {
+        val = val * (unsigned long long)base + (unsigned long long)d;
+        s++;
+    }
+
+    if (endptr)
+        *endptr = (char *)(s != start ? s : nptr);
+
+    if (s == start)
+        return 0;
+
+    long long result = (long long)val;
+    if (neg)
+        result = -result;
+    return result;
+}
+
+unsigned long long strtoull(const char *nptr, char **endptr, int base)
+{
+    const char *s = nptr;
+    while (*s == ' ' || *s == '\t' || *s == '\n' || *s == '\r' || *s == '\f' ||
+           *s == '\v')
+        s++;
+
+    int neg = 0;
+    if (*s == '+' || *s == '-') {
+        if (*s == '-')
+            neg = 1;
+        s++;
+    }
+
+    if (base == 0) {
+        if (*s == '0') {
+            if (s[1] == 'x' || s[1] == 'X') {
+                base = 16;
+                s += 2;
+            } else {
+                base = 8;
+                s += 1;
+            }
+        } else {
+            base = 10;
+        }
+    } else if (base == 16) {
+        if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X'))
+            s += 2;
+    }
+
+    unsigned long long val = 0;
+    const char *start = s;
+    int d;
+    while ((d = digit_val(*s)) >= 0 && d < base) {
+        val = val * (unsigned long long)base + (unsigned long long)d;
+        s++;
+    }
+
+    if (endptr)
+        *endptr = (char *)(s != start ? s : nptr);
+
+    if (s == start)
+        return 0;
+
+    if (neg)
+        return (unsigned long long)(-(long long)val);
+    return val;
+}
+
 int atoi(const char *nptr)
 {
     return (int)strtol(nptr, NULL, 10);

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -436,6 +436,9 @@ static const char *test_string_helpers(void)
     char *end;
     mu_assert("strtol hex", strtol("ff", &end, 16) == 255 && *end == '\0');
     mu_assert("strtol partial", strtol("12xy", &end, 10) == 12 && strcmp(end, "xy") == 0);
+    mu_assert("strtoul basic", strtoul("123", &end, 10) == 123ul && *end == '\0');
+    mu_assert("strtoll neg", strtoll("-321", &end, 10) == -321ll && *end == '\0');
+    mu_assert("strtoull big", strtoull("1234567890123", &end, 10) == 1234567890123ull && *end == '\0');
     mu_assert("strtod basic", strtod("2.5", &end) == 2.5 && *end == '\0');
     mu_assert("strtod exp", strtod("1e2", &end) == 100.0 && *end == '\0');
     mu_assert("atof", atof("-3.0") == -3.0);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -238,7 +238,8 @@ The **string** module provides fundamental operations needed by most C programs:
   delimiter characters. `strtok` stores its parsing state in static
   memory and is not thread-safe. `strtok_r` lets the caller maintain the
   context and is safe for concurrent use.
-- Simple number conversion helpers `atoi`, `strtol`, `strtod`, and `atof`.
+  - Simple number conversion helpers `atoi`, `strtol`, `strtoul`, `strtoll`,
+    `strtoull`, `strtod`, and `atof`.
 
 Basic time formatting is available via `strftime`. Only a small subset of
  conversions is implemented (`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`) and the


### PR DESCRIPTION
## Summary
- add unsigned and long long conversion prototypes
- implement `strtoul`, `strtoll`, and `strtoull`
- test new conversion routines
- document additional helpers

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858a4a802b48324892dfbcea26f0342