### PR TITLE
Add passwd lookup APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ SRC := \
     src/wchar_conv.c \
     src/tempfile.c \
     src/getline.c \
+    src/pwd.c \
     src/math.c \
     src/math_extra.c \
     src/regex.c

--- a/include/pwd.h
+++ b/include/pwd.h
@@ -1,0 +1,19 @@
+#ifndef PWD_H
+#define PWD_H
+
+#include <sys/types.h>
+
+struct passwd {
+    char *pw_name;
+    char *pw_passwd;
+    uid_t pw_uid;
+    gid_t pw_gid;
+    char *pw_gecos;
+    char *pw_dir;
+    char *pw_shell;
+};
+
+struct passwd *getpwuid(uid_t uid);
+struct passwd *getpwnam(const char *name);
+
+#endif /* PWD_H */

--- a/src/pwd.c
+++ b/src/pwd.c
@@ -1,0 +1,98 @@
+#include "pwd.h"
+#include "io.h"
+#include "string.h"
+#include "stdlib.h"
+#include "env.h"
+#include <fcntl.h>
+#include <unistd.h>
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+
+static const char *passwd_path(void)
+{
+    const char *p = getenv("VLIBC_PASSWD");
+    if (p && *p)
+        return p;
+    return "/etc/passwd";
+}
+
+static struct passwd pw;
+static char linebuf[256];
+
+static struct passwd *parse_line(const char *line)
+{
+    strncpy(linebuf, line, sizeof(linebuf) - 1);
+    linebuf[sizeof(linebuf) - 1] = '\0';
+
+    char *save;
+    pw.pw_name = strtok_r(linebuf, ":", &save);
+    pw.pw_passwd = strtok_r(NULL, ":", &save);
+    char *uid_s = strtok_r(NULL, ":", &save);
+    char *gid_s = strtok_r(NULL, ":", &save);
+    pw.pw_gecos = strtok_r(NULL, ":", &save);
+    pw.pw_dir = strtok_r(NULL, ":", &save);
+    pw.pw_shell = strtok_r(NULL, ":\n", &save);
+    if (!pw.pw_name || !pw.pw_passwd || !uid_s || !gid_s ||
+        !pw.pw_gecos || !pw.pw_dir || !pw.pw_shell)
+        return NULL;
+    pw.pw_uid = (uid_t)atoi(uid_s);
+    pw.pw_gid = (gid_t)atoi(gid_s);
+    return &pw;
+}
+
+static struct passwd *lookup(const char *name, uid_t uid, int by_name)
+{
+    int fd = open(passwd_path(), O_RDONLY, 0);
+    if (fd < 0)
+        return NULL;
+    char buf[4096];
+    ssize_t n = read(fd, buf, sizeof(buf) - 1);
+    close(fd);
+    if (n <= 0)
+        return NULL;
+    buf[n] = '\0';
+
+    char *save_line;
+    for (char *line = strtok_r(buf, "\n", &save_line); line;
+         line = strtok_r(NULL, "\n", &save_line)) {
+        struct passwd *p = parse_line(line);
+        if (!p)
+            continue;
+        if (by_name) {
+            if (strcmp(p->pw_name, name) == 0)
+                return p;
+        } else {
+            if (p->pw_uid == uid)
+                return p;
+        }
+    }
+    return NULL;
+}
+
+struct passwd *getpwuid(uid_t uid)
+{
+    return lookup(NULL, uid, 0);
+}
+
+struct passwd *getpwnam(const char *name)
+{
+    return lookup(name, 0, 1);
+}
+
+#else
+
+extern struct passwd *host_getpwuid(uid_t) __asm("getpwuid");
+extern struct passwd *host_getpwnam(const char *) __asm("getpwnam");
+
+struct passwd *getpwuid(uid_t uid)
+{
+    return host_getpwuid(uid);
+}
+
+struct passwd *getpwnam(const char *name)
+{
+    return host_getpwnam(name);
+}
+
+#endif

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -32,14 +32,15 @@ This document outlines the architecture, planned modules, and API design for **v
 26. [File Status](#file-status)
 27. [Directory Iteration](#directory-iteration)
 28. [Path Canonicalization](#path-canonicalization)
-29. [Time Formatting](#time-formatting)
-30. [Locale Support](#locale-support)
-31. [Time Retrieval](#time-retrieval)
-32. [Sleep Functions](#sleep-functions)
-33. [Raw System Calls](#raw-system-calls)
-34. [Non-local Jumps](#non-local-jumps)
-35. [Limitations](#limitations)
-36. [Conclusion](#conclusion)
+29. [User Database](#user-database)
+30. [Time Formatting](#time-formatting)
+31. [Locale Support](#locale-support)
+32. [Time Retrieval](#time-retrieval)
+33. [Sleep Functions](#sleep-functions)
+34. [Raw System Calls](#raw-system-calls)
+35. [Non-local Jumps](#non-local-jumps)
+36. [Limitations](#limitations)
+37. [Conclusion](#conclusion)
 
 ## Overview
 
@@ -718,6 +719,28 @@ directory.
 char buf[256];
 realpath("tests/../", buf); // buf now holds the absolute path to the repository
 ```
+
+## User Database
+
+`pwd.h` exposes minimal lookup helpers for entries in `/etc/passwd`.
+
+```c
+struct passwd {
+    char *pw_name;
+    char *pw_passwd;
+    uid_t pw_uid;
+    gid_t pw_gid;
+    char *pw_gecos;
+    char *pw_dir;
+    char *pw_shell;
+};
+
+struct passwd *getpwuid(uid_t uid);
+struct passwd *getpwnam(const char *name);
+```
+
+On BSD systems vlibc parses the file directly. The location can be
+overridden via the `VLIBC_PASSWD` environment variable for testing.
 
 ## Time Formatting
 


### PR DESCRIPTION
## Summary
- add <pwd.h> with `struct passwd` and lookup prototypes
- parse `/etc/passwd` on BSD or delegate to host libc
- document user database in `vlibcdoc.md`
- test lookups using a temporary passwd file
- include new source in build

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858cd1e76948324b708efb829fb62d8