### PR TITLE
Add unistd.h header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,8 @@ install: $(LIB)
 	install -m 644 $(LIB) $(DESTDIR)$(PREFIX)/lib
 	install -d $(DESTDIR)$(PREFIX)/include
 	install -m 644 include/*.h $(DESTDIR)$(PREFIX)/include
+	# ensure the new unistd.h header is installed
+	install -m 644 include/unistd.h $(DESTDIR)$(PREFIX)/include
 	install -d $(DESTDIR)$(PREFIX)/include/sys
 	install -m 644 include/sys/*.h $(DESTDIR)$(PREFIX)/include/sys
 

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -1,0 +1,25 @@
+#ifndef UNISTD_H
+#define UNISTD_H
+
+#include <sys/types.h>
+#include "io.h"
+#include "process.h"
+#include "env.h"
+
+#ifndef STDIN_FILENO
+#define STDIN_FILENO 0
+#endif
+#ifndef STDOUT_FILENO
+#define STDOUT_FILENO 1
+#endif
+#ifndef STDERR_FILENO
+#define STDERR_FILENO 2
+#endif
+
+#ifndef SEEK_SET
+#define SEEK_SET 0
+#define SEEK_CUR 1
+#define SEEK_END 2
+#endif
+
+#endif /* UNISTD_H */

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -164,6 +164,7 @@ stdio.h      - simple stream I/O
 stdlib.h     - basic utilities
 string.h     - string manipulation
 regex.h     - simple regular expression matching
+unistd.h    - POSIX I/O and process helpers
 sys/file.h   - file permission helpers
 sys/mman.h   - memory mapping helpers
 sys/select.h - fd_set macros and select wrapper


### PR DESCRIPTION
## Summary
- add `include/unistd.h` exposing common POSIX helpers and macros
- install the new header via Makefile
- document `unistd.h` in `vlibcdoc.md`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6858d2cae32083249f50268633b2af0b