### PR TITLE
Implement basic strptime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ SRC := \
     src/time_conv.c \
     src/time_r.c \
     src/strftime.c \
+    src/strptime.c \
     src/stat.c \
     src/statvfs.c \
     src/utime.c \

--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ clock_gettime(CLOCK_MONOTONIC, &ts);
 
 `CLOCK_REALTIME` returns the wall-clock time.
 
+## Time Formatting
+
+`strftime` converts a `struct tm` to a human readable string. The
+complementary `strptime` can parse the same fields back into a `struct tm`:
+
+```c
+struct tm tm = {0};
+strptime("2023-05-06 07:08:09", "%Y-%m-%d %H:%M:%S", &tm);
+```
+
+Only `%Y`, `%m`, `%d`, `%H`, `%M`, and `%S` are understood.
+
 ## IPv6 Support
 
 Networking helpers such as `inet_pton`, `inet_ntop`, `getaddrinfo` and

--- a/include/time.h
+++ b/include/time.h
@@ -54,6 +54,7 @@ int usleep(useconds_t usec);
 int nanosleep(const struct timespec *req, struct timespec *rem);
 
 size_t strftime(char *s, size_t max, const char *format, const struct tm *tm);
+char *strptime(const char *s, const char *format, struct tm *tm);
 
 /* basic time conversion helpers */
 struct tm *gmtime(const time_t *timep);

--- a/src/strptime.c
+++ b/src/strptime.c
@@ -1,0 +1,82 @@
+#include "time.h"
+
+static int parse_num(const char **sp, int width)
+{
+    const char *s = *sp;
+    int val = 0;
+    for (int i = 0; i < width; i++) {
+        if (s[i] < '0' || s[i] > '9')
+            return -1;
+        val = val * 10 + (s[i] - '0');
+    }
+    *sp += width;
+    return val;
+}
+
+char *strptime(const char *s, const char *format, struct tm *tm)
+{
+    if (!s || !format || !tm)
+        return NULL;
+    const char *p = s;
+    for (; *format; ++format) {
+        if (*format != '%') {
+            if (*p != *format)
+                return NULL;
+            if (*p)
+                p++;
+            continue;
+        }
+        ++format;
+        if (!*format)
+            return NULL;
+        int v;
+        switch (*format) {
+        case '%':
+            if (*p != '%')
+                return NULL;
+            if (*p)
+                p++;
+            break;
+        case 'Y':
+            v = parse_num(&p, 4);
+            if (v < 0)
+                return NULL;
+            tm->tm_year = v - 1900;
+            break;
+        case 'm':
+            v = parse_num(&p, 2);
+            if (v < 1 || v > 12)
+                return NULL;
+            tm->tm_mon = v - 1;
+            break;
+        case 'd':
+            v = parse_num(&p, 2);
+            if (v < 1 || v > 31)
+                return NULL;
+            tm->tm_mday = v;
+            break;
+        case 'H':
+            v = parse_num(&p, 2);
+            if (v < 0 || v > 23)
+                return NULL;
+            tm->tm_hour = v;
+            break;
+        case 'M':
+            v = parse_num(&p, 2);
+            if (v < 0 || v > 59)
+                return NULL;
+            tm->tm_min = v;
+            break;
+        case 'S':
+            v = parse_num(&p, 2);
+            if (v < 0 || v > 60)
+                return NULL;
+            tm->tm_sec = v;
+            break;
+        default:
+            return NULL;
+        }
+    }
+    return (char *)p;
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1192,6 +1192,21 @@ static const char *test_strftime_basic(void)
     return 0;
 }
 
+static const char *test_strptime_basic(void)
+{
+    struct tm tm;
+    memset(&tm, 0, sizeof(tm));
+    char *r = strptime("2023-05-06 07:08:09", "%Y-%m-%d %H:%M:%S", &tm);
+    mu_assert("strptime ret", r && *r == '\0');
+    mu_assert("tm year", tm.tm_year == 123);
+    mu_assert("tm mon", tm.tm_mon == 4);
+    mu_assert("tm mday", tm.tm_mday == 6);
+    mu_assert("tm hour", tm.tm_hour == 7);
+    mu_assert("tm min", tm.tm_min == 8);
+    mu_assert("tm sec", tm.tm_sec == 9);
+    return 0;
+}
+
 static const char *test_time_conversions(void)
 {
     time_t t = 1700000000;
@@ -1915,6 +1930,7 @@ static const char *all_tests(void)
     mu_run_test(test_poll_pipe);
     mu_run_test(test_sleep_functions);
     mu_run_test(test_strftime_basic);
+    mu_run_test(test_strptime_basic);
     mu_run_test(test_time_conversions);
     mu_run_test(test_time_r_conversions);
     mu_run_test(test_environment);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -289,8 +289,9 @@ char *vowel = strpbrk(text, "aeiou");
 size_t prefix = strspn("abc123", "abc");
 ```
 
-Basic time formatting is available via `strftime`. Only a small subset of
- conversions is implemented (`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`) and the
+Basic time formatting is available via `strftime` and the matching
+`strptime` parser. Only a small subset of conversions is implemented
+(`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`) and the
  output uses the current locale. Non-`"C"` locales work when the host
  `setlocale(3)` accepts them (primarily on BSD systems).
 
@@ -934,6 +935,7 @@ running tests.
 ## Time Formatting
 
 A minimal `strftime` supports `%Y`, `%m`, `%d`, `%H`, `%M`, and `%S`.
+The `strptime` helper parses those same fields back into a `struct tm` and returns a pointer to the first unparsed character or `NULL` on failure.
 `timegm` converts a `struct tm` in UTC back to `time_t` using the same logic as `mktime` but without timezone adjustments.
 
 ## Locale Support


### PR DESCRIPTION
## Summary
- add a small `strptime` implementation
- expose `strptime` in `time.h`
- document usage in README and vlibcdoc
- add unit test for the parser

## Testing
- `make test` *(fails: Command timed out or was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6859686c628883249c83e32bc6ee55a1