### PR TITLE
Add IPv6 networking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ sscanf("42 example", "%d %s", &num, word);
 
 For detailed documentation, see [vlibcdoc.md](vlibcdoc.md).
 
+## IPv6 Support
+
+Networking helpers such as `inet_pton`, `inet_ntop`, `getaddrinfo` and
+`getnameinfo` understand both IPv4 and IPv6 addresses. Use the standard
+`AF_INET6` family to work with IPv6 sockets and address resolution.
+
 ## Platform Support
 
 The library currently targets Linux but aims to run on other POSIX systems as

--- a/include/arpa/inet.h
+++ b/include/arpa/inet.h
@@ -3,6 +3,14 @@
 
 #include <netinet/in.h>
 
+#ifndef INET_ADDRSTRLEN
+#define INET_ADDRSTRLEN 16
+#endif
+
+#ifndef INET6_ADDRSTRLEN
+#define INET6_ADDRSTRLEN 46
+#endif
+
 int inet_pton(int af, const char *src, void *dst);
 const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
 

--- a/include/netdb.h
+++ b/include/netdb.h
@@ -4,6 +4,14 @@
 #include "sys/socket.h"
 #include <stddef.h>
 
+#ifndef NI_MAXHOST
+#define NI_MAXHOST 1025
+#endif
+
+#ifndef NI_MAXSERV
+#define NI_MAXSERV 32
+#endif
+
 struct addrinfo {
     int ai_flags;
     int ai_family;

--- a/src/inet_ntop.c
+++ b/src/inet_ntop.c
@@ -3,26 +3,95 @@
 #include "stdio.h"
 #include <arpa/inet.h>
 
+static char *hex16(char *p, uint16_t val)
+{
+    int started = 0;
+    for (int i = 12; i >= 0; i -= 4) {
+        int d = (val >> i) & 0xF;
+        if (d || started || i == 0) {
+            *p++ = d < 10 ? '0' + d : 'a' + d - 10;
+            started = 1;
+        }
+    }
+    return p;
+}
+
 const char *inet_ntop(int af, const void *src, char *dst, socklen_t size)
 {
-    if (af != AF_INET) {
-        errno = EAFNOSUPPORT;
-        return NULL;
-    }
     if (!src || !dst || size == 0) {
         errno = EINVAL;
         return NULL;
     }
-    if (size < INET_ADDRSTRLEN) {
-        errno = ENOSPC;
+    if (af == AF_INET) {
+        if (size < INET_ADDRSTRLEN) {
+            errno = ENOSPC;
+            return NULL;
+        }
+        const struct in_addr *in = src;
+        uint32_t addr = ntohl(in->s_addr);
+        unsigned char a = (addr >> 24) & 0xFF;
+        unsigned char b = (addr >> 16) & 0xFF;
+        unsigned char c = (addr >> 8) & 0xFF;
+        unsigned char d = addr & 0xFF;
+        snprintf(dst, size, "%u.%u.%u.%u", a, b, c, d);
+        return dst;
+    } else if (af == AF_INET6) {
+        if (size < INET6_ADDRSTRLEN) {
+            errno = ENOSPC;
+            return NULL;
+        }
+        const struct in6_addr *in6 = src;
+        uint16_t words[8];
+        for (int i = 0; i < 8; i++)
+            words[i] = ((uint16_t)in6->s6_addr[i * 2] << 8) |
+                       in6->s6_addr[i * 2 + 1];
+        int best_base = -1, best_len = 0;
+        int cur_base = -1, cur_len = 0;
+        for (int i = 0; i < 8; i++) {
+            if (words[i] == 0) {
+                if (cur_base == -1) {
+                    cur_base = i;
+                    cur_len = 1;
+                } else {
+                    cur_len++;
+                }
+            } else {
+                if (cur_base != -1) {
+                    if (cur_len > best_len) {
+                        best_base = cur_base;
+                        best_len = cur_len;
+                    }
+                    cur_base = -1;
+                    cur_len = 0;
+                }
+            }
+        }
+        if (cur_base != -1 && cur_len > best_len) {
+            best_base = cur_base;
+            best_len = cur_len;
+        }
+        if (best_len < 2)
+            best_base = -1;
+
+        char buf[INET6_ADDRSTRLEN];
+        char *p = buf;
+        for (int i = 0; i < 8; i++) {
+            if (best_base == i) {
+                *p++ = ':'; *p++ = ':';
+                i += best_len - 1;
+                continue;
+            }
+            if (i > 0 && p[-1] != ':')
+                *p++ = ':';
+            p = hex16(p, words[i]);
+        }
+        if (best_base != -1 && best_base + best_len == 8)
+            *p++ = ':';
+        *p = '\0';
+        snprintf(dst, size, "%s", buf);
+        return dst;
+    } else {
+        errno = EAFNOSUPPORT;
         return NULL;
     }
-    const struct in_addr *in = src;
-    uint32_t addr = ntohl(in->s_addr);
-    unsigned char a = (addr >> 24) & 0xFF;
-    unsigned char b = (addr >> 16) & 0xFF;
-    unsigned char c = (addr >> 8) & 0xFF;
-    unsigned char d = addr & 0xFF;
-    snprintf(dst, size, "%u.%u.%u.%u", a, b, c, d);
-    return dst;
 }

--- a/src/inet_pton.c
+++ b/src/inet_pton.c
@@ -2,6 +2,7 @@
 #include "errno.h"
 #include "stdlib.h"
 #include <stdint.h>
+#include <string.h>
 #include <arpa/inet.h>
 
 static int parse_ipv4(const char *s, uint32_t *out)
@@ -27,20 +28,90 @@ static int parse_ipv4(const char *s, uint32_t *out)
     return 0;
 }
 
+static int parse_ipv6(const char *s, unsigned char *out)
+{
+    uint16_t words[8] = {0};
+    int cur = 0;
+    int zpos = -1;
+    if (*s == ':') {
+        if (s[1] != ':')
+            return -1;
+        zpos = cur;
+        s += 2;
+    }
+    while (*s && cur < 8) {
+        if (*s == ':') {
+            if (zpos != -1)
+                return -1;
+            zpos = cur;
+            s++;
+            if (*s == ':')
+                return -1;
+            continue;
+        }
+        char *end;
+        long val = strtol(s, &end, 16);
+        if (val < 0 || val > 0xffff)
+            return -1;
+        words[cur++] = (uint16_t)val;
+        s = end;
+        if (*s == '.') {
+            if (cur > 6)
+                return -1;
+            uint32_t ipv4;
+            if (parse_ipv4(s, &ipv4) != 0)
+                return -1;
+            words[cur++] = (uint16_t)((ipv4 >> 16) & 0xffff);
+            words[cur++] = (uint16_t)(ipv4 & 0xffff);
+            s += strlen(s);
+            break;
+        }
+        if (*s == ':')
+            s++;
+        else if (*s)
+            return -1;
+    }
+    if (*s)
+        return -1;
+    int fill = 8 - cur;
+    if (zpos == -1 && cur != 8)
+        return -1;
+    if (zpos != -1) {
+        for (int i = cur - 1; i >= zpos; i--)
+            words[i + fill] = words[i];
+        for (int i = zpos; i < zpos + fill; i++)
+            words[i] = 0;
+    }
+    for (int i = 0; i < 8; i++) {
+        out[i * 2] = words[i] >> 8;
+        out[i * 2 + 1] = words[i] & 0xff;
+    }
+    return 0;
+}
+
 int inet_pton(int af, const char *src, void *dst)
 {
-    if (af != AF_INET) {
-        errno = EAFNOSUPPORT;
-        return -1;
-    }
     if (!src || !dst) {
         errno = EINVAL;
         return -1;
     }
-    uint32_t ip;
-    if (parse_ipv4(src, &ip) != 0)
-        return 0;
-    struct in_addr *in = dst;
-    in->s_addr = htonl(ip);
-    return 1;
+    if (af == AF_INET) {
+        uint32_t ip;
+        if (parse_ipv4(src, &ip) != 0)
+            return 0;
+        struct in_addr *in = dst;
+        in->s_addr = htonl(ip);
+        return 1;
+    } else if (af == AF_INET6) {
+        unsigned char buf[16];
+        if (parse_ipv6(src, buf) != 0)
+            return 0;
+        struct in6_addr *in6 = dst;
+        for (int i = 0; i < 16; i++)
+            in6->s6_addr[i] = buf[i];
+        return 1;
+    } else {
+        errno = EAFNOSUPPORT;
+        return -1;
+    }
 }

--- a/src/netdb.c
+++ b/src/netdb.c
@@ -5,6 +5,7 @@
 #include "errno.h"
 #include "stdlib.h"
 #include "stdio.h"
+#include "arpa/inet.h"
 #include <stdint.h>
 #include <netinet/in.h>
 
@@ -31,6 +32,67 @@ static int parse_ipv4(const char *s, uint32_t *out)
     if (d < 0 || d > 255 || (*end && *end != ' ' && *end != '\t'))
         return -1;
     *out = (uint32_t)((a << 24) | (b << 16) | (c << 8) | d);
+    return 0;
+}
+
+static int parse_ipv6(const char *s, unsigned char *out)
+{
+    uint16_t words[8] = {0};
+    int cur = 0;
+    int zpos = -1;
+    if (*s == ':') {
+        if (s[1] != ':')
+            return -1;
+        zpos = cur;
+        s += 2;
+    }
+    while (*s && cur < 8) {
+        if (*s == ':') {
+            if (zpos != -1)
+                return -1;
+            zpos = cur;
+            s++;
+            if (*s == ':')
+                return -1;
+            continue;
+        }
+        char *end;
+        long val = strtol(s, &end, 16);
+        if (val < 0 || val > 0xffff)
+            return -1;
+        words[cur++] = (uint16_t)val;
+        s = end;
+        if (*s == '.') {
+            if (cur > 6)
+                return -1;
+            uint32_t ipv4;
+            if (parse_ipv4(s, &ipv4) != 0)
+                return -1;
+            words[cur++] = (uint16_t)((ipv4 >> 16) & 0xffff);
+            words[cur++] = (uint16_t)(ipv4 & 0xffff);
+            s += strlen(s);
+            break;
+        }
+        if (*s == ':')
+            s++;
+        else if (*s)
+            return -1;
+    }
+    if (*s)
+        return -1;
+    int fill = 8 - cur;
+    if (zpos == -1 && cur != 8)
+        return -1;
+    if (zpos != -1) {
+        for (int i = cur - 1; i >= zpos; i--)
+            words[i + fill] = words[i];
+        for (int i = zpos; i < zpos + fill; i++)
+            words[i] = 0;
+    }
+    for (int i = 0; i < 8; i++) {
+        out[i * 2] = words[i] >> 8;
+        out[i * 2 + 1] = words[i] & 0xff;
+    }
     return 0;
 }
 
@@ -87,41 +149,65 @@ int getaddrinfo(const char *node, const char *service,
     if (!node && !service)
         return -1;
 
-    uint32_t ip = 0;
+    uint32_t ip4 = 0;
+    unsigned char ip6[16];
+    int family = AF_UNSPEC;
     if (node) {
-        if (parse_ipv4(node, &ip) != 0) {
-            if (hosts_lookup(node, &ip) != 0) {
+        if (parse_ipv6(node, ip6) == 0) {
+            family = AF_INET6;
+        } else if (parse_ipv4(node, &ip4) == 0) {
+            family = AF_INET;
+        } else {
+            if (hosts_lookup(node, &ip4) != 0) {
                 errno = ENOENT;
                 return -1;
             }
+            family = AF_INET;
         }
+    } else {
+        family = AF_INET;
     }
 
     uint16_t port = 0;
     if (service)
         port = (uint16_t)atoi(service);
 
-    struct sockaddr_in *sa = malloc(sizeof(struct sockaddr_in));
-    if (!sa)
-        return -1;
-    sa->sin_family = AF_INET;
-    sa->sin_port = htons16(port);
-    sa->sin_addr.s_addr = ip;
-    memset(sa->sin_zero, 0, sizeof(sa->sin_zero));
-
     struct addrinfo *ai = malloc(sizeof(struct addrinfo));
-    if (!ai) {
-        free(sa);
+    if (!ai)
         return -1;
-    }
     ai->ai_flags = 0;
-    ai->ai_family = AF_INET;
+    ai->ai_family = family;
     ai->ai_socktype = 0;
     ai->ai_protocol = 0;
-    ai->ai_addrlen = sizeof(struct sockaddr_in);
-    ai->ai_addr = (struct sockaddr *)sa;
-    ai->ai_canonname = NULL;
     ai->ai_next = NULL;
+
+    if (family == AF_INET6) {
+        struct sockaddr_in6 *sa6 = malloc(sizeof(struct sockaddr_in6));
+        if (!sa6) {
+            free(ai);
+            return -1;
+        }
+        sa6->sin6_family = AF_INET6;
+        sa6->sin6_port = htons16(port);
+        memcpy(&sa6->sin6_addr, ip6, 16);
+        sa6->sin6_flowinfo = 0;
+        sa6->sin6_scope_id = 0;
+        ai->ai_addrlen = sizeof(struct sockaddr_in6);
+        ai->ai_addr = (struct sockaddr *)sa6;
+    } else {
+        struct sockaddr_in *sa = malloc(sizeof(struct sockaddr_in));
+        if (!sa) {
+            free(ai);
+            return -1;
+        }
+        sa->sin_family = AF_INET;
+        sa->sin_port = htons16(port);
+        sa->sin_addr.s_addr = ip4;
+        memset(sa->sin_zero, 0, sizeof(sa->sin_zero));
+        ai->ai_addrlen = sizeof(struct sockaddr_in);
+        ai->ai_addr = (struct sockaddr *)sa;
+    }
+    ai->ai_canonname = NULL;
 
     *res = ai;
     return 0;
@@ -145,19 +231,26 @@ int getnameinfo(const struct sockaddr *sa, socklen_t salen,
                 char *serv, socklen_t servlen, int flags)
 {
     (void)flags;
-    if (!sa || salen < (socklen_t)sizeof(struct sockaddr_in))
+    if (!sa)
         return -1;
-    const struct sockaddr_in *sin = (const struct sockaddr_in *)sa;
-    if (host && hostlen > 0) {
-        unsigned char b[4];
-        uint32_t addr = sin->sin_addr.s_addr;
-        b[0] = (addr >> 24) & 0xFF;
-        b[1] = (addr >> 16) & 0xFF;
-        b[2] = (addr >> 8) & 0xFF;
-        b[3] = addr & 0xFF;
-        snprintf(host, hostlen, "%u.%u.%u.%u", b[0], b[1], b[2], b[3]);
+    if (sa->sa_family == AF_INET) {
+        if (salen < (socklen_t)sizeof(struct sockaddr_in))
+            return -1;
+        const struct sockaddr_in *sin = (const struct sockaddr_in *)sa;
+        if (host && hostlen > 0)
+            inet_ntop(AF_INET, &sin->sin_addr, host, hostlen);
+        if (serv && servlen > 0)
+            snprintf(serv, servlen, "%u", ntohs16(sin->sin_port));
+        return 0;
+    } else if (sa->sa_family == AF_INET6) {
+        if (salen < (socklen_t)sizeof(struct sockaddr_in6))
+            return -1;
+        const struct sockaddr_in6 *sin6 = (const struct sockaddr_in6 *)sa;
+        if (host && hostlen > 0)
+            inet_ntop(AF_INET6, &sin6->sin6_addr, host, hostlen);
+        if (serv && servlen > 0)
+            snprintf(serv, servlen, "%u", ntohs16(sin6->sin6_port));
+        return 0;
     }
-    if (serv && servlen > 0)
-        snprintf(serv, servlen, "%u", ntohs16(sin->sin_port));
-    return 0;
+    return -1;
 }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -299,6 +299,16 @@ static const char *test_inet_pton_ntop(void)
     struct in_addr back;
     r = inet_pton(AF_INET, buf, &back);
     mu_assert("inet_pton round", r == 1 && back.s_addr == addr.s_addr);
+
+    struct in6_addr addr6;
+    r = inet_pton(AF_INET6, "2001:db8::1", &addr6);
+    mu_assert("inet_pton6", r == 1);
+    char buf6[INET6_ADDRSTRLEN];
+    p = inet_ntop(AF_INET6, &addr6, buf6, sizeof(buf6));
+    mu_assert("inet_ntop6", p && strcmp(buf6, "2001:db8::1") == 0);
+    struct in6_addr back6;
+    r = inet_pton(AF_INET6, buf6, &back6);
+    mu_assert("inet_pton6 round", r == 1 && memcmp(&back6, &addr6, sizeof(addr6)) == 0);
     return 0;
 }
 

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -150,7 +150,7 @@ locale.h     - locale helpers
 math.h       - basic math routines
 memory.h     - heap allocation
 netdb.h      - address resolution helpers
-arpa/inet.h  - IPv4 presentation conversion helpers
+arpa/inet.h  - IPv4/IPv6 presentation conversion helpers
 poll.h       - I/O multiplexing helpers
 process.h    - process creation and control
 pthread.h    - minimal threading support
@@ -576,8 +576,8 @@ syscalls including `socket`, `bind`, `listen`, `accept`, `connect`,
 `send`, `recv`, `sendto`, and `recvfrom`. Address resolution is handled
 via `getaddrinfo`, `freeaddrinfo`, and `getnameinfo`.
 
-Utilities `inet_pton` and `inet_ntop` convert between dotted IPv4 strings
-and binary network format.
+Utilities `inet_pton` and `inet_ntop` convert between IPv4 or IPv6
+presentation strings and binary network format.
 
 ```c
 struct addrinfo *ai;


### PR DESCRIPTION
## Summary
- support IPv6 addresses for inet_pton/inet_ntop
- handle IPv6 in getaddrinfo/getnameinfo
- define presentation length constants in headers
- document IPv6 usage
- extend tests for IPv6 round‑trip

## Testing
- `make test` *(fails: `open should fail`)*

------
https://chatgpt.com/codex/tasks/task_e_6858ba3a56b883249da6a66ce4a013f7