### PR TITLE
Add simple fnmatch implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ SRC := \
     src/pwd.c \
     src/math.c \
     src/math_extra.c \
+    src/fnmatch.c \
     src/regex.c \
     src/glob.c
 

--- a/include/fnmatch.h
+++ b/include/fnmatch.h
@@ -1,0 +1,11 @@
+#ifndef FNMATCH_H
+#define FNMATCH_H
+
+/* pattern matching for filenames */
+
+#define FNM_NOESCAPE 0x01
+#define FNM_NOMATCH  1
+
+int fnmatch(const char *pattern, const char *string, int flags);
+
+#endif /* FNMATCH_H */

--- a/src/fnmatch.c
+++ b/src/fnmatch.c
@@ -1,0 +1,91 @@
+#include "fnmatch.h"
+#include "string.h"
+
+static int match_range(const char *p, char c, int flags, const char **end)
+{
+    int negate = 0;
+    int match = 0;
+    size_t i = 1;
+
+    if (p[i] == '!' || p[i] == '^') {
+        negate = 1;
+        i++;
+    }
+
+    for (; p[i]; i++) {
+        char pc = p[i];
+        if (pc == ']' && i > 1 + negate)
+            break;
+        if (pc == '\\' && !(flags & FNM_NOESCAPE)) {
+            i++;
+            pc = p[i];
+        }
+        if (p[i + 1] == '-' && p[i + 2] && p[i + 2] != ']') {
+            char start = pc;
+            i += 2;
+            char endc = p[i];
+            if (endc == '\\' && !(flags & FNM_NOESCAPE)) {
+                i++;
+                endc = p[i];
+            }
+            if (c >= start && c <= endc)
+                match = 1;
+        } else {
+            if (c == pc)
+                match = 1;
+        }
+    }
+
+    if (p[i] != ']') {
+        *end = p + 1;
+        return (c == '[');
+    }
+    *end = p + i + 1;
+    return negate ? !match : match;
+}
+
+int fnmatch(const char *pattern, const char *string, int flags)
+{
+    const char *p = pattern;
+    const char *s = string;
+
+    while (*p) {
+        if (*p == '?') {
+            if (*s == '\0')
+                return FNM_NOMATCH;
+            s++; p++;
+        } else if (*p == '*') {
+            while (*p == '*')
+                p++;
+            if (*p == '\0')
+                return 0;
+            while (*s) {
+                int r = fnmatch(p, s, flags);
+                if (r == 0)
+                    return 0;
+                s++;
+            }
+            return FNM_NOMATCH;
+        } else if (*p == '[') {
+            if (*s == '\0')
+                return FNM_NOMATCH;
+            const char *next;
+            if (!match_range(p, *s, flags, &next))
+                return FNM_NOMATCH;
+            s++; p = next;
+        } else if (*p == '\\' && !(flags & FNM_NOESCAPE)) {
+            p++;
+            if (*p == '\0')
+                return FNM_NOMATCH;
+            if (*p != *s)
+                return FNM_NOMATCH;
+            s++; p++;
+        } else {
+            if (*p != *s)
+                return FNM_NOMATCH;
+            s++; p++;
+        }
+    }
+    return *s ? FNM_NOMATCH : 0;
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -25,6 +25,7 @@
 #include "../include/pwd.h"
 #include "../include/process.h"
 #include "../include/getopt.h"
+#include "../include/fnmatch.h"
 #include "../include/math.h"
 #include "../include/locale.h"
 #include <unistd.h>
@@ -1612,6 +1613,16 @@ static const char *test_qsort_strings(void)
     return 0;
 }
 
+static const char *test_fnmatch_basic(void)
+{
+    mu_assert("star match", fnmatch("*.c", "foo.c", 0) == 0);
+    mu_assert("star miss", fnmatch("*.c", "foo.h", 0) == FNM_NOMATCH);
+    mu_assert("question", fnmatch("t?st", "test", 0) == 0);
+    mu_assert("range match", fnmatch("file.[ch]", "file.c", 0) == 0);
+    mu_assert("range miss", fnmatch("file.[ch]", "file.x", 0) == FNM_NOMATCH);
+    return 0;
+}
+
 static const char *test_math_functions(void)
 {
     mu_assert("fabs", fabs(-3.5) == 3.5);
@@ -1844,6 +1855,7 @@ static const char *all_tests(void)
     mu_run_test(test_dirent);
     mu_run_test(test_qsort_int);
     mu_run_test(test_qsort_strings);
+    mu_run_test(test_fnmatch_basic);
     mu_run_test(test_math_functions);
     mu_run_test(test_getopt_basic);
     mu_run_test(test_getopt_missing);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -45,6 +45,7 @@ This document outlines the architecture, planned modules, and API design for **v
 39. [Conclusion](#conclusion)
 40. [Logging](#logging)
 41. [Path Expansion](#path-expansion)
+42. [Filename Matching](#filename-matching)
 
 ## Overview
 
@@ -813,6 +814,18 @@ if (glob("src/*.c", 0, NULL, &g) == 0) {
 
 Results are sorted by default; pass `GLOB_NOSORT` to preserve the
 filesystem order.
+
+## Filename Matching
+
+`fnmatch` compares a filename against a pattern containing `*`, `?` and
+character classes. Backslashes escape special characters unless the
+`FNM_NOESCAPE` flag is provided.
+
+```c
+if (fnmatch("*.c", "example.c", 0) == 0) {
+    /* matched */
+}
+```
 
 ## User Database
 


### PR DESCRIPTION
## Summary
- implement `fnmatch` with wildcard and character class support
- expose new function in `include/fnmatch.h`
- compile new source file
- document usage in `vlibcdoc.md`
- test `fnmatch` via unit test

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858d9fdb5d08324b4bb0619b23ceb08