### PR TITLE
Implement getopt_long_only parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ SRC := \
     src/getopt.c \
     src/dlfcn.c \
     src/getopt_long.c \
+    src/getopt_long_only.c \
     src/locale.c \
     src/wchar.c \
     src/tempfile.c \

--- a/include/getopt.h
+++ b/include/getopt.h
@@ -21,5 +21,7 @@ struct option {
 int getopt(int argc, char * const argv[], const char *optstring);
 int getopt_long(int argc, char * const argv[], const char *optstring,
                const struct option *longopts, int *longindex);
+int getopt_long_only(int argc, char * const argv[], const char *optstring,
+                     const struct option *longopts, int *longindex);
 
 #endif /* GETOPT_H */

--- a/src/getopt_long_only.c
+++ b/src/getopt_long_only.c
@@ -1,0 +1,65 @@
+#include "getopt.h"
+#include "stdio.h"
+#include "string.h"
+
+/*
+ * Parse command line options allowing long options with a single dash.
+ * If a matching long option is not found, fall back to getopt() for
+ * short option processing.
+ */
+int getopt_long_only(int argc, char * const argv[], const char *optstring,
+                     const struct option *longopts, int *longindex)
+{
+    if (optind >= argc)
+        return -1;
+
+    char *arg = argv[optind];
+    if (arg[0] != '-' || arg[1] == '\0')
+        return getopt(argc, argv, optstring);
+
+    /* handle the --foo case */
+    if (arg[1] == '-')
+        arg += 2;
+    else
+        arg += 1;
+
+    const char *eq = strchr(arg, '=');
+    size_t len = eq ? (size_t)(eq - arg) : strlen(arg);
+
+    for (int i = 0; longopts && longopts[i].name; i++) {
+        if (strncmp(arg, longopts[i].name, len) == 0 &&
+            longopts[i].name[len] == '\0') {
+            if (longindex)
+                *longindex = i;
+
+            if (longopts[i].has_arg == required_argument) {
+                if (eq)
+                    optarg = (char *)(eq + 1);
+                else if (optind + 1 < argc)
+                    optarg = argv[++optind];
+                else {
+                    if (opterr)
+                        fprintf(stderr, "option '--%s' requires argument\n",
+                                longopts[i].name);
+                    optind++;
+                    optopt = longopts[i].val;
+                    return optstring && optstring[0] == ':' ? ':' : '?';
+                }
+            } else if (longopts[i].has_arg == optional_argument) {
+                optarg = eq ? (char *)(eq + 1) : NULL;
+            } else {
+                optarg = NULL;
+            }
+
+            optind++;
+            if (longopts[i].flag) {
+                *longopts[i].flag = longopts[i].val;
+                return 0;
+            }
+            return longopts[i].val;
+        }
+    }
+
+    /* no matching long option - treat as short */
+    return getopt(argc, argv, optstring);
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1485,6 +1485,56 @@ static const char *test_getopt_long_basic(void)
     return 0;
 }
 
+static const char *test_getopt_long_only_missing(void)
+{
+    char *argv[] = {"prog", "-bar", NULL};
+    int argc = 2;
+    struct option longopts[] = {
+        {"bar", required_argument, NULL, 'b'},
+        {0, 0, 0, 0}
+    };
+    optind = 1;
+    opterr = 0;
+    int r = getopt_long_only(argc, argv, "b:", longopts, NULL);
+    mu_assert("missing ret", r == '?');
+    mu_assert("optopt", optopt == 'b');
+    mu_assert("index", optind == 2);
+    return 0;
+}
+
+static const char *test_getopt_long_only_basic(void)
+{
+    char *argv[] = {"prog", "-foo", "-bar=val", "rest", NULL};
+    int argc = 4;
+    int foo = 0;
+    char *bar = NULL;
+    struct option longopts[] = {
+        {"foo", no_argument, &foo, 1},
+        {"bar", required_argument, NULL, 'b'},
+        {0, 0, 0, 0}
+    };
+    optind = 1;
+    opterr = 0;
+    int c;
+    while ((c = getopt_long_only(argc, argv, "b:", longopts, NULL)) != -1) {
+        switch (c) {
+        case 0:
+            break;
+        case 'b':
+            bar = optarg;
+            break;
+        default:
+            return "unexpected long opt";
+        }
+    }
+    mu_assert("foo", foo == 1);
+    mu_assert("bar", bar && strcmp(bar, "val") == 0);
+    mu_assert("optind", optind == 3);
+    mu_assert("rest", strcmp(argv[optind], "rest") == 0);
+
+    return 0;
+}
+
 static const char *all_tests(void)
 {
     mu_run_test(test_malloc);
@@ -1551,6 +1601,8 @@ static const char *all_tests(void)
     mu_run_test(test_dlopen_basic);
     mu_run_test(test_getopt_long_missing);
     mu_run_test(test_getopt_long_basic);
+    mu_run_test(test_getopt_long_only_missing);
+    mu_run_test(test_getopt_long_only_basic);
 
     return 0;
 }

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -302,10 +302,12 @@ returned unchanged by `tolower` and `toupper`.
 
 ## Option Parsing
 
-Command-line arguments can be processed with `getopt` or `getopt_long`. The
-former handles short options while the latter accepts an array of `struct
-option` describing long names. `getopt_long` returns the option's value field
-or sets a flag when supplied in the table.
+Command-line arguments can be processed with `getopt`, `getopt_long` or
+`getopt_long_only`. The former handles short options while the latter
+two accept an array of `struct option` describing long names. The
+`getopt_long_only` variant also recognizes long options when they are
+prefixed with a single dash. Both long parsing functions return the
+option's value field or set a flag when supplied in the table.
 
 ## Random Numbers
 


### PR DESCRIPTION
## Summary
- expose `getopt_long_only` in the public header
- implement `getopt_long_only` parser
- document the new option parser in the manual
- test long-only option parsing

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858cbd24d048324868e04451c157522