### PR TITLE
Add statvfs support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ SRC := \
     src/time_r.c \
     src/strftime.c \
     src/stat.c \
+    src/statvfs.c \
     src/utime.c \
     src/pthread.c \
     src/dirent.c \

--- a/include/sys/statvfs.h
+++ b/include/sys/statvfs.h
@@ -1,0 +1,19 @@
+#ifndef SYS_STATVFS_H
+#define SYS_STATVFS_H
+
+#include <sys/types.h>
+
+#if defined(__has_include)
+#  if __has_include("/usr/include/x86_64-linux-gnu/sys/statvfs.h")
+#    include "/usr/include/x86_64-linux-gnu/sys/statvfs.h"
+#  elif __has_include("/usr/include/sys/statvfs.h")
+#    include "/usr/include/sys/statvfs.h"
+#  endif
+#endif
+
+struct statvfs;
+
+int statvfs(const char *path, struct statvfs *buf);
+int fstatvfs(int fd, struct statvfs *buf);
+
+#endif /* SYS_STATVFS_H */

--- a/src/statvfs.c
+++ b/src/statvfs.c
@@ -1,0 +1,98 @@
+#include "sys/statvfs.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+
+extern int host_statvfs(const char *, struct statvfs *) __asm__("statvfs");
+extern int host_fstatvfs(int, struct statvfs *) __asm__("fstatvfs");
+
+int statvfs(const char *path, struct statvfs *buf)
+{
+    return host_statvfs(path, buf);
+}
+
+int fstatvfs(int fd, struct statvfs *buf)
+{
+    return host_fstatvfs(fd, buf);
+}
+
+#else
+
+#include <sys/statfs.h>
+
+static void cvt(struct statvfs *out, const struct statfs *in)
+{
+    out->f_bsize = in->f_bsize;
+#ifdef _STATFS_F_FRSIZE
+    out->f_frsize = in->f_frsize;
+#else
+    out->f_frsize = in->f_bsize;
+#endif
+    out->f_blocks = in->f_blocks;
+    out->f_bfree = in->f_bfree;
+    out->f_bavail = in->f_bavail;
+    out->f_files = in->f_files;
+    out->f_ffree = in->f_ffree;
+    out->f_favail = in->f_ffree;
+#ifdef __FSID_T_TYPE
+    out->f_fsid = ((unsigned long)in->f_fsid.__val[0] & 0xffffffffUL) |
+                  ((unsigned long)in->f_fsid.__val[1] << 32);
+#else
+    out->f_fsid = (unsigned long)in->f_fsid;
+#endif
+#ifdef _STATFS_F_FLAGS
+    out->f_flag = in->f_flags;
+#else
+    out->f_flag = 0;
+#endif
+#ifdef _STATFS_F_NAMELEN
+    out->f_namemax = in->f_namelen;
+#else
+    out->f_namemax = 255;
+#endif
+    out->f_type = in->f_type;
+    for (int i = 0; i < 5; i++)
+        out->__f_spare[i] = 0;
+}
+
+int statvfs(const char *path, struct statvfs *buf)
+{
+#ifdef SYS_statfs
+    struct statfs s;
+    long ret = vlibc_syscall(SYS_statfs, (long)path, (long)&s, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    cvt(buf, &s);
+    return 0;
+#else
+    (void)path; (void)buf;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+int fstatvfs(int fd, struct statvfs *buf)
+{
+#ifdef SYS_fstatfs
+    struct statfs s;
+    long ret = vlibc_syscall(SYS_fstatfs, fd, (long)&s, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    cvt(buf, &s);
+    return 0;
+#else
+    (void)fd; (void)buf;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+#endif

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -30,20 +30,21 @@ This document outlines the architecture, planned modules, and API design for **v
 24. [I/O Multiplexing](#io-multiplexing)
 25. [File Permissions](#file-permissions)
 26. [File Status](#file-status)
-27. [Directory Iteration](#directory-iteration)
-28. [Path Canonicalization](#path-canonicalization)
-29. [Path Utilities](#path-utilities)
-30. [User Database](#user-database)
-31. [Time Formatting](#time-formatting)
-32. [Locale Support](#locale-support)
-33. [Time Retrieval](#time-retrieval)
-34. [Sleep Functions](#sleep-functions)
-35. [Raw System Calls](#raw-system-calls)
-36. [Non-local Jumps](#non-local-jumps)
-37. [Limitations](#limitations)
-38. [Conclusion](#conclusion)
-39. [Logging](#logging)
-40. [Path Expansion](#path-expansion)
+27. [Filesystem Statistics](#filesystem-statistics)
+28. [Directory Iteration](#directory-iteration)
+29. [Path Canonicalization](#path-canonicalization)
+30. [Path Utilities](#path-utilities)
+31. [User Database](#user-database)
+32. [Time Formatting](#time-formatting)
+33. [Locale Support](#locale-support)
+34. [Time Retrieval](#time-retrieval)
+35. [Sleep Functions](#sleep-functions)
+36. [Raw System Calls](#raw-system-calls)
+37. [Non-local Jumps](#non-local-jumps)
+38. [Limitations](#limitations)
+39. [Conclusion](#conclusion)
+40. [Logging](#logging)
+41. [Path Expansion](#path-expansion)
 
 ## Overview
 
@@ -173,6 +174,7 @@ sys/mman.h   - memory mapping helpers
 sys/select.h - fd_set macros and select wrapper
 sys/socket.h - networking wrappers
 sys/stat.h   - file status functions
+sys/statvfs.h - filesystem statistics
 syscall.h    - raw syscall interface
 time.h       - time related helpers
 vlibc.h      - library initialization
@@ -737,6 +739,21 @@ file:
 ```c
 struct utimbuf t = { .actime = 1625097600, .modtime = 1625097600 };
 utime("data.txt", &t);
+```
+
+## Filesystem Statistics
+
+`statvfs` and `fstatvfs` from `sys/statvfs.h` report details about the
+underlying filesystem such as block size and available space. On Linux
+the vlibc wrappers issue the `statfs`/`fstatfs` syscalls and translate the
+results. On BSD systems they simply call the host C library
+implementations.
+
+```c
+struct statvfs sv;
+if (statvfs("/", &sv) == 0) {
+    printf("%lu blocks free\n", (unsigned long)sv.f_bfree);
+}
 ```
 
 ## Directory Iteration


### PR DESCRIPTION
## Summary
- introduce `sys/statvfs.h` with struct and prototypes
- implement `statvfs` and `fstatvfs` wrappers
- register new module in build
- document filesystem statistics usage

## Testing
- `make`
- `make test` *(fails: "open should fail" and exits 1)*

------
https://chatgpt.com/codex/tasks/task_e_6858d823fe348324a86794fc8e8e08c8