### PR TITLE
Add basic math functions

### DIFF
--- a/include/math.h
+++ b/include/math.h
@@ -6,5 +6,10 @@ double cos(double x);
 double tan(double x);
 double sqrt(double x);
 double pow(double base, double exp);
+double log(double x);
+double exp(double x);
+double floor(double x);
+double ceil(double x);
+double fabs(double x);
 
 #endif /* MATH_H */

--- a/src/math.c
+++ b/src/math.c
@@ -100,3 +100,34 @@ double pow(double base, double exp)
 
     return exp_approx(exp * log_approx(base));
 }
+
+double log(double x)
+{
+    return log_approx(x);
+}
+
+double exp(double x)
+{
+    return exp_approx(x);
+}
+
+double floor(double x)
+{
+    long i = (long)x;
+    if (x < 0.0 && x != (double)i)
+        --i;
+    return (double)i;
+}
+
+double ceil(double x)
+{
+    long i = (long)x;
+    if (x > 0.0 && x != (double)i)
+        ++i;
+    return (double)i;
+}
+
+double fabs(double x)
+{
+    return x < 0.0 ? -x : x;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -24,6 +24,7 @@
 #include "../include/env.h"
 #include "../include/process.h"
 #include "../include/getopt.h"
+#include "../include/math.h"
 #include <unistd.h>
 #include <stdio.h>
 #include <errno.h>
@@ -1125,6 +1126,17 @@ static const char *test_qsort_strings(void)
     return 0;
 }
 
+static const char *test_math_functions(void)
+{
+    mu_assert("fabs", fabs(-3.5) == 3.5);
+    mu_assert("floor", floor(2.7) == 2.0);
+    mu_assert("ceil", ceil(2.3) == 3.0);
+    double l = log(5.0);
+    mu_assert("exp/log", fabs(exp(l) - 5.0) < 1e-6);
+    mu_assert("log/exp", fabs(log(exp(1.0)) - 1.0) < 1e-6);
+    return 0;
+}
+
 static const char *test_getopt_basic(void)
 {
     char *argv[] = {"prog", "-f", "-a", "val", "rest", NULL};
@@ -1277,6 +1289,7 @@ static const char *all_tests(void)
     mu_run_test(test_dirent);
     mu_run_test(test_qsort_int);
     mu_run_test(test_qsort_strings);
+    mu_run_test(test_math_functions);
     mu_run_test(test_getopt_basic);
     mu_run_test(test_getopt_missing);
     mu_run_test(test_dlopen_basic);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -311,7 +311,9 @@ int *found = bsearch(&key, values, 3, sizeof(int), cmp_int);
 
 ## Math Functions
 
-`sin`, `cos`, `tan`, `sqrt`, and `pow` are provided in `math.h`.
+`sin`, `cos`, `tan`, `sqrt`, `pow`, `log`, `exp`, `floor`, `ceil`, and
+`fabs` are provided in `math.h`. These use simple series approximations
+and are suitable for basic calculations but may lack high precision.
 
 ## Process Control
 


### PR DESCRIPTION
## Summary
- expose log, exp, floor, ceil and fabs in `math.h`
- implement new math helpers in `src/math.c`
- test simple behavior of the extra math routines
- document the expanded math API

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858a4d2a61c8324a39f65ac98418a93