### PR TITLE
Add glob path expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,8 @@ SRC := \
     src/pwd.c \
     src/math.c \
     src/math_extra.c \
-    src/regex.c
+    src/regex.c \
+    src/glob.c
 
 ARCH_SRC := $(wildcard src/arch/$(ARCH)/*.c)
 SRC += $(if $(ARCH_SRC),$(ARCH_SRC),src/setjmp.c)

--- a/include/glob.h
+++ b/include/glob.h
@@ -1,0 +1,26 @@
+#ifndef GLOB_H
+#define GLOB_H
+
+#include <stddef.h>
+
+/* result structure for glob matches */
+typedef struct {
+    size_t gl_pathc;  /* number of matched paths */
+    char **gl_pathv;  /* NULL terminated list of matches */
+    size_t gl_offs;   /* reserved */
+} glob_t;
+
+/* glob flags */
+#define GLOB_NOSORT   0x01
+#define GLOB_NOESCAPE 0x02
+
+/* error codes */
+#define GLOB_NOMATCH  1
+#define GLOB_NOSPACE  2
+#define GLOB_ABORTED  3
+
+int glob(const char *pattern, int flags,
+         int (*errfunc)(const char *epath, int eerrno), glob_t *pglob);
+void globfree(glob_t *pglob);
+
+#endif /* GLOB_H */

--- a/src/glob.c
+++ b/src/glob.c
@@ -1,0 +1,141 @@
+#include "glob.h"
+#include "string.h"
+#include "memory.h"
+#include "stdlib.h"
+#include "dirent.h"
+#include <fnmatch.h>
+#include <errno.h>
+
+static char *join_path(const char *base, const char *name)
+{
+    size_t blen = base ? strlen(base) : 0;
+    size_t add = (blen && base[blen-1] != '/') ? 1 : 0;
+    size_t nlen = strlen(name);
+    char *res = malloc(blen + add + nlen + 1);
+    if (!res)
+        return NULL;
+    if (blen) {
+        memcpy(res, base, blen);
+        if (add)
+            res[blen] = '/';
+    }
+    size_t pos = blen + add;
+    memcpy(res + pos, name, nlen);
+    res[pos + nlen] = '\0';
+    return res;
+}
+
+static int add_match(glob_t *g, const char *path)
+{
+    char **tmp = realloc(g->gl_pathv, sizeof(char*) * (g->gl_pathc + 2));
+    if (!tmp)
+        return -1;
+    g->gl_pathv = tmp;
+    g->gl_pathv[g->gl_pathc] = strdup(path);
+    if (!g->gl_pathv[g->gl_pathc])
+        return -1;
+    g->gl_pathc++;
+    g->gl_pathv[g->gl_pathc] = NULL;
+    return 0;
+}
+
+static int cmp_str(const void *a, const void *b)
+{
+    const char *sa = *(const char *const*)a;
+    const char *sb = *(const char *const*)b;
+    return strcmp(sa, sb);
+}
+
+static int expand(const char *base, const char *pattern, glob_t *g, int flags,
+                  int (*errfunc)(const char *, int));
+
+static int handle_dir(const char *dir, const char *pattern, const char *rest,
+                      glob_t *g, int flags,
+                      int (*errfunc)(const char *, int))
+{
+    DIR *d = opendir(*dir ? dir : ".");
+    if (!d) {
+        if (errfunc)
+            errfunc(dir, errno);
+        return 0;
+    }
+    struct dirent *ent;
+    int ret = 0;
+    int fnm_flags = (flags & GLOB_NOESCAPE) ? FNM_NOESCAPE : 0;
+    while ((ent = readdir(d))) {
+        const char *name = ent->d_name;
+        if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
+            continue;
+        if (fnmatch(pattern, name, fnm_flags) == 0) {
+            char *next = join_path(dir, name);
+            if (!next) { ret = GLOB_NOSPACE; break; }
+            if (rest) {
+                ret = expand(next, rest, g, flags, errfunc);
+            } else {
+                if (add_match(g, next) < 0)
+                    ret = GLOB_NOSPACE;
+            }
+            free(next);
+            if (ret)
+                break;
+        }
+    }
+    closedir(d);
+    return ret;
+}
+
+static int expand(const char *base, const char *pattern, glob_t *g, int flags,
+                  int (*errfunc)(const char *, int))
+{
+    while (*pattern == '/')
+        pattern++;
+    const char *slash = strchr(pattern, '/');
+    if (!slash)
+        return handle_dir(base, pattern, NULL, g, flags, errfunc);
+
+    size_t len = (size_t)(slash - pattern);
+    char part[len + 1];
+    memcpy(part, pattern, len);
+    part[len] = '\0';
+    const char *rest = slash[1] ? slash + 1 : NULL;
+
+    return handle_dir(base, part, rest, g, flags, errfunc);
+}
+
+int glob(const char *pattern, int flags,
+         int (*errfunc)(const char *epath, int eerrno), glob_t *pglob)
+{
+    if (!pglob)
+        return GLOB_ABORTED;
+    pglob->gl_pathc = 0;
+    pglob->gl_pathv = NULL;
+    pglob->gl_offs = 0;
+
+    if (!pattern)
+        return GLOB_ABORTED;
+
+    int ret;
+    if (pattern[0] == '/')
+        ret = expand("/", pattern + 1, pglob, flags, errfunc);
+    else
+        ret = expand("", pattern, pglob, flags, errfunc);
+
+    if (ret == 0 && pglob->gl_pathc == 0)
+        ret = GLOB_NOMATCH;
+    if (ret == 0 && !(flags & GLOB_NOSORT))
+        qsort(pglob->gl_pathv, pglob->gl_pathc, sizeof(char*), cmp_str);
+    return ret;
+}
+
+void globfree(glob_t *pglob)
+{
+    if (!pglob)
+        return;
+    for (size_t i = 0; i < pglob->gl_pathc; i++)
+        free(pglob->gl_pathv[i]);
+    free(pglob->gl_pathv);
+    pglob->gl_pathv = NULL;
+    pglob->gl_pathc = 0;
+    pglob->gl_offs = 0;
+}
+

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -32,15 +32,16 @@ This document outlines the architecture, planned modules, and API design for **v
 26. [File Status](#file-status)
 27. [Directory Iteration](#directory-iteration)
 28. [Path Canonicalization](#path-canonicalization)
-29. [User Database](#user-database)
-30. [Time Formatting](#time-formatting)
-31. [Locale Support](#locale-support)
-32. [Time Retrieval](#time-retrieval)
-33. [Sleep Functions](#sleep-functions)
-34. [Raw System Calls](#raw-system-calls)
-35. [Non-local Jumps](#non-local-jumps)
-36. [Limitations](#limitations)
-37. [Conclusion](#conclusion)
+29. [Path Expansion](#path-expansion)
+30. [User Database](#user-database)
+31. [Time Formatting](#time-formatting)
+32. [Locale Support](#locale-support)
+33. [Time Retrieval](#time-retrieval)
+34. [Sleep Functions](#sleep-functions)
+35. [Raw System Calls](#raw-system-calls)
+36. [Non-local Jumps](#non-local-jumps)
+37. [Limitations](#limitations)
+38. [Conclusion](#conclusion)
 
 ## Overview
 
@@ -753,6 +754,24 @@ directory.
 char buf[256];
 realpath("tests/../", buf); // buf now holds the absolute path to the repository
 ```
+
+## Path Expansion
+
+`glob` expands wildcard patterns like `*.c` into a list of matching
+paths. It iterates through directories using `opendir` and
+`readdir` and compares entries with `fnmatch`.
+
+```c
+glob_t g;
+if (glob("src/*.c", 0, NULL, &g) == 0) {
+    for (size_t i = 0; i < g.gl_pathc; i++)
+        printf("%s\n", g.gl_pathv[i]);
+    globfree(&g);
+}
+```
+
+Results are sorted by default; pass `GLOB_NOSORT` to preserve the
+filesystem order.
 
 ## User Database
 


### PR DESCRIPTION
## Summary
- implement lightweight glob and globfree
- expose API in new `glob.h`
- hook glob into the build
- document path expansion API

## Testing
- `make test` *(fails: "open should fail", Tests run: 15)*

------
https://chatgpt.com/codex/tasks/task_e_6858d2100a008324af45ecfa29466346