### PR TITLE
Implement interval timers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ SRC := \
     src/time.c \
     src/time_conv.c \
     src/time_r.c \
+    src/itimer.c \
     src/strftime.c \
     src/strptime.c \
     src/stat.c \

--- a/include/time.h
+++ b/include/time.h
@@ -24,6 +24,21 @@ struct timeval {
 };
 #endif
 
+struct itimerval {
+    struct timeval it_interval; /* timer period */
+    struct timeval it_value;    /* time until next expiration */
+};
+
+#ifndef ITIMER_REAL
+#define ITIMER_REAL    0
+#endif
+#ifndef ITIMER_VIRTUAL
+#define ITIMER_VIRTUAL 1
+#endif
+#ifndef ITIMER_PROF
+#define ITIMER_PROF    2
+#endif
+
 struct tm {
     int tm_sec;   /* seconds [0,60] */
     int tm_min;   /* minutes [0,59] */
@@ -52,6 +67,10 @@ int gettimeofday(struct timeval *tv, void *tz);
 unsigned sleep(unsigned seconds);
 int usleep(useconds_t usec);
 int nanosleep(const struct timespec *req, struct timespec *rem);
+
+int setitimer(int which, const struct itimerval *new,
+              struct itimerval *old);
+int getitimer(int which, struct itimerval *curr);
 
 size_t strftime(char *s, size_t max, const char *format, const struct tm *tm);
 char *strptime(const char *s, const char *format, struct tm *tm);

--- a/src/itimer.c
+++ b/src/itimer.c
@@ -1,0 +1,46 @@
+#include "time.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int setitimer(int which, const struct itimerval *new, struct itimerval *old)
+{
+#ifdef SYS_setitimer
+    long ret = vlibc_syscall(SYS_setitimer, which, (long)new, (long)old, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_setitimer(int, const struct itimerval *, struct itimerval *)
+        __asm__("setitimer");
+    return host_setitimer(which, new, old);
+#else
+    (void)which; (void)new; (void)old;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+int getitimer(int which, struct itimerval *curr)
+{
+#ifdef SYS_getitimer
+    long ret = vlibc_syscall(SYS_getitimer, which, (long)curr, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_getitimer(int, struct itimerval *) __asm__("getitimer");
+    return host_getitimer(which, curr);
+#else
+    (void)which; (void)curr;
+    errno = ENOSYS;
+    return -1;
+#endif
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -40,13 +40,14 @@ This document outlines the architecture, planned modules, and API design for **v
 34. [Locale Support](#locale-support)
 35. [Time Retrieval](#time-retrieval)
 36. [Sleep Functions](#sleep-functions)
-37. [Raw System Calls](#raw-system-calls)
-38. [Non-local Jumps](#non-local-jumps)
-39. [Limitations](#limitations)
-40. [Conclusion](#conclusion)
-41. [Logging](#logging)
-42. [Path Expansion](#path-expansion)
-43. [Filesystem Statistics](#filesystem-statistics)
+37. [Interval Timers](#interval-timers)
+38. [Raw System Calls](#raw-system-calls)
+39. [Non-local Jumps](#non-local-jumps)
+40. [Limitations](#limitations)
+41. [Conclusion](#conclusion)
+42. [Logging](#logging)
+43. [Path Expansion](#path-expansion)
+44. [Filesystem Statistics](#filesystem-statistics)
 
 ## Overview
 
@@ -994,6 +995,16 @@ Delay helpers are available in `time.h`:
 unsigned sleep(unsigned seconds);
 int usleep(useconds_t usec);
 int nanosleep(const struct timespec *req, struct timespec *rem);
+```
+
+## Interval Timers
+
+`setitimer` schedules periodic `SIGALRM` delivery or CPU timers. `getitimer`
+returns the remaining time and interval.
+
+```c
+struct itimerval it = { {1, 0}, {1, 0} };
+setitimer(ITIMER_REAL, &it, NULL);
 ```
 
 ## Logging


### PR DESCRIPTION
## Summary
- implement `setitimer` and `getitimer` wrappers
- expose interval timer APIs via `<time.h>`
- document interval timers in the manual

## Testing
- `make test` *(fails: no output because tests hang in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_685971000f3c8324bfd097a1ca944f4e