### PR TITLE
Implement posix_spawn wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ char word[16];
 sscanf("42 example", "%d %s", &num, word);
 ```
 
+Launching a program in a new process with `posix_spawn` is similarly easy:
+
+```c
+pid_t pid;
+char *args[] = {"/bin/echo", "spawn", NULL};
+posix_spawn(&pid, "/bin/echo", NULL, NULL, args, environ);
+waitpid(pid, NULL, 0);
+```
+
 For detailed documentation, see [vlibcdoc.md](vlibcdoc.md).
 
 ## Time Retrieval

--- a/include/process.h
+++ b/include/process.h
@@ -19,4 +19,15 @@ void exit(int status);
 typedef void (*sighandler_t)(int);
 sighandler_t signal(int signum, sighandler_t handler);
 
+typedef struct { int __dummy; } posix_spawnattr_t;
+typedef struct { int __dummy; } posix_spawn_file_actions_t;
+int posix_spawn(pid_t *pid, const char *path,
+                const posix_spawn_file_actions_t *file_actions,
+                const posix_spawnattr_t *attrp,
+                char *const argv[], char *const envp[]);
+int posix_spawnp(pid_t *pid, const char *file,
+                 const posix_spawn_file_actions_t *file_actions,
+                 const posix_spawnattr_t *attrp,
+                 char *const argv[], char *const envp[]);
+
 #endif /* PROCESS_H */

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1254,6 +1254,20 @@ static const char *test_execvp_fn(void)
     return 0;
 }
 
+static const char *test_posix_spawn_fn(void)
+{
+    extern char **__environ;
+    env_init(__environ);
+    pid_t pid;
+    char *argv[] = {"/bin/echo", "spawn", NULL};
+    int r = posix_spawn(&pid, "/bin/echo", NULL, NULL, argv, __environ);
+    mu_assert("posix_spawn", r == 0);
+    int status = 0;
+    waitpid(pid, &status, 0);
+    mu_assert("spawn status", WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    return 0;
+}
+
 static const char *test_popen_fn(void)
 {
     FILE *f = popen("echo popen", "r");
@@ -1736,6 +1750,7 @@ static const char *all_tests(void)
     mu_run_test(test_strsignal_names);
     mu_run_test(test_system_fn);
     mu_run_test(test_execvp_fn);
+    mu_run_test(test_posix_spawn_fn);
     mu_run_test(test_popen_fn);
     mu_run_test(test_rand_fn);
     mu_run_test(test_temp_files);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -386,6 +386,14 @@ and installing signal handlers.  The companion `signal.h` header offers
 pid_t fork(void);
 int execve(const char *pathname, char *const argv[], char *const envp[]);
 int execvp(const char *file, char *const argv[]);
+int posix_spawn(pid_t *pid, const char *path,
+                const posix_spawn_file_actions_t *file_actions,
+                const posix_spawnattr_t *attrp,
+                char *const argv[], char *const envp[]);
+int posix_spawnp(pid_t *pid, const char *file,
+                 const posix_spawn_file_actions_t *file_actions,
+                 const posix_spawnattr_t *attrp,
+                 char *const argv[], char *const envp[]);
 pid_t waitpid(pid_t pid, int *status, int options);
 int kill(pid_t pid, int sig);
 pid_t getpid(void);
@@ -403,11 +411,9 @@ void exit(int status);
 
 ```c
 /* Spawn a child that prints a message and wait for it to finish. */
-pid_t pid = fork();
-if (pid == 0) {
-    char *args[] = {"/bin/echo", "hello", NULL};
-    execve("/bin/echo", args, NULL);
-}
+pid_t pid;
+char *args[] = {"/bin/echo", "hello", NULL};
+posix_spawn(&pid, "/bin/echo", NULL, NULL, args, environ);
 waitpid(pid, NULL, 0);
 
 /* Install a handler and send the process an interrupt. */


### PR DESCRIPTION
## Summary
- introduce `posix_spawn` and `posix_spawnp` APIs
- document spawning processes in README and vlibcdoc
- add minimal tests using `posix_spawn`

## Testing
- `make -j$(nproc)`
- `make test` *(fails: `open should fail`)*

------
https://chatgpt.com/codex/tasks/task_e_6858d219b53083249088e9f11abdda54