### PR TITLE
Add pread/pwrite support

### DIFF
--- a/include/io.h
+++ b/include/io.h
@@ -6,6 +6,8 @@
 int open(const char *path, int flags, ...);
 ssize_t read(int fd, void *buf, size_t count);
 ssize_t write(int fd, const void *buf, size_t count);
+ssize_t pread(int fd, void *buf, size_t count, off_t offset);
+ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
 int close(int fd);
 off_t lseek(int fd, off_t offset, int whence);
 int dup(int oldfd);

--- a/src/io.c
+++ b/src/io.c
@@ -49,6 +49,40 @@ ssize_t write(int fd, const void *buf, size_t count)
     return (ssize_t)ret;
 }
 
+ssize_t pread(int fd, void *buf, size_t count, off_t offset)
+{
+#ifdef SYS_pread
+    long ret = vlibc_syscall(SYS_pread, fd, (long)buf, count, offset, 0, 0);
+#elif defined(SYS_pread64)
+    long ret = vlibc_syscall(SYS_pread64, fd, (long)buf, count, offset, 0, 0);
+#else
+    extern ssize_t host_pread(int, void *, size_t, off_t) __asm__("pread");
+    return host_pread(fd, buf, count, offset);
+#endif
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (ssize_t)ret;
+}
+
+ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset)
+{
+#ifdef SYS_pwrite
+    long ret = vlibc_syscall(SYS_pwrite, fd, (long)buf, count, offset, 0, 0);
+#elif defined(SYS_pwrite64)
+    long ret = vlibc_syscall(SYS_pwrite64, fd, (long)buf, count, offset, 0, 0);
+#else
+    extern ssize_t host_pwrite(int, const void *, size_t, off_t) __asm__("pwrite");
+    return host_pwrite(fd, buf, count, offset);
+#endif
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (ssize_t)ret;
+}
+
 int close(int fd)
 {
     long ret = vlibc_syscall(SYS_close, fd, 0, 0, 0, 0, 0);

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -220,6 +220,33 @@ static const char *test_lseek_dup(void)
     return 0;
 }
 
+static const char *test_pread_pwrite(void)
+{
+    const char *fname = "tmp_pread_file";
+    int fd = open(fname, O_CREAT | O_RDWR, 0644);
+    mu_assert("open", fd >= 0);
+
+    const char *msg = "abcdef";
+    mu_assert("init write", write(fd, msg, 6) == 6);
+    off_t pos = lseek(fd, 0, SEEK_CUR);
+    mu_assert("pos", pos == 6);
+
+    const char *patch = "XY";
+    ssize_t w = pwrite(fd, patch, 2, 2);
+    mu_assert("pwrite", w == 2);
+    mu_assert("offset unchanged", lseek(fd, 0, SEEK_CUR) == pos);
+
+    char buf[5] = {0};
+    ssize_t r = pread(fd, buf, 4, 1);
+    mu_assert("pread", r == 4);
+    mu_assert("pread data", strncmp(buf, "bXYe", 4) == 0);
+    mu_assert("offset still", lseek(fd, 0, SEEK_CUR) == pos);
+
+    close(fd);
+    unlink(fname);
+    return 0;
+}
+
 static const char *test_socket(void)
 {
     int fd = socket(AF_INET, SOCK_STREAM, 0);
@@ -1428,6 +1455,7 @@ static const char *all_tests(void)
     mu_run_test(test_memory_ops);
     mu_run_test(test_io);
     mu_run_test(test_lseek_dup);
+    mu_run_test(test_pread_pwrite);
     mu_run_test(test_dup3_cloexec);
     mu_run_test(test_pipe2_cloexec);
     mu_run_test(test_socket);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -555,11 +555,13 @@ chdir("/");
 
 ## File Descriptor Helpers
 
-Low-level descriptor routines perform simple tasks such as repositioning a file
-or duplicating handles.
+Low-level descriptor routines perform simple tasks such as repositioning a file,
+reading or writing at a specific offset, or duplicating handles.
 
 ```c
 off_t pos = lseek(fd, 0, SEEK_SET);
+ssize_t n = pread(fd, buf, 16, 4);
+pwrite(fd, buf, n, 32);
 int duped = dup(fd);
 int pipefd[2];
 pipe(pipefd);


### PR DESCRIPTION
## Summary
- declare `pread` and `pwrite` prototypes
- implement `pread`/`pwrite` wrappers
- document the new calls
- test reading and writing at offsets

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858c86a291083248ad4ee863c6c9b44