### PR TITLE
Add socket option wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ SRC := \
     src/strto.c \
     src/rand.c \
     src/socket.c \
+    src/setsockopt.c \
+    src/getsockopt.c \
     src/netdb.c \
     src/inet_pton.c \
     src/inet_ntop.c \

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -25,5 +25,9 @@ ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,
                const struct sockaddr *dest, socklen_t addrlen);
 ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
                  struct sockaddr *src, socklen_t *addrlen);
+int setsockopt(int sockfd, int level, int optname,
+               const void *optval, socklen_t optlen);
+int getsockopt(int sockfd, int level, int optname,
+               void *optval, socklen_t *optlen);
 
 #endif /* SYS_SOCKET_H */

--- a/src/getsockopt.c
+++ b/src/getsockopt.c
@@ -1,0 +1,17 @@
+#include "sys/socket.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int getsockopt(int sockfd, int level, int optname,
+               void *optval, socklen_t *optlen)
+{
+    long ret = vlibc_syscall(SYS_getsockopt, sockfd, level, optname,
+                             (long)optval, (long)optlen, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+}

--- a/src/setsockopt.c
+++ b/src/setsockopt.c
@@ -1,0 +1,17 @@
+#include "sys/socket.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int setsockopt(int sockfd, int level, int optname,
+               const void *optval, socklen_t optlen)
+{
+    long ret = vlibc_syscall(SYS_setsockopt, sockfd, level, optname,
+                             (long)optval, optlen, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -616,7 +616,8 @@ FILE *anon = tmpfile();
 
 The socket layer exposes thin wrappers around the kernel's networking
 syscalls including `socket`, `bind`, `listen`, `accept`, `connect`,
-`send`, `recv`, `sendto`, and `recvfrom`. Address resolution is handled
+`send`, `recv`, `sendto`, `recvfrom`, `setsockopt`, and `getsockopt`.
+Address resolution is handled
 via `getaddrinfo`, `freeaddrinfo`, and `getnameinfo`.
 
 Utilities `inet_pton` and `inet_ntop` convert between IPv4 or IPv6


### PR DESCRIPTION
## Summary
- add setsockopt/getsockopt wrappers
- expose new functions in header
- document socket options
- compile wrappers in build

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858c8e36ce083249a7b8a008a36a3a7