### PR TITLE
Add strlcpy/strlcat support

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -19,6 +19,8 @@ char *strdup(const char *s);
 char *strncpy(char *dest, const char *src, size_t n);
 char *strcat(char *dest, const char *src);
 char *strncat(char *dest, const char *src, size_t n);
+size_t strlcpy(char *dst, const char *src, size_t size);
+size_t strlcat(char *dst, const char *src, size_t size);
 void *vmemcpy(void *dest, const void *src, size_t n);
 void *vmemmove(void *dest, const void *src, size_t n);
 void *vmemset(void *s, int c, size_t n);

--- a/src/string_extra.c
+++ b/src/string_extra.c
@@ -58,3 +58,28 @@ int strcasecmp(const char *s1, const char *s2)
 {
     return strncasecmp(s1, s2, (size_t)-1);
 }
+
+size_t strlcpy(char *dst, const char *src, size_t size)
+{
+    size_t len = vstrlen(src);
+    if (size) {
+        size_t copy = len >= size ? size - 1 : len;
+        vmemcpy(dst, src, copy);
+        dst[copy] = '\0';
+    }
+    return len;
+}
+
+size_t strlcat(char *dst, const char *src, size_t size)
+{
+    size_t dlen = vstrlen(dst);
+    size_t slen = vstrlen(src);
+
+    if (dlen < size) {
+        size_t copy = slen >= size - dlen ? size - dlen - 1 : slen;
+        vmemcpy(dst + dlen, src, copy);
+        dst[dlen + copy] = '\0';
+    }
+
+    return dlen + slen;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -482,6 +482,31 @@ static const char *test_string_casecmp(void)
     return 0;
 }
 
+static const char *test_strlcpy_cat(void)
+{
+    char buf[16];
+    size_t r = strlcpy(buf, "abc", sizeof(buf));
+    mu_assert("strlcpy ret", r == 3);
+    mu_assert("strlcpy copy", strcmp(buf, "abc") == 0);
+
+    char t[4];
+    r = strlcpy(t, "abcdef", sizeof(t));
+    mu_assert("strlcpy trunc ret", r == 6);
+    mu_assert("strlcpy trunc", strcmp(t, "abc") == 0);
+
+    char cbuf[10] = "foo";
+    r = strlcat(cbuf, "bar", sizeof(cbuf));
+    mu_assert("strlcat ret", r == 6);
+    mu_assert("strlcat copy", strcmp(cbuf, "foobar") == 0);
+
+    char c2[7] = "hello";
+    r = strlcat(c2, "world", sizeof(c2));
+    mu_assert("strlcat trunc ret", r == 10);
+    mu_assert("strlcat trunc", strcmp(c2, "hellow") == 0);
+
+    return 0;
+}
+
 static const char *test_widechar_basic(void)
 {
     wchar_t wc = 0;
@@ -1369,6 +1394,7 @@ static const char *all_tests(void)
     mu_run_test(test_link_readlink);
     mu_run_test(test_string_helpers);
     mu_run_test(test_string_casecmp);
+    mu_run_test(test_strlcpy_cat);
     mu_run_test(test_widechar_basic);
     mu_run_test(test_strtok_basic);
     mu_run_test(test_strtok_r_basic);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -226,7 +226,7 @@ their access protections.
 
 The **string** module provides fundamental operations needed by most C programs:
 
-- `vstrlen`, `vstrcpy`, `vstrncmp`, `strnlen`, `strcat` and `strncat` equivalents.
+- `vstrlen`, `vstrcpy`, `vstrncmp`, `strnlen`, `strcat`, `strncat`, `strlcpy` and `strlcat` equivalents.
 - Search helpers `strstr`, `strrchr`, and `memchr` for locating substrings or bytes.
 - Case-insensitive comparisons `strcasecmp` and `strncasecmp`.
 - Conventional memory routines (`memcpy`, `memmove`, `memset`, `memcmp`) map to


### PR DESCRIPTION
## Summary
- expose `strlcpy`/`strlcat` in headers
- implement the new helpers
- cover them with new unit tests
- document the helpers under **String Handling**

## Testing
- `make test` *(fails: "open should fail")*

------
https://chatgpt.com/codex/tasks/task_e_6858c2f5023c83248de07bc3557d65d1