### PR TITLE
Add getline/getdelim support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ SRC := \
     src/locale.c \
     src/wchar.c \
     src/tempfile.c \
+    src/getline.c \
     src/math.c
 
 ARCH_SRC := $(wildcard src/arch/$(ARCH)/*.c)

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdarg.h>
+#include <sys/types.h>
 
 typedef struct {
     int fd;
@@ -66,5 +67,8 @@ int mkstemp(char *template);
 FILE *tmpfile(void);
 char *tmpnam(char *s);
 char *tempnam(const char *dir, const char *pfx);
+
+ssize_t getdelim(char **lineptr, size_t *n, int delim, FILE *stream);
+ssize_t getline(char **lineptr, size_t *n, FILE *stream);
 
 #endif /* STDIO_H */

--- a/src/getline.c
+++ b/src/getline.c
@@ -1,0 +1,45 @@
+#include "stdio.h"
+#include "memory.h"
+#include "errno.h"
+
+ssize_t getdelim(char **lineptr, size_t *n, int delim, FILE *stream)
+{
+    if (!lineptr || !n || !stream) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!*lineptr || *n == 0) {
+        *n = *n ? *n : 128;
+        *lineptr = malloc(*n);
+        if (!*lineptr) {
+            errno = ENOMEM;
+            return -1;
+        }
+    }
+    size_t pos = 0;
+    int c;
+    while ((c = fgetc(stream)) != -1) {
+        if (pos + 1 >= *n) {
+            size_t new_size = *n * 2;
+            char *tmp = realloc(*lineptr, new_size);
+            if (!tmp) {
+                errno = ENOMEM;
+                return -1;
+            }
+            *lineptr = tmp;
+            *n = new_size;
+        }
+        (*lineptr)[pos++] = (char)c;
+        if (c == delim)
+            break;
+    }
+    if (c == -1 && pos == 0)
+        return -1;
+    (*lineptr)[pos] = '\0';
+    return (ssize_t)pos;
+}
+
+ssize_t getline(char **lineptr, size_t *n, FILE *stream)
+{
+    return getdelim(lineptr, n, '\n', stream);
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -697,6 +697,52 @@ static const char *test_fgets_fputs(void)
     return 0;
 }
 
+static const char *test_getline_various(void)
+{
+    FILE *f = fopen("tmp_getline", "w+");
+    mu_assert("fopen", f != NULL);
+    const char *content = "short\nlonger line here\nlast";
+    mu_assert("write", fwrite(content, 1, strlen(content), f) == (ssize_t)strlen(content));
+    rewind(f);
+    char *line = NULL;
+    size_t cap = 0;
+    ssize_t len = getline(&line, &cap, f);
+    mu_assert("line1", len == 6 && strcmp(line, "short\n") == 0);
+    len = getline(&line, &cap, f);
+    mu_assert("line2", len == 17 && strcmp(line, "longer line here\n") == 0);
+    len = getline(&line, &cap, f);
+    mu_assert("line3", len == 4 && strcmp(line, "last") == 0);
+    len = getline(&line, &cap, f);
+    mu_assert("eof", len == -1);
+    free(line);
+    fclose(f);
+    unlink("tmp_getline");
+    return 0;
+}
+
+static const char *test_getdelim_various(void)
+{
+    FILE *f = fopen("tmp_getdelim", "w+");
+    mu_assert("fopen", f != NULL);
+    const char *content = "aa,bbb,cccc,";
+    mu_assert("write", fwrite(content, 1, strlen(content), f) == (ssize_t)strlen(content));
+    rewind(f);
+    char *line = NULL;
+    size_t cap = 0;
+    ssize_t len = getdelim(&line, &cap, ',', f);
+    mu_assert("tok1", len == 3 && strcmp(line, "aa,") == 0);
+    len = getdelim(&line, &cap, ',', f);
+    mu_assert("tok2", len == 4 && strcmp(line, "bbb,") == 0);
+    len = getdelim(&line, &cap, ',', f);
+    mu_assert("tok3", len == 5 && strcmp(line, "cccc,") == 0);
+    len = getdelim(&line, &cap, ',', f);
+    mu_assert("eof", len == -1);
+    free(line);
+    fclose(f);
+    unlink("tmp_getdelim");
+    return 0;
+}
+
 static const char *test_fflush(void)
 {
     FILE *f = fopen("tmp_flush", "w");
@@ -1378,6 +1424,8 @@ static const char *all_tests(void)
     mu_run_test(test_fseek_rewind);
     mu_run_test(test_fgetc_fputc);
     mu_run_test(test_fgets_fputs);
+    mu_run_test(test_getline_various);
+    mu_run_test(test_getdelim_various);
     mu_run_test(test_fflush);
     mu_run_test(test_pthread);
     mu_run_test(test_pthread_detach);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -551,9 +551,11 @@ descriptors 0, 1 and 2. They can be used with the provided `fread`,
 `fwrite`, `fseek`, `ftell`, `rewind`, `fgetc`, `fputc`, `fgets`,
 `fputs`, `sprintf`, `snprintf`, `vsprintf`, `vsnprintf`, `fprintf`,
 `vfprintf`, `printf`, `vprintf`, `vsscanf`, `vfscanf`, `vscanf`,
-`sscanf`, `fscanf`, and `scanf` helpers.
+`sscanf`, `fscanf`, `scanf`, `getline`, and `getdelim` helpers.
 `fflush(stream)` succeeds
 and invokes `fsync` on the descriptor when one is present.
+
+`getline` and `getdelim` grow the supplied buffer automatically while reading.
 
 Streams may be given a custom buffer with `setvbuf` or the simpler
 `setbuf`. When buffered, I/O operates on that memory until it is filled


### PR DESCRIPTION
## Summary
- expose `getdelim` and `getline` in `<stdio.h>`
- implement the functions using `fgetc`
- test reading delimited input of varying length
- document the helpers

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858c2fef52083249fc5c9f0e7e234c1