### PR TITLE
Add multibyte conversion helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ SRC := \
     src/getopt_long.c \
     src/locale.c \
     src/wchar.c \
+    src/wchar_conv.c \
     src/tempfile.c \
     src/getline.c \
     src/math.c \

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -13,5 +13,11 @@ typedef struct { int __dummy; } mbstate_t;
 int mbtowc(wchar_t *pwc, const char *s, size_t n);
 int wctomb(char *s, wchar_t wc);
 size_t wcslen(const wchar_t *s);
+size_t mbrtowc(wchar_t *pwc, const char *s, size_t n, mbstate_t *ps);
+size_t wcrtomb(char *s, wchar_t wc, mbstate_t *ps);
+size_t mbstowcs(wchar_t *dst, const char *src, size_t n);
+size_t wcstombs(char *dst, const wchar_t *src, size_t n);
+size_t mbrlen(const char *s, size_t n, mbstate_t *ps);
+int mbsinit(const mbstate_t *ps);
 
 #endif /* WCHAR_H */

--- a/src/wchar_conv.c
+++ b/src/wchar_conv.c
@@ -1,0 +1,102 @@
+#include "wchar.h"
+#include_next <wchar.h>
+
+extern size_t host_mbrtowc(wchar_t *, const char *, size_t, mbstate_t *) __asm__("mbrtowc");
+extern size_t host_wcrtomb(char *, wchar_t, mbstate_t *) __asm__("wcrtomb");
+extern size_t host_mbstowcs(wchar_t *, const char *, size_t) __asm__("mbstowcs");
+extern size_t host_wcstombs(char *, const wchar_t *, size_t) __asm__("wcstombs");
+
+int mbsinit(const mbstate_t *ps)
+{
+    (void)ps;
+    return 1;
+}
+
+size_t mbrlen(const char *s, size_t n, mbstate_t *ps)
+{
+    return mbrtowc(NULL, s, n, ps);
+}
+
+size_t mbrtowc(wchar_t *pwc, const char *s, size_t n, mbstate_t *ps)
+{
+    (void)ps;
+    if (!s)
+        return 0;
+    if (n == 0)
+        return (size_t)-2;
+    unsigned char ch = (unsigned char)*s;
+    if (ch < 0x80) {
+        if (pwc)
+            *pwc = (wchar_t)ch;
+        return ch ? 1 : 0;
+    }
+    return host_mbrtowc(pwc, s, n, ps);
+}
+
+size_t wcrtomb(char *s, wchar_t wc, mbstate_t *ps)
+{
+    (void)ps;
+    if (!s)
+        return 1;
+    if ((unsigned)wc < 0x80) {
+        *s = (char)wc;
+        return 1;
+    }
+    return host_wcrtomb(s, wc, ps);
+}
+
+static int has_non_ascii_mb(const char *s)
+{
+    while (*s) {
+        if (((unsigned char)*s) >= 0x80)
+            return 1;
+        s++;
+    }
+    return 0;
+}
+
+static int has_non_ascii_wc(const wchar_t *s)
+{
+    while (*s) {
+        if ((unsigned)*s >= 0x80)
+            return 1;
+        s++;
+    }
+    return 0;
+}
+
+size_t mbstowcs(wchar_t *dst, const char *src, size_t n)
+{
+    if (has_non_ascii_mb(src))
+        return host_mbstowcs(dst, src, n);
+
+    size_t i = 0;
+    if (dst) {
+        for (; i < n && src[i]; i++)
+            dst[i] = (unsigned char)src[i];
+        if (i < n)
+            dst[i] = 0;
+    } else {
+        while (src[i])
+            i++;
+    }
+    return i;
+}
+
+size_t wcstombs(char *dst, const wchar_t *src, size_t n)
+{
+    if (has_non_ascii_wc(src))
+        return host_wcstombs(dst, src, n);
+
+    size_t i = 0;
+    if (dst) {
+        for (; i < n && src[i]; i++)
+            dst[i] = (char)src[i];
+        if (i < n)
+            dst[i] = 0;
+    } else {
+        while (src[i])
+            i++;
+    }
+    return i;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -529,6 +529,35 @@ static const char *test_widechar_basic(void)
     return 0;
 }
 
+static const char *test_widechar_conv(void)
+{
+    wchar_t wbuf[4];
+    size_t n = mbstowcs(wbuf, "abc", 4);
+    mu_assert("mbstowcs count", n == 3);
+    mu_assert("mbstowcs conv", wbuf[0] == L'a' && wbuf[1] == L'b' && wbuf[2] == L'c');
+
+    char mbuf[4];
+    n = wcstombs(mbuf, wbuf, 4);
+    mu_assert("wcstombs count", n == 3);
+    mu_assert("wcstombs conv", strcmp(mbuf, "abc") == 0);
+
+    mbstate_t st = {0};
+    n = mbrlen("z", 1, &st);
+    mu_assert("mbrlen", n == 1);
+
+    wchar_t wc = 0;
+    n = mbrtowc(&wc, "x", 1, &st);
+    mu_assert("mbrtowc", n == 1 && wc == L'x');
+
+    char out[2] = {0};
+    n = wcrtomb(out, wc, &st);
+    mu_assert("wcrtomb", n == 1 && out[0] == 'x');
+
+    mu_assert("mbsinit", mbsinit(&st));
+
+    return 0;
+}
+
 static const char *test_strtok_basic(void)
 {
     char buf[] = "a,b,c";
@@ -1454,6 +1483,7 @@ static const char *all_tests(void)
     mu_run_test(test_string_casecmp);
     mu_run_test(test_strlcpy_cat);
     mu_run_test(test_widechar_basic);
+    mu_run_test(test_widechar_conv);
     mu_run_test(test_strtok_basic);
     mu_run_test(test_strtok_r_basic);
     mu_run_test(test_printf_functions);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -262,8 +262,11 @@ The goal is to offer just enough functionality for common tasks without the comp
 ### Wide Character Conversion
 
 `mbtowc` converts a multibyte sequence to a single `wchar_t` and `wctomb`
-performs the opposite conversion. `wcslen` returns the length of a wide
-string excluding the terminator.
+performs the opposite conversion.  `mbrtowc`/`wcrtomb` are stateful
+variants used by `mbstowcs` and `wcstombs` for converting entire
+strings.  These helpers handle ASCII directly and fall back to the host
+C library when encountering non-ASCII data.  `wcslen` returns the length
+of a wide string excluding the terminator.
 
 ## Character Classification
 


### PR DESCRIPTION
## Summary
- extend `wchar.h` with additional conversion prototypes
- implement ASCII `mbrtowc`, `wcrtomb`, `mbstowcs`, and `wcstombs`
- hook new source file into the build
- test wide-character conversions
- document multibyte helpers

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858ca05219c8324ae5aca17d3f2005f