### PR TITLE
Add clock_gettime support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ SRC := \
     src/mmap.c \
     src/env.c \
     src/sleep.c \
+    src/clock_gettime.c \
     src/time.c \
     src/time_conv.c \
     src/strftime.c \

--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ sscanf("42 example", "%d %s", &num, word);
 
 For detailed documentation, see [vlibcdoc.md](vlibcdoc.md).
 
+## Time Retrieval
+
+Use `clock_gettime` for precise timestamps.
+
+```c
+struct timespec ts;
+clock_gettime(CLOCK_MONOTONIC, &ts);
+```
+
+`CLOCK_REALTIME` returns the wall-clock time.
+
 ## IPv6 Support
 
 Networking helpers such as `inet_pton`, `inet_ntop`, `getaddrinfo` and

--- a/include/time.h
+++ b/include/time.h
@@ -36,6 +36,15 @@ struct tm {
     int tm_isdst; /* daylight savings time flag */
 };
 
+#ifndef CLOCK_REALTIME
+#define CLOCK_REALTIME 0
+#endif
+#ifndef CLOCK_MONOTONIC
+#define CLOCK_MONOTONIC 1
+#endif
+
+int clock_gettime(int clk_id, struct timespec *ts);
+
 time_t time(time_t *t);
 int gettimeofday(struct timeval *tv, void *tz);
 

--- a/src/clock_gettime.c
+++ b/src/clock_gettime.c
@@ -1,0 +1,26 @@
+#include "time.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int clock_gettime(int clk_id, struct timespec *ts)
+{
+#ifdef SYS_clock_gettime
+    long ret = vlibc_syscall(SYS_clock_gettime, clk_id, (long)ts, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#else
+    struct timeval tv;
+    if (gettimeofday(&tv, NULL) < 0)
+        return -1;
+    if (ts) {
+        ts->tv_sec = tv.tv_sec;
+        ts->tv_nsec = tv.tv_usec * 1000;
+    }
+    return 0;
+#endif
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -679,12 +679,12 @@ convert between `time_t` and `struct tm` or human readable strings.
 
 ## Time Retrieval
 
-Use `time` or `gettimeofday` to obtain the current time of day.
+Use `time`, `gettimeofday`, or `clock_gettime` to obtain the current time of day.
 
 ```c
 time_t now = time(NULL);
-struct timeval tv;
-gettimeofday(&tv, NULL);
+struct timespec ts;
+clock_gettime(CLOCK_REALTIME, &ts);
 ```
 
 ## Sleep Functions


### PR DESCRIPTION
## Summary
- expose `CLOCK_REALTIME`/`CLOCK_MONOTONIC` and `clock_gettime()` in `time.h`
- implement `clock_gettime` with fallback to `gettimeofday`
- document time retrieval APIs

## Testing
- `make clean >/dev/null && make test >/tmp/make_test.log` *(fails: open should fail)*


------
https://chatgpt.com/codex/tasks/task_e_6858c2aa01288324bd0afd186a3f4136