### PR TITLE
Add isatty wrapper and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ SRC := \
     src/inet_pton.c \
     src/inet_ntop.c \
     src/fd.c \
+    src/isatty.c \
     src/file.c \
     src/file_perm.c \
     src/truncate.c \

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -1,0 +1,12 @@
+#ifndef UNISTD_H
+#define UNISTD_H
+
+#if defined(__has_include)
+#  if __has_include_next(<unistd.h>)
+#    include_next <unistd.h>
+#  endif
+#endif
+
+int isatty(int fd);
+
+#endif /* UNISTD_H */

--- a/src/isatty.c
+++ b/src/isatty.c
@@ -1,0 +1,32 @@
+#include "unistd.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+#ifndef __has_include
+#define __has_include(x) 0
+#endif
+#if __has_include(<termios.h>)
+#include <termios.h>
+#endif
+
+int isatty(int fd)
+{
+#ifdef SYS_isatty
+    long ret = vlibc_syscall(SYS_isatty, fd, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return 0;
+    }
+    return (int)ret;
+#else
+#if __has_include(<termios.h>)
+    struct termios t;
+    return tcgetattr(fd, &t) == 0;
+#else
+    (void)fd;
+    errno = ENOTTY;
+    return 0;
+#endif
+#endif
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -318,6 +318,19 @@ static const char *test_pipe2_cloexec(void)
     return 0;
 }
 
+static const char *test_isatty_stdin(void)
+{
+    int fd = open("tmp_isatty_file", O_CREAT | O_RDWR, 0644);
+    mu_assert("open", fd >= 0);
+    int stdin_tty = isatty(0);
+    int file_tty = isatty(fd);
+    close(fd);
+    unlink("tmp_isatty_file");
+    mu_assert("file not tty", file_tty == 0);
+    mu_assert("stdin result valid", stdin_tty == 0 || stdin_tty == 1);
+    return 0;
+}
+
 static const char *test_udp_send_recv(void)
 {
     int s1 = socket(AF_INET, SOCK_DGRAM, 0);
@@ -1722,6 +1735,7 @@ static const char *all_tests(void)
     mu_run_test(test_pread_pwrite);
     mu_run_test(test_dup3_cloexec);
     mu_run_test(test_pipe2_cloexec);
+    mu_run_test(test_isatty_stdin);
     mu_run_test(test_socket);
     mu_run_test(test_socketpair_basic);
     mu_run_test(test_udp_send_recv);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -606,6 +606,8 @@ int pipefd[2];
 pipe(pipefd);
 ```
 
+Use `isatty(fd)` to query whether a descriptor refers to a terminal.
+
 ## Standard Streams
 
 `stdin`, `stdout`, and `stderr` are lightweight streams wrapping file


### PR DESCRIPTION
## Summary
- declare `isatty` in `unistd.h`
- implement `isatty` with syscall or `tcgetattr`
- compile new source file
- test terminal detection of `isatty`
- document the helper in I/O docs

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858d2dc632c83249a53323831a98060