### PR TITLE
Add BSD syslog wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ SRC := \
     src/wchar.c \
     src/wchar_conv.c \
     src/tempfile.c \
+    src/syslog.c \
     src/getline.c \
     src/pwd.c \
     src/math.c \

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ programs. Key features include:
 - Dynamic loading
 - Environment variable handling
 - Host name queries and changes
+- Syslog-style logging
 
 **Note**: vlibc provides only a small subset of the standard C library. Some
 functions depend on system calls that are currently implemented for Linux. BSD

--- a/include/syslog.h
+++ b/include/syslog.h
@@ -1,0 +1,38 @@
+#ifndef SYSLOG_H
+#define SYSLOG_H
+
+#include <stdarg.h>
+
+/* syslog priorities */
+#define LOG_EMERG   0
+#define LOG_ALERT   1
+#define LOG_CRIT    2
+#define LOG_ERR     3
+#define LOG_WARNING 4
+#define LOG_NOTICE  5
+#define LOG_INFO    6
+#define LOG_DEBUG   7
+
+/* facilities */
+#define LOG_KERN    (0<<3)
+#define LOG_USER    (1<<3)
+#define LOG_DAEMON  (3<<3)
+#define LOG_AUTH    (4<<3)
+#define LOG_SYSLOG  (5<<3)
+#define LOG_LOCAL0  (16<<3)
+#define LOG_LOCAL1  (17<<3)
+#define LOG_LOCAL2  (18<<3)
+#define LOG_LOCAL3  (19<<3)
+#define LOG_LOCAL4  (20<<3)
+#define LOG_LOCAL5  (21<<3)
+#define LOG_LOCAL6  (22<<3)
+#define LOG_LOCAL7  (23<<3)
+
+/* options */
+#define LOG_PID     0x01
+
+void openlog(const char *ident, int option, int facility);
+void syslog(int priority, const char *format, ...);
+void closelog(void);
+
+#endif /* SYSLOG_H */

--- a/src/syslog.c
+++ b/src/syslog.c
@@ -1,0 +1,81 @@
+#include "syslog.h"
+#include "string.h"
+#include "stdio.h"
+#include "process.h"
+#include "io.h"
+#include "errno.h"
+#include "sys/socket.h"
+#include <sys/un.h>
+#include <unistd.h>
+#include <stdarg.h>
+
+static int log_fd = -1;
+static int log_facility = LOG_USER;
+static int log_option = 0;
+static char log_ident[32] = "";
+
+void openlog(const char *ident, int option, int facility)
+{
+    if (ident)
+        strlcpy(log_ident, ident, sizeof(log_ident));
+    else
+        log_ident[0] = '\0';
+
+    log_option = option;
+    log_facility = facility;
+
+    if (log_fd != -1) {
+        close(log_fd);
+        log_fd = -1;
+    }
+
+    log_fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+    if (log_fd < 0)
+        return;
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strlcpy(addr.sun_path, "/dev/log", sizeof(addr.sun_path));
+    connect(log_fd, (struct sockaddr *)&addr, sizeof(addr));
+}
+
+void closelog(void)
+{
+    if (log_fd != -1) {
+        close(log_fd);
+        log_fd = -1;
+    }
+}
+
+void syslog(int priority, const char *format, ...)
+{
+    if (log_fd == -1)
+        openlog(NULL, 0, LOG_USER);
+
+    char msg[256];
+    va_list ap;
+    va_start(ap, format);
+    int len = vsnprintf(msg, sizeof(msg), format, ap);
+    va_end(ap);
+    if (len < 0)
+        return;
+    if (len >= (int)sizeof(msg))
+        len = sizeof(msg) - 1;
+
+    char buf[300];
+    int n = snprintf(buf, sizeof(buf), "<%d>", priority | log_facility);
+    if (log_ident[0]) {
+        n += snprintf(buf + n, sizeof(buf) - n, "%s", log_ident);
+        if (log_option & LOG_PID)
+            n += snprintf(buf + n, sizeof(buf) - n, "[%d]", getpid());
+        n += snprintf(buf + n, sizeof(buf) - n, ": ");
+    }
+    if ((size_t)(n + len) >= sizeof(buf))
+        len = sizeof(buf) - n - 1;
+    memcpy(buf + n, msg, len);
+    n += len;
+
+    if (log_fd != -1)
+        send(log_fd, buf, n, 0);
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -37,10 +37,11 @@ This document outlines the architecture, planned modules, and API design for **v
 31. [Locale Support](#locale-support)
 32. [Time Retrieval](#time-retrieval)
 33. [Sleep Functions](#sleep-functions)
-34. [Raw System Calls](#raw-system-calls)
-35. [Non-local Jumps](#non-local-jumps)
-36. [Limitations](#limitations)
-37. [Conclusion](#conclusion)
+34. [Logging](#logging)
+35. [Raw System Calls](#raw-system-calls)
+36. [Non-local Jumps](#non-local-jumps)
+37. [Limitations](#limitations)
+38. [Conclusion](#conclusion)
 
 ## Overview
 
@@ -808,6 +809,21 @@ unsigned sleep(unsigned seconds);
 int usleep(useconds_t usec);
 int nanosleep(const struct timespec *req, struct timespec *rem);
 ```
+
+## Logging
+
+`syslog.h` provides simple helpers to send log messages to `/dev/log` on
+BSD-style systems. Call `openlog` once with an identifier then use `syslog`
+with a priority and `printf`-style format:
+
+```c
+openlog("myapp", LOG_PID, LOG_USER);
+syslog(LOG_INFO, "started with %d workers", workers);
+closelog();
+```
+
+Messages are written using a Unix datagram socket so applications can integrate
+with the host's syslog daemon.
 
 ## Raw System Calls
 


### PR DESCRIPTION
## Summary
- add simple syslog.h with priority and facility constants
- implement openlog/closelog/syslog using `/dev/log`
- compile new source
- document logging helpers
- mention the feature in README

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858d22127c48324853590fe3145f555