### PR TITLE
Implement strndup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ SRC := \
     src/system.c \
     src/string.c \
     src/string_extra.c \
+    src/strndup.c \
     src/strerror_r.c \
     src/strto.c \
     src/rand.c \

--- a/include/signal.h
+++ b/include/signal.h
@@ -69,6 +69,6 @@ int sigfillset(sigset_t *set);
 int sigaddset(sigset_t *set, int signo);
 int sigdelset(sigset_t *set, int signo);
 int sigismember(const sigset_t *set, int signo);
-const char *strsignal(int signum);
+char *strsignal(int signum);
 
 #endif /* SIGNAL_H */

--- a/include/string.h
+++ b/include/string.h
@@ -16,6 +16,7 @@ int vstrncmp(const char *s1, const char *s2, size_t n);
 int strcmp(const char *s1, const char *s2);
 char *strchr(const char *s, int c);
 char *strdup(const char *s);
+char *strndup(const char *s, size_t n);
 char *strncpy(char *dest, const char *src, size_t n);
 char *strcat(char *dest, const char *src);
 char *strncat(char *dest, const char *src, size_t n);

--- a/src/signal.c
+++ b/src/signal.c
@@ -105,11 +105,11 @@ static const struct sig_name sig_names[] = {
     { 0, NULL }
 };
 
-const char *strsignal(int signum)
+char *strsignal(int signum)
 {
     for (size_t i = 0; sig_names[i].name; ++i) {
         if (sig_names[i].num == signum)
-            return sig_names[i].name;
+            return (char *)sig_names[i].name;
     }
     return "Unknown signal";
 }

--- a/src/strndup.c
+++ b/src/strndup.c
@@ -1,0 +1,13 @@
+#include "string.h"
+#include "memory.h"
+
+char *strndup(const char *s, size_t n)
+{
+    size_t len = strnlen(s, n);
+    char *dup = malloc(len + 1);
+    if (!dup)
+        return NULL;
+    vmemcpy(dup, s, len);
+    dup[len] = '\0';
+    return dup;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -579,6 +579,19 @@ static const char *test_strlcpy_cat(void)
     return 0;
 }
 
+static const char *test_strndup_basic(void)
+{
+    char *p = strndup("hello", 10);
+    mu_assert("strndup copy", p && strcmp(p, "hello") == 0);
+    free(p);
+
+    p = strndup("truncate", 4);
+    mu_assert("strndup trunc", p && strcmp(p, "trun") == 0);
+    free(p);
+
+    return 0;
+}
+
 static const char *test_widechar_basic(void)
 {
     wchar_t wc = 0;
@@ -1653,6 +1666,7 @@ static const char *all_tests(void)
     mu_run_test(test_string_helpers);
     mu_run_test(test_string_casecmp);
     mu_run_test(test_strlcpy_cat);
+    mu_run_test(test_strndup_basic);
     mu_run_test(test_widechar_basic);
     mu_run_test(test_widechar_conv);
     mu_run_test(test_strtok_basic);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -244,6 +244,7 @@ their access protections.
 The **string** module provides fundamental operations needed by most C programs:
 
 - `vstrlen`, `vstrcpy`, `vstrncmp`, `strnlen`, `strcat`, `strncat`, `strlcpy` and `strlcat` equivalents.
+- `strdup` and `strndup` helpers allocate new copies of strings.
 - Search helpers `strstr`, `strrchr`, and `memchr` for locating substrings or bytes.
 - Prefix scanners `strspn` and `strcspn` along with `strpbrk` for finding any character from a set.
 - Case-insensitive comparisons `strcasecmp` and `strncasecmp`.


### PR DESCRIPTION
## Summary
- declare `strndup` in public string header
- implement `strndup` using `malloc` and `strnlen`
- test copying and truncating behaviour of `strndup`
- document the helper in vlibcdoc
- expose our own `strsignal` declaration as `char *`

## Testing
- `make test` *(fails: `open should fail`)*

------
https://chatgpt.com/codex/tasks/task_e_6858d0130ea883248ba7f9b771b9b47b