### PR TITLE
Add socketpair wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ SRC := \
     src/strto.c \
     src/rand.c \
     src/socket.c \
+    src/socketpair.c \
     src/setsockopt.c \
     src/getsockopt.c \
     src/netdb.c \

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -19,6 +19,7 @@ int listen(int sockfd, int backlog);
 int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 int accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags);
 int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
+int socketpair(int domain, int type, int protocol, int sv[2]);
 ssize_t send(int sockfd, const void *buf, size_t len, int flags);
 ssize_t recv(int sockfd, void *buf, size_t len, int flags);
 ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,

--- a/src/socketpair.c
+++ b/src/socketpair.c
@@ -1,0 +1,16 @@
+#include "sys/socket.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int socketpair(int domain, int type, int protocol, int sv[2])
+{
+    long ret = vlibc_syscall(SYS_socketpair, domain, type, protocol,
+                             (long)sv, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -280,6 +280,21 @@ static const char *test_socket(void)
     return 0;
 }
 
+static const char *test_socketpair_basic(void)
+{
+    int sv[2];
+    mu_assert("socketpair", socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+    const char *msg = "ok";
+    ssize_t w = write(sv[0], msg, 2);
+    mu_assert("write", w == 2);
+    char buf[3] = {0};
+    ssize_t r = read(sv[1], buf, 2);
+    mu_assert("read", r == 2 && strcmp(buf, msg) == 0);
+    close(sv[0]);
+    close(sv[1]);
+    return 0;
+}
+
 static const char *test_dup3_cloexec(void)
 {
     const char *fname = "tmp_dup3_file";
@@ -1498,6 +1513,7 @@ static const char *all_tests(void)
     mu_run_test(test_dup3_cloexec);
     mu_run_test(test_pipe2_cloexec);
     mu_run_test(test_socket);
+    mu_run_test(test_socketpair_basic);
     mu_run_test(test_udp_send_recv);
     mu_run_test(test_inet_pton_ntop);
     mu_run_test(test_errno_open);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -634,7 +634,8 @@ FILE *anon = tmpfile();
 
 The socket layer exposes thin wrappers around the kernel's networking
 syscalls including `socket`, `bind`, `listen`, `accept`, `connect`,
-`send`, `recv`, `sendto`, `recvfrom`, `setsockopt`, and `getsockopt`.
+`socketpair`, `send`, `recv`, `sendto`, `recvfrom`, `setsockopt`, and
+`getsockopt`.
 Address resolution is handled
 via `getaddrinfo`, `freeaddrinfo`, and `getnameinfo`.
 
@@ -644,9 +645,20 @@ presentation strings and binary network format.
 ```c
 struct addrinfo *ai;
 if (getaddrinfo("localhost", "80", NULL, &ai) == 0) {
-    int fd = socket(AF_INET, SOCK_STREAM, 0);
+int fd = socket(AF_INET, SOCK_STREAM, 0);
     connect(fd, ai->ai_addr, ai->ai_addrlen);
     freeaddrinfo(ai);
+}
+```
+
+Create a pair of connected sockets with `socketpair`:
+
+```c
+int sv[2];
+if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0) {
+    send(sv[0], "hi", 2, 0);
+    char buf[3] = {0};
+    recv(sv[1], buf, 2, 0);
 }
 ```
 


### PR DESCRIPTION
## Summary
- expose `socketpair` in header
- implement `socketpair` syscall wrapper
- test socketpair basic usage
- document socketpair with an example

## Testing
- `make test` *(fails: `open should fail`)*

------
https://chatgpt.com/codex/tasks/task_e_6858cba3d21c8324be886e1bc2ceca4e