### PR TITLE
Add simple regex engine and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,8 @@ SRC := \
     src/locale.c \
     src/wchar.c \
     src/tempfile.c \
-    src/math.c
+    src/math.c \
+    src/regex.c
 
 ARCH_SRC := $(wildcard src/arch/$(ARCH)/*.c)
 SRC += $(if $(ARCH_SRC),$(ARCH_SRC),src/setjmp.c)

--- a/include/regex.h
+++ b/include/regex.h
@@ -1,0 +1,31 @@
+#ifndef REGEX_H
+#define REGEX_H
+
+#include <stddef.h>
+
+/* simple regular expression interface */
+
+typedef struct {
+    void *impl;        /* internal compiled form */
+    size_t re_nsub;    /* number of capture groups (unused) */
+} regex_t;
+
+typedef struct {
+    int rm_so; /* start offset */
+    int rm_eo; /* end offset */
+} regmatch_t;
+
+/* compile pattern into preg */
+int regcomp(regex_t *preg, const char *pattern, int cflags);
+
+/* execute regex on string */
+int regexec(const regex_t *preg, const char *string,
+            size_t nmatch, regmatch_t pmatch[], int eflags);
+
+/* free compiled pattern */
+void regfree(regex_t *preg);
+
+/* error code when no match was found */
+#define REG_NOMATCH 1
+
+#endif /* REGEX_H */

--- a/src/regex.c
+++ b/src/regex.c
@@ -1,0 +1,265 @@
+#include "regex.h"
+#include "memory.h"
+#include <string.h>
+#include <ctype.h>
+
+/*
+ * This implementation is adapted from the public domain tiny-regex-c
+ * project. It builds a very small NFA for the pattern and performs a
+ * backtracking search. Only a subset of BRE/ERE syntax is supported:
+ * '.', '*', '+', '?', '^', '$' and basic character classes.
+ */
+
+struct token {
+    unsigned char type;
+    union {
+        unsigned char ch;
+        unsigned char *ccl;
+    } u;
+};
+
+/* token types */
+enum {
+    UNUSED, DOT, BEGIN, END, QUESTION, STAR, PLUS, CHAR, CHAR_CLASS, INV_CHAR_CLASS,
+    DIGIT, NOT_DIGIT, ALPHA, NOT_ALPHA, SPACE, NOT_SPACE
+};
+
+struct regex_impl {
+    struct token *pat;
+    unsigned char *ccl;
+};
+
+/* helper prototypes */
+static int matchpattern(struct token *pat, const char *text, int *matchlen);
+
+static int matchdigit(char c) { return isdigit((unsigned char)c); }
+static int matchalpha(char c) { return isalnum((unsigned char)c) || c == '_'; }
+static int matchspace(char c) { return isspace((unsigned char)c); }
+
+static int matchrange(char c, const char *str)
+{
+    return (c != '-') && str[0] && str[1] == '-' && str[2] &&
+           c >= str[0] && c <= str[2];
+}
+
+static int matchdot(char c)
+{
+#ifdef RE_DOT_MATCHES_NEWLINE
+    (void)c; return 1;
+#else
+    return c != '\n' && c != '\r';
+#endif
+}
+
+static int ismeta(char c)
+{
+    return c=='s' || c=='S' || c=='w' || c=='W' || c=='d' || c=='D';
+}
+
+static int matchmeta(char c, const char *str)
+{
+    switch (str[0]) {
+    case 'd': return  matchdigit(c);
+    case 'D': return !matchdigit(c);
+    case 'w': return  matchalpha(c);
+    case 'W': return !matchalpha(c);
+    case 's': return  matchspace(c);
+    case 'S': return !matchspace(c);
+    default:  return c == str[0];
+    }
+}
+
+static int matchclass(char c, const char *str)
+{
+    do {
+        if (matchrange(c, str))
+            return 1;
+        else if (str[0] == '\\') {
+            str++;
+            if (matchmeta(c, str))
+                return 1;
+            else if (c == str[0] && !ismeta(c))
+                return 1;
+        } else if (c == str[0]) {
+            if (c == '-')
+                return (str[-1] == '\0' || str[1] == '\0');
+            return 1;
+        }
+    } while (*str++);
+    return 0;
+}
+
+static int matchone(struct token t, char c)
+{
+    switch (t.type) {
+    case DOT:            return matchdot(c);
+    case CHAR_CLASS:     return  matchclass(c, (const char*)t.u.ccl);
+    case INV_CHAR_CLASS: return !matchclass(c, (const char*)t.u.ccl);
+    case DIGIT:          return  matchdigit(c);
+    case NOT_DIGIT:      return !matchdigit(c);
+    case ALPHA:          return  matchalpha(c);
+    case NOT_ALPHA:      return !matchalpha(c);
+    case SPACE:          return  matchspace(c);
+    case NOT_SPACE:      return !matchspace(c);
+    default:             return t.u.ch == (unsigned char)c;
+    }
+}
+
+static int matchstar(struct token p, struct token *pat, const char *text, int *ml)
+{
+    int pre = *ml;
+    const char *save = text;
+    while (*text && matchone(p, *text)) {
+        text++; (*ml)++; }
+    while (text >= save) {
+        if (matchpattern(pat, text, ml))
+            return 1;
+        text--; (*ml)--;
+    }
+    *ml = pre;
+    return 0;
+}
+
+static int matchplus(struct token p, struct token *pat, const char *text, int *ml)
+{
+    const char *save = text;
+    while (*text && matchone(p, *text)) { text++; (*ml)++; }
+    while (text > save) {
+        if (matchpattern(pat, text, ml))
+            return 1;
+        text--; (*ml)--;
+    }
+    return 0;
+}
+
+static int matchquestion(struct token p, struct token *pat, const char *text, int *ml)
+{
+    if (p.type == UNUSED)
+        return 1;
+    if (matchpattern(pat, text, ml))
+        return 1;
+    if (*text && matchone(p, *text++)) {
+        if (matchpattern(pat, text, ml)) {
+            (*ml)++; return 1; }
+    }
+    return 0;
+}
+
+/* iterative matcher */
+static int matchpattern(struct token *pat, const char *text, int *matchlen)
+{
+    int pre = *matchlen;
+    do {
+        if (pat[0].type == UNUSED || pat[1].type == QUESTION)
+            return matchquestion(pat[0], &pat[2], text, matchlen);
+        else if (pat[1].type == STAR)
+            return matchstar(pat[0], &pat[2], text, matchlen);
+        else if (pat[1].type == PLUS)
+            return matchplus(pat[0], &pat[2], text, matchlen);
+        else if (pat[0].type == END && pat[1].type == UNUSED)
+            return *text == '\0';
+        *matchlen += 1;
+    } while (*text && matchone(*pat++, *text++));
+    *matchlen = pre;
+    return 0;
+}
+
+int regcomp(regex_t *preg, const char *pattern, int cflags)
+{
+    (void)cflags;
+    size_t len = strlen(pattern);
+    struct regex_impl *ri = calloc(1, sizeof(*ri));
+    if (!ri)
+        return -1;
+    ri->pat = malloc((len + 1) * sizeof(struct token));
+    ri->ccl = malloc(len * 2 + 1);
+    if (!ri->pat || !ri->ccl) {
+        free(ri->pat); free(ri->ccl); free(ri); return -1; }
+    size_t ccl_idx = 1; /* first byte reserved */
+    size_t i = 0, j = 0;
+    while (pattern[i] && j + 1 < len) {
+        char c = pattern[i];
+        switch (c) {
+        case '^': ri->pat[j].type = BEGIN; break;
+        case '$': ri->pat[j].type = END;   break;
+        case '.': ri->pat[j].type = DOT;   break;
+        case '*': ri->pat[j].type = STAR;  break;
+        case '+': ri->pat[j].type = PLUS;  break;
+        case '?': ri->pat[j].type = QUESTION; break;
+        case '\\':
+            if (pattern[i+1]) {
+                i++;
+                switch (pattern[i]) {
+                case 'd': ri->pat[j].type = DIGIT; break;
+                case 'D': ri->pat[j].type = NOT_DIGIT; break;
+                case 'w': ri->pat[j].type = ALPHA; break;
+                case 'W': ri->pat[j].type = NOT_ALPHA; break;
+                case 's': ri->pat[j].type = SPACE; break;
+                case 'S': ri->pat[j].type = NOT_SPACE; break;
+                default:  ri->pat[j].type = CHAR; ri->pat[j].u.ch = pattern[i]; break;
+                }
+            }
+            break;
+        case '[': {
+            size_t start = ccl_idx;
+            if (pattern[i+1] == '^') { ri->pat[j].type = INV_CHAR_CLASS; i++; }
+            else ri->pat[j].type = CHAR_CLASS;
+            while (pattern[++i] && pattern[i] != ']') {
+                if (pattern[i] == '\\' && pattern[i+1]) {
+                    ri->ccl[ccl_idx++] = pattern[i++];
+                }
+                ri->ccl[ccl_idx++] = pattern[i];
+            }
+            ri->ccl[ccl_idx++] = 0;
+            ri->pat[j].u.ccl = &ri->ccl[start];
+            break; }
+        default:
+            ri->pat[j].type = CHAR; ri->pat[j].u.ch = c; break;
+        }
+        i++; j++; if (ccl_idx + 1 >= len*2) break;
+    }
+    ri->pat[j].type = UNUSED;
+    preg->impl = ri;
+    preg->re_nsub = 0;
+    return 0;
+}
+
+int regexec(const regex_t *preg, const char *string,
+            size_t nmatch, regmatch_t pmatch[], int eflags)
+{
+    (void)eflags;
+    if (!preg || !preg->impl)
+        return REG_NOMATCH;
+    struct regex_impl *ri = (struct regex_impl *)preg->impl;
+    int len = 0;
+    int pos = -1;
+    if (ri->pat[0].type == BEGIN) {
+        if (matchpattern(&ri->pat[1], string, &len))
+            pos = 0;
+    } else {
+        const char *t = string; int idx = -1;
+        do {
+            idx++; len = 0;
+            if (matchpattern(ri->pat, t, &len)) { pos = idx; break; }
+        } while (*t++);
+    }
+    if (pos < 0)
+        return REG_NOMATCH;
+    if (nmatch > 0) {
+        pmatch[0].rm_so = pos;
+        pmatch[0].rm_eo = pos + len;
+    }
+    return 0;
+}
+
+void regfree(regex_t *preg)
+{
+    if (!preg || !preg->impl)
+        return;
+    struct regex_impl *ri = (struct regex_impl *)preg->impl;
+    free(ri->pat);
+    free(ri->ccl);
+    free(ri);
+    preg->impl = NULL;
+}
+

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -14,31 +14,32 @@ This document outlines the architecture, planned modules, and API design for **v
 8. [Option Parsing](#option-parsing)
 9. [Random Numbers](#random-numbers)
 10. [Sorting Helpers](#sorting-helpers)
-11. [Math Functions](#math-functions)
-12. [Process Control](#process-control)
-13. [Error Reporting](#error-reporting)
-14. [Errno Access](#errno-access)
-15. [Threading](#threading)
-16. [Dynamic Loading](#dynamic-loading)
-17. [Environment Variables](#environment-variables)
-18. [Basic File I/O](#basic-file-io)
-19. [File Descriptor Helpers](#file-descriptor-helpers)
-20. [Standard Streams](#standard-streams)
-21. [Temporary Files](#temporary-files)
-22. [Networking](#networking)
-23. [I/O Multiplexing](#io-multiplexing)
-24. [File Permissions](#file-permissions)
-25. [File Status](#file-status)
-26. [Directory Iteration](#directory-iteration)
-27. [Path Canonicalization](#path-canonicalization)
-28. [Time Formatting](#time-formatting)
-29. [Locale Support](#locale-support)
-30. [Time Retrieval](#time-retrieval)
-31. [Sleep Functions](#sleep-functions)
-32. [Raw System Calls](#raw-system-calls)
-33. [Non-local Jumps](#non-local-jumps)
-34. [Limitations](#limitations)
-35. [Conclusion](#conclusion)
+11. [Regular Expressions](#regular-expressions)
+12. [Math Functions](#math-functions)
+13. [Process Control](#process-control)
+14. [Error Reporting](#error-reporting)
+15. [Errno Access](#errno-access)
+16. [Threading](#threading)
+17. [Dynamic Loading](#dynamic-loading)
+18. [Environment Variables](#environment-variables)
+19. [Basic File I/O](#basic-file-io)
+20. [File Descriptor Helpers](#file-descriptor-helpers)
+21. [Standard Streams](#standard-streams)
+22. [Temporary Files](#temporary-files)
+23. [Networking](#networking)
+24. [I/O Multiplexing](#io-multiplexing)
+25. [File Permissions](#file-permissions)
+26. [File Status](#file-status)
+27. [Directory Iteration](#directory-iteration)
+28. [Path Canonicalization](#path-canonicalization)
+29. [Time Formatting](#time-formatting)
+30. [Locale Support](#locale-support)
+31. [Time Retrieval](#time-retrieval)
+32. [Sleep Functions](#sleep-functions)
+33. [Raw System Calls](#raw-system-calls)
+34. [Non-local Jumps](#non-local-jumps)
+35. [Limitations](#limitations)
+36. [Conclusion](#conclusion)
 
 ## Overview
 
@@ -160,6 +161,7 @@ setjmp.h     - non-local jump helpers
 stdio.h      - simple stream I/O
 stdlib.h     - basic utilities
 string.h     - string manipulation
+regex.h     - simple regular expression matching
 sys/file.h   - file permission helpers
 sys/mman.h   - memory mapping helpers
 sys/select.h - fd_set macros and select wrapper
@@ -314,6 +316,25 @@ qsort(values, 3, sizeof(int), cmp_int);
 int key = 7;
 int *found = bsearch(&key, values, 3, sizeof(int), cmp_int);
 ```
+
+## Regular Expressions
+
+The `regex` module offers a lightweight matcher covering a small
+subset of POSIX expressions.  Patterns are compiled with `regcomp`
+and executed using `regexec`.
+
+```c
+regex_t re;
+regcomp(&re, "h.*o", 0);
+if (regexec(&re, "hello", 0, NULL, 0) == 0) {
+    /* matched */
+}
+regfree(&re);
+```
+
+Only simple features are implemented: `.` matches any character,
+`*`, `+` and `?` provide repetition, `[]` defines character classes
+and `^`/`$` anchor to the start or end of the string.
 
 ## Math Functions
 
@@ -731,6 +752,8 @@ state.
    than `"C"` or `"POSIX"`.
  - `setjmp`/`longjmp` rely on the host C library when available.
    Only an x86_64 fallback implementation is provided.
+ - Regular expressions cover only a subset of POSIX syntax and do not
+   implement advanced constructs like backreferences.
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary
- add regex.h API
- implement basic NFA regex engine
- compile new regex.c
- document regex usage and limitations

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858c2c03f80832493236264c93214e0