### PR TITLE
Add access and faccessat wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ SRC := \
     src/file_perm.c \
     src/truncate.c \
     src/dir.c \
+    src/access.c \
     src/getcwd.c \
     src/realpath.c \
     src/path.c \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ packs only the most essential runtime components needed by portable C
 programs. Key features include:
 
 - File I/O wrappers
+- Permission checks with `access()` and `faccessat()`
 - Process creation and control
 - Threading primitives
 - Networking sockets

--- a/include/io.h
+++ b/include/io.h
@@ -25,5 +25,7 @@ ssize_t readlink(const char *pathname, char *buf, size_t bufsiz);
 int mkdir(const char *pathname, mode_t mode);
 int rmdir(const char *pathname);
 int chdir(const char *path);
+int access(const char *pathname, int mode);
+int faccessat(int dirfd, const char *pathname, int mode, int flags);
 
 #endif /* IO_H */

--- a/src/access.c
+++ b/src/access.c
@@ -1,0 +1,46 @@
+#include "io.h"
+#include "errno.h"
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int access(const char *pathname, int mode)
+{
+#ifdef SYS_access
+    long ret = vlibc_syscall(SYS_access, (long)pathname, mode, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#else
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_access(const char *, int) __asm__("access");
+    return host_access(pathname, mode);
+#else
+    (void)pathname; (void)mode; errno = ENOSYS; return -1;
+#endif
+#endif
+}
+
+int faccessat(int dirfd, const char *pathname, int mode, int flags)
+{
+#ifdef SYS_faccessat
+    long ret = vlibc_syscall(SYS_faccessat, dirfd, (long)pathname, mode, flags, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#else
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_faccessat(int, const char *, int, int) __asm__("faccessat");
+    return host_faccessat(dirfd, pathname, mode, flags);
+#else
+    (void)dirfd; (void)pathname; (void)mode; (void)flags; errno = ENOSYS; return -1;
+#endif
+#endif
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -606,6 +606,8 @@ Thin wrappers around the kernel's file APIs live in `io.h`. Functions
 like `open`, `read`, `write`, `close`, `unlink`, `rename`, `symlink`,
 `mkdir`, `rmdir`, `chdir`, and the file size controls `truncate` and
 `ftruncate` simply pass their arguments to the corresponding syscalls.
+`access` and `faccessat` query permissions on files without opening
+them.
 Vector I/O through `readv` and `writev` is available to gather or scatter
 multiple buffers in a single call.
 


### PR DESCRIPTION
## Summary
- implement `access` and `faccessat`
- export their prototypes
- compile new source
- document permission check helpers in docs
- mention access functions in README

## Testing
- `make`
- `make test` *(fails: no output due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_685962050460832484edb72364b48bfb