### PR TITLE
Add timegm conversion function

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -59,6 +59,7 @@ size_t strftime(char *s, size_t max, const char *format, const struct tm *tm);
 struct tm *gmtime(const time_t *timep);
 struct tm *localtime(const time_t *timep);
 time_t mktime(struct tm *tm);
+time_t timegm(struct tm *tm);
 char *ctime(const time_t *timep);
 
 #endif /* TIME_H */

--- a/src/time_conv.c
+++ b/src/time_conv.c
@@ -89,6 +89,11 @@ time_t mktime(struct tm *tm)
     return t;
 }
 
+time_t timegm(struct tm *tm)
+{
+    return mktime(tm);
+}
+
 char *ctime(const time_t *timep)
 {
     static char buf[32];

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1025,6 +1025,10 @@ static const char *test_time_conversions(void)
     time_t r = mktime(&tmp);
     mu_assert("mktime", r == 1700000000);
 
+    tmp = *gm;
+    r = timegm(&tmp);
+    mu_assert("timegm", r == 1700000000);
+
     char *s = ctime(&t);
     mu_assert("ctime", strcmp(s, "Tue Nov 14 22:13:20 2023\n") == 0);
     return 0;

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -722,6 +722,7 @@ realpath("tests/../", buf); // buf now holds the absolute path to the repository
 ## Time Formatting
 
 A minimal `strftime` supports `%Y`, `%m`, `%d`, `%H`, `%M`, and `%S`.
+`timegm` converts a `struct tm` in UTC back to `time_t` using the same logic as `mktime` but without timezone adjustments.
 
 ## Locale Support
 


### PR DESCRIPTION
## Summary
- add `timegm` declaration
- implement `timegm` using existing `mktime` logic
- document the function in the Time Formatting section
- test `timegm` alongside existing time conversion helpers

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858cd4bacf88324871f3b119fc41526