### PR TITLE
Add hostname helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ SRC := \
     $(SYS_SRC) \
     src/mmap.c \
     src/env.c \
+    src/hostname.c \
     src/sleep.c \
     src/clock_gettime.c \
     src/time.c \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ programs. Key features include:
 - Networking sockets
 - Dynamic loading
 - Environment variable handling
+- Host name queries and changes
 
 **Note**: vlibc provides only a small subset of the standard C library. Some
 functions depend on system calls that are currently implemented for Linux. BSD

--- a/include/env.h
+++ b/include/env.h
@@ -1,6 +1,8 @@
 #ifndef ENV_H
 #define ENV_H
 
+#include <stddef.h>
+
 /* Access to environment variables */
 
 /* global environment pointer */
@@ -12,5 +14,9 @@ void env_init(char **envp);
 char *getenv(const char *name);
 int setenv(const char *name, const char *value, int overwrite);
 int unsetenv(const char *name);
+
+/* Host name helpers */
+int gethostname(char *name, size_t len);
+int sethostname(const char *name, size_t len);
 
 #endif /* ENV_H */

--- a/src/hostname.c
+++ b/src/hostname.c
@@ -1,0 +1,35 @@
+#include "env.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int gethostname(char *name, size_t len)
+{
+#ifdef SYS_gethostname
+    long ret = vlibc_syscall(SYS_gethostname, (long)name, len, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#else
+    extern int host_gethostname(char *, size_t) __asm__("gethostname");
+    return host_gethostname(name, len);
+#endif
+}
+
+int sethostname(const char *name, size_t len)
+{
+#ifdef SYS_sethostname
+    long ret = vlibc_syscall(SYS_sethostname, (long)name, len, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#else
+    extern int host_sethostname(const char *, size_t) __asm__("sethostname");
+    return host_sethostname(name, len);
+#endif
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1050,6 +1050,14 @@ static const char *test_locale_from_env(void)
     return 0;
 }
 
+static const char *test_gethostname_fn(void)
+{
+    char buf[256];
+    mu_assert("gethostname", gethostname(buf, sizeof(buf)) == 0);
+    mu_assert("non-empty", buf[0] != '\0');
+    return 0;
+}
+
 static const char *test_error_reporting(void)
 {
     errno = ENOENT;
@@ -1529,6 +1537,7 @@ static const char *all_tests(void)
     mu_run_test(test_time_conversions);
     mu_run_test(test_environment);
     mu_run_test(test_locale_from_env);
+    mu_run_test(test_gethostname_fn);
     mu_run_test(test_error_reporting);
     mu_run_test(test_system_fn);
     mu_run_test(test_execvp_fn);


### PR DESCRIPTION
## Summary
- expose `gethostname`/`sethostname` in `env.h`
- implement hostname wrappers
- build hostname wrapper
- document hostname helpers
- test hostname wrappers

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858cbaf34fc8324be820297c25b667d