### PR TITLE
Add arc4random and rand_r implementations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ SRC := \
     src/strerror_r.c \
     src/strto.c \
     src/rand.c \
+    src/arc4random.c \
     src/socket.c \
     src/socketpair.c \
     src/setsockopt.c \

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -40,6 +40,9 @@ void *bsearch(const void *key, const void *base, size_t nmemb, size_t size,
 /* Pseudo-random number generator */
 int rand(void);
 void srand(unsigned seed);
+unsigned int arc4random(void);
+void arc4random_buf(void *buf, size_t len);
+int rand_r(unsigned *state);
 
 /* Register a function to run at normal process exit */
 int atexit(void (*fn)(void));

--- a/src/arc4random.c
+++ b/src/arc4random.c
@@ -1,0 +1,45 @@
+#include "stdlib.h"
+#include "io.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdint.h>
+
+/*
+ * Simple arc4random implementation. Use the system getrandom if available
+ * in the future. For now read from /dev/urandom which is present on most
+ * Unix-like systems. On BSD systems with arc4random in libc this fallback
+ * keeps us portable when that function is absent.
+ */
+
+static void fill_urandom(void *buf, size_t len)
+{
+    int fd = open("/dev/urandom", O_RDONLY);
+    if (fd < 0)
+        return;
+    size_t off = 0;
+    while (off < len) {
+        ssize_t r = read(fd, (unsigned char *)buf + off, len - off);
+        if (r <= 0)
+            break;
+        off += (size_t)r;
+    }
+    close(fd);
+}
+
+void arc4random_buf(void *buf, size_t len)
+{
+    fill_urandom(buf, len);
+}
+
+unsigned int arc4random(void)
+{
+    unsigned int v = 0;
+    arc4random_buf(&v, sizeof(v));
+    return v;
+}
+
+int rand_r(unsigned *state)
+{
+    *state = *state * 1103515245 + 12345;
+    return (int)((*state >> 16) & 0x7fff);
+}

--- a/src/tempfile.c
+++ b/src/tempfile.c
@@ -7,31 +7,10 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
-#define USE_ARC4RANDOM 1
-#endif
-
 static int fill_random(unsigned char *buf, size_t len)
 {
-#ifdef USE_ARC4RANDOM
     arc4random_buf(buf, len);
     return 0;
-#else
-    int fd = open("/dev/urandom", O_RDONLY);
-    if (fd < 0)
-        return -1;
-    size_t off = 0;
-    while (off < len) {
-        ssize_t r = read(fd, buf + off, len - off);
-        if (r <= 0) {
-            close(fd);
-            return -1;
-        }
-        off += (size_t)r;
-    }
-    close(fd);
-    return 0;
-#endif
 }
 
 static int replace_x(char *template)

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -363,11 +363,19 @@ linear congruential generator.
 ```c
 int rand(void);
 void srand(unsigned seed);
+unsigned int arc4random(void);
+void arc4random_buf(void *buf, size_t len);
+int rand_r(unsigned *state);
 ```
 
 Calling `srand()` initializes the internal state. Reusing the same seed
 produces the identical sequence of numbers, each in the range `0` to
 `32767`.
+
+`arc4random()` returns a 32-bit value sourced from the operating system's
+random generator. `arc4random_buf()` fills an arbitrary buffer with secure
+random bytes. The `rand_r()` variant operates like `rand()` but stores its
+state in a user-provided variable so it can be used in threaded code.
 
 ## Sorting Helpers
 


### PR DESCRIPTION
## Summary
- implement `arc4random`, `arc4random_buf` and `rand_r`
- expose prototypes in `<stdlib.h>`
- use `arc4random_buf` for temp file creation
- document new random number functions

## Testing
- `make test` *(fails: tests hang in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6859858627b883248cf5be55fa3c4524