### PR TITLE
Add daemon() helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ SRC := \
     src/signal.c \
     src/abort.c \
     src/system.c \
+    src/daemon.c \
     src/string.c \
     src/string_extra.c \
     src/strndup.c \

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -13,6 +13,7 @@
 #include "env.h"
 
 int isatty(int fd);
+int daemon(int nochdir, int noclose);
 
 uid_t getuid(void);
 uid_t geteuid(void);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -1,0 +1,53 @@
+#include "unistd.h"
+#include "io.h"
+#include "sys/file.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include "syscall.h"
+
+int daemon(int nochdir, int noclose)
+{
+    pid_t pid = fork();
+    if (pid < 0)
+        return -1;
+    if (pid > 0)
+        _exit(0);
+
+    long ret;
+#ifdef SYS_setsid
+    ret = vlibc_syscall(SYS_setsid, 0, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+#else
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    extern pid_t host_setsid(void) __asm__("setsid");
+    if (host_setsid() < 0)
+        return -1;
+#else
+    errno = ENOSYS;
+    return -1;
+#endif
+#endif
+
+    if (!nochdir)
+        chdir("/");
+    umask(0);
+
+    if (!noclose) {
+        int fd = open("/dev/null", 2);
+        if (fd < 0)
+            fd = open("/dev/null", 0);
+        if (fd >= 0) {
+            dup2(fd, 0);
+            dup2(fd, 1);
+            dup2(fd, 2);
+            if (fd > 2)
+                close(fd);
+        }
+    }
+
+    return 0;
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -451,6 +451,7 @@ gid_t getegid(void);
 int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact);
 int sigprocmask(int how, const sigset_t *set, sigset_t *oldset);
 int system(const char *command);
+int daemon(int nochdir, int noclose);
 int atexit(void (*fn)(void));
 void abort(void);
 void exit(int status);
@@ -473,6 +474,10 @@ waitpid(pid, NULL, 0);
 void on_int(int signo) { (void)signo; }
 signal(SIGINT, on_int);
 kill(getpid(), SIGINT);
+
+/* Detach and run in the background. */
+if (daemon(0, 0) < 0)
+    perror("daemon");
 ```
 
 `execvp` performs the same operation as `execve` but searches the directories in the `PATH` environment variable when the program name does not contain a slash.


### PR DESCRIPTION
## Summary
- provide daemon() prototype
- implement daemon() for simple backgrounding
- document usage with a short example

## Testing
- `make test` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_6859877297288324a2d143e8401ac174