### PR TITLE
Add pthread condition variable primitives

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -15,6 +15,10 @@ typedef struct {
     atomic_flag locked;
 } pthread_mutex_t;
 
+typedef struct {
+    atomic_int seq;
+} pthread_cond_t;
+
 int pthread_create(pthread_t *thread, const void *attr,
                    void *(*start_routine)(void *), void *arg);
 int pthread_join(pthread_t thread, void **retval);
@@ -24,5 +28,10 @@ int pthread_mutex_init(pthread_mutex_t *mutex, void *attr);
 int pthread_mutex_destroy(pthread_mutex_t *mutex);
 int pthread_mutex_lock(pthread_mutex_t *mutex);
 int pthread_mutex_unlock(pthread_mutex_t *mutex);
+
+int pthread_cond_init(pthread_cond_t *cond, void *attr);
+int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex);
+int pthread_cond_signal(pthread_cond_t *cond);
+int pthread_cond_broadcast(pthread_cond_t *cond);
 
 #endif /* PTHREAD_H */

--- a/src/pthread.c
+++ b/src/pthread.c
@@ -2,6 +2,7 @@
 #include_next <pthread.h>
 #include <errno.h>
 #include <stdatomic.h>
+#include "time.h"
 
 /* simple spinlock based mutex */
 int pthread_mutex_init(pthread_mutex_t *mutex, void *attr)
@@ -29,4 +30,34 @@ int pthread_mutex_destroy(pthread_mutex_t *mutex)
 {
     (void)mutex;
     return 0;
+}
+
+int pthread_cond_init(pthread_cond_t *cond, void *attr)
+{
+    (void)attr;
+    atomic_store(&cond->seq, 0);
+    return 0;
+}
+
+int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
+{
+    int seq = atomic_load_explicit(&cond->seq, memory_order_relaxed);
+    pthread_mutex_unlock(mutex);
+    while (atomic_load_explicit(&cond->seq, memory_order_acquire) == seq) {
+        struct timespec ts = {0, 1000000};
+        nanosleep(&ts, NULL);
+    }
+    pthread_mutex_lock(mutex);
+    return 0;
+}
+
+int pthread_cond_signal(pthread_cond_t *cond)
+{
+    atomic_fetch_add_explicit(&cond->seq, 1, memory_order_release);
+    return 0;
+}
+
+int pthread_cond_broadcast(pthread_cond_t *cond)
+{
+    return pthread_cond_signal(cond);
 }

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -489,6 +489,11 @@ int pthread_mutex_init(pthread_mutex_t *mutex, void *attr);
 int pthread_mutex_destroy(pthread_mutex_t *mutex);
 int pthread_mutex_lock(pthread_mutex_t *mutex);
 int pthread_mutex_unlock(pthread_mutex_t *mutex);
+
+int pthread_cond_init(pthread_cond_t *cond, void *attr);
+int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex);
+int pthread_cond_signal(pthread_cond_t *cond);
+int pthread_cond_broadcast(pthread_cond_t *cond);
 ```
 
 Threads share the process address space and use a simple spinlock-based
@@ -508,6 +513,11 @@ Mutex routines provide minimal mutual exclusion. `pthread_mutex_init()`
 initializes a mutex, `pthread_mutex_lock()` acquires it, and
 `pthread_mutex_unlock()` releases it.  Destroying a locked mutex with
 `pthread_mutex_destroy()` is undefined.
+
+Condition variables provide simple waiting semantics. A thread calls
+`pthread_cond_wait()` with a locked mutex and blocks until another thread
+signals the condition. `pthread_cond_signal()` wakes a single waiter while
+`pthread_cond_broadcast()` wakes all waiters.
 
 ### Example
 


### PR DESCRIPTION
## Summary
- introduce `pthread_cond_t` and basic condition variable functions
- implement simple spin-based wait/signaling logic
- document condition variable routines in vlibc documentation

## Testing
- `make test` *(fails: open should fail)*

------
https://chatgpt.com/codex/tasks/task_e_6858da26a4e88324bedc18e790ab7aeb