### PR TITLE
Implement utime and utimes wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ SRC := \
     src/time_conv.c \
     src/strftime.c \
     src/stat.c \
+    src/utime.c \
     src/pthread.c \
     src/dirent.c \
     src/default_shell.c \

--- a/include/sys/file.h
+++ b/include/sys/file.h
@@ -2,6 +2,7 @@
 #define SYS_FILE_H
 
 #include <sys/types.h>
+#include "../time.h"
 
 #if defined(__has_include)
 #  if __has_include("/usr/include/x86_64-linux-gnu/sys/file.h")
@@ -14,5 +15,14 @@
 int chmod(const char *path, mode_t mode);
 int chown(const char *path, uid_t owner, gid_t group);
 mode_t umask(mode_t mask);
+
+struct utimbuf {
+    time_t actime;
+    time_t modtime;
+};
+
+struct timeval;
+int utime(const char *path, const struct utimbuf *times);
+int utimes(const char *path, const struct timeval times[2]);
 
 #endif /* SYS_FILE_H */

--- a/src/utime.c
+++ b/src/utime.c
@@ -1,0 +1,75 @@
+#include "sys/file.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "syscall.h"
+
+#ifndef AT_FDCWD
+#define AT_FDCWD -100
+#endif
+
+#ifndef SYS_utimensat
+extern int host_utimes(const char *path, const struct timeval times[2]) __asm__("utimes");
+extern int host_utime(const char *path, const struct utimbuf *times) __asm__("utime");
+#endif
+
+int utimes(const char *path, const struct timeval times[2])
+{
+#ifdef SYS_utimensat
+    struct timespec ts[2];
+    if (times) {
+        ts[0].tv_sec = times[0].tv_sec;
+        ts[0].tv_nsec = times[0].tv_usec * 1000;
+        ts[1].tv_sec = times[1].tv_sec;
+        ts[1].tv_nsec = times[1].tv_usec * 1000;
+    }
+    long ret = vlibc_syscall(SYS_utimensat, AT_FDCWD, (long)path,
+                             times ? (long)ts : 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#elif defined(SYS_utimes)
+    long ret = vlibc_syscall(SYS_utimes, (long)path, (long)times,
+                             0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#else
+    return host_utimes(path, times);
+#endif
+}
+
+int utime(const char *path, const struct utimbuf *times)
+{
+#ifdef SYS_utimensat
+    struct timespec ts[2];
+    if (times) {
+        ts[0].tv_sec = times->actime;
+        ts[0].tv_nsec = 0;
+        ts[1].tv_sec = times->modtime;
+        ts[1].tv_nsec = 0;
+    }
+    long ret = vlibc_syscall(SYS_utimensat, AT_FDCWD, (long)path,
+                             times ? (long)ts : 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#elif defined(SYS_utime)
+    long ret = vlibc_syscall(SYS_utime, (long)path, (long)times,
+                             0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#else
+    return host_utime(path, times);
+#endif
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -677,7 +677,14 @@ chown("data.txt", 1000, 1000);
 
 ## File Status
 
-`stat`, `fstat`, and `lstat` from `sys/stat.h` query file metadata.
+`stat`, `fstat`, and `lstat` from `sys/stat.h` query file metadata. The
+`utime` and `utimes` helpers adjust the access and modification times of a
+file:
+
+```c
+struct utimbuf t = { .actime = 1625097600, .modtime = 1625097600 };
+utime("data.txt", &t);
+```
 
 ## Directory Iteration
 


### PR DESCRIPTION
## Summary
- define `struct utimbuf` and declare `utime`/`utimes`
- implement wrappers that use `utimensat` or fall back to host
- compile new file in the build
- mention the helpers in docs

## Testing
- `make test` *(fails: Tests run: 14)*

------
https://chatgpt.com/codex/tasks/task_e_6858cba9b37c8324a261203cf2691501