### PR TITLE
Add strsignal function

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -69,5 +69,6 @@ int sigfillset(sigset_t *set);
 int sigaddset(sigset_t *set, int signo);
 int sigdelset(sigset_t *set, int signo);
 int sigismember(const sigset_t *set, int signo);
+const char *strsignal(int signum);
 
 #endif /* SIGNAL_H */

--- a/src/signal.c
+++ b/src/signal.c
@@ -2,6 +2,7 @@
 #include "errno.h"
 #include <sys/syscall.h>
 #include "syscall.h"
+#include <stddef.h>
 
 int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
 {
@@ -72,4 +73,43 @@ int sigismember(const sigset_t *set, int signo)
     if (signo <= 0 || signo > 8 * (int)sizeof(sigset_t))
         return 0;
     return (*set & ((sigset_t)1 << (signo - 1))) ? 1 : 0;
+}
+
+struct sig_name {
+    int num;
+    const char *name;
+};
+
+static const struct sig_name sig_names[] = {
+    { SIGHUP, "Hangup" },
+    { SIGINT, "Interrupt" },
+    { SIGQUIT, "Quit" },
+    { SIGILL, "Illegal instruction" },
+    { SIGTRAP, "Trace/breakpoint trap" },
+    { SIGABRT, "Aborted" },
+    { SIGBUS, "Bus error" },
+    { SIGFPE, "Floating point exception" },
+    { SIGKILL, "Killed" },
+    { SIGUSR1, "User signal 1" },
+    { SIGSEGV, "Segmentation fault" },
+    { SIGUSR2, "User signal 2" },
+    { SIGPIPE, "Broken pipe" },
+    { SIGALRM, "Alarm clock" },
+    { SIGTERM, "Terminated" },
+    { SIGCHLD, "Child exited" },
+    { SIGCONT, "Continued" },
+    { SIGSTOP, "Stopped (signal)" },
+    { SIGTSTP, "Stopped" },
+    { SIGTTIN, "Stopped (tty input)" },
+    { SIGTTOU, "Stopped (tty output)" },
+    { 0, NULL }
+};
+
+const char *strsignal(int signum)
+{
+    for (size_t i = 0; sig_names[i].name; ++i) {
+        if (sig_names[i].num == signum)
+            return sig_names[i].name;
+    }
+    return "Unknown signal";
 }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1092,6 +1092,14 @@ static const char *test_error_reporting(void)
     return 0;
 }
 
+static const char *test_strsignal_names(void)
+{
+    mu_assert("SIGHUP", strcmp(strsignal(SIGHUP), "Hangup") == 0);
+    mu_assert("SIGINT", strcmp(strsignal(SIGINT), "Interrupt") == 0);
+    mu_assert("unknown", strcmp(strsignal(9999), "Unknown signal") == 0);
+    return 0;
+}
+
 static const char *test_pid_functions(void)
 {
     pid_t pid = getpid();
@@ -1530,6 +1538,7 @@ static const char *all_tests(void)
     mu_run_test(test_environment);
     mu_run_test(test_locale_from_env);
     mu_run_test(test_error_reporting);
+    mu_run_test(test_strsignal_names);
     mu_run_test(test_system_fn);
     mu_run_test(test_execvp_fn);
     mu_run_test(test_popen_fn);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -421,6 +421,7 @@ vlibc provides minimal helpers to report errors:
 const char *strerror(int errnum);
 int strerror_r(int errnum, char *buf, size_t buflen);
 void perror(const char *s);
+const char *strsignal(int signum);
 ```
 
 
@@ -428,6 +429,8 @@ void perror(const char *s);
 codes it does not recognize. `strerror_r()` is a thread-safe variant that
 writes the message into `buf`. `perror()` writes a message to `stderr`
 combining the optional prefix with the text for the current `errno`.
+`strsignal()` maps a signal number to a short descriptive string or
+"Unknown signal" when the name is not recognized.
 
 ## Errno Access
 


### PR DESCRIPTION
## Summary
- add `strsignal` declaration to the signal API
- implement `strsignal` with common signal names
- document the helper in `vlibcdoc.md`
- test signal name lookups

## Testing
- `make test` *(fails: `open should fail`)*

------
https://chatgpt.com/codex/tasks/task_e_6858cbcaeba8832497a7be26d34f6f12