### PR TITLE
Add uname support and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ SRC := \
     src/mmap.c \
     src/env.c \
     src/hostname.c \
+    src/uname.c \
     src/sleep.c \
     src/clock_gettime.c \
     src/time.c \

--- a/include/sys/utsname.h
+++ b/include/sys/utsname.h
@@ -1,0 +1,32 @@
+#ifndef SYS_UTSNAME_H
+#define SYS_UTSNAME_H
+
+#include <sys/types.h>
+
+#if defined(__has_include)
+#  if __has_include("/usr/include/x86_64-linux-gnu/sys/utsname.h")
+#    include "/usr/include/x86_64-linux-gnu/sys/utsname.h"
+#    define VLIBC_SYS_UTSNAME_NATIVE 1
+#  elif __has_include("/usr/include/sys/utsname.h")
+#    include "/usr/include/sys/utsname.h"
+#    define VLIBC_SYS_UTSNAME_NATIVE 1
+#  endif
+#endif
+
+#ifndef VLIBC_SYS_UTSNAME_NATIVE
+#ifndef _UTSNAME_LENGTH
+#define _UTSNAME_LENGTH 65
+#endif
+
+struct utsname {
+    char sysname[_UTSNAME_LENGTH];
+    char nodename[_UTSNAME_LENGTH];
+    char release[_UTSNAME_LENGTH];
+    char version[_UTSNAME_LENGTH];
+    char machine[_UTSNAME_LENGTH];
+};
+#endif
+
+int uname(struct utsname *buf);
+
+#endif /* SYS_UTSNAME_H */

--- a/src/uname.c
+++ b/src/uname.c
@@ -1,0 +1,53 @@
+#include "sys/utsname.h"
+#include "errno.h"
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+#include <sys/sysctl.h>
+#include "string.h"
+
+int uname(struct utsname *u)
+{
+    size_t n;
+    n = sizeof(u->sysname);
+    if (sysctlbyname("kern.ostype", u->sysname, &n, NULL, 0) < 0)
+        return -1;
+    if (n >= sizeof(u->sysname))
+        u->sysname[sizeof(u->sysname) - 1] = '\0';
+
+    n = sizeof(u->nodename);
+    if (sysctlbyname("kern.hostname", u->nodename, &n, NULL, 0) < 0)
+        return -1;
+    if (n >= sizeof(u->nodename))
+        u->nodename[sizeof(u->nodename) - 1] = '\0';
+
+    n = sizeof(u->release);
+    if (sysctlbyname("kern.osrelease", u->release, &n, NULL, 0) < 0)
+        return -1;
+    if (n >= sizeof(u->release))
+        u->release[sizeof(u->release) - 1] = '\0';
+
+    n = sizeof(u->version);
+    if (sysctlbyname("kern.version", u->version, &n, NULL, 0) < 0)
+        return -1;
+    if (n >= sizeof(u->version))
+        u->version[sizeof(u->version) - 1] = '\0';
+
+    n = sizeof(u->machine);
+    if (sysctlbyname("hw.machine", u->machine, &n, NULL, 0) < 0)
+        return -1;
+    if (n >= sizeof(u->machine))
+        u->machine[sizeof(u->machine) - 1] = '\0';
+
+    return 0;
+}
+
+#else
+extern int host_uname(struct utsname *) __asm__("uname");
+
+int uname(struct utsname *u)
+{
+    return host_uname(u);
+}
+#endif
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -23,6 +23,7 @@
 #include "../include/stdlib.h"
 #include "../include/wchar.h"
 #include "../include/env.h"
+#include "../include/sys/utsname.h"
 #include "../include/pwd.h"
 #include "../include/grp.h"
 #include "../include/process.h"
@@ -1368,6 +1369,15 @@ static const char *test_gethostname_fn(void)
     return 0;
 }
 
+static const char *test_uname_fn(void)
+{
+    struct utsname u;
+    mu_assert("uname", uname(&u) == 0);
+    mu_assert("sysname", u.sysname[0] != '\0');
+    mu_assert("release", u.release[0] != '\0');
+    return 0;
+}
+
 static const char *test_error_reporting(void)
 {
     errno = ENOENT;
@@ -2004,6 +2014,7 @@ static const char *all_tests(void)
     mu_run_test(test_environment);
     mu_run_test(test_locale_from_env);
     mu_run_test(test_gethostname_fn);
+    mu_run_test(test_uname_fn);
     mu_run_test(test_error_reporting);
     mu_run_test(test_strsignal_names);
     mu_run_test(test_system_fn);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -22,33 +22,34 @@ This document outlines the architecture, planned modules, and API design for **v
 16. [Threading](#threading)
 17. [Dynamic Loading](#dynamic-loading)
 18. [Environment Variables](#environment-variables)
-19. [Basic File I/O](#basic-file-io)
-20. [File Descriptor Helpers](#file-descriptor-helpers)
-21. [File Control](#file-control)
-22. [Terminal Attributes](#terminal-attributes)
-23. [Standard Streams](#standard-streams)
-24. [Temporary Files](#temporary-files)
-25. [Networking](#networking)
-26. [I/O Multiplexing](#io-multiplexing)
-27. [File Permissions](#file-permissions)
-28. [File Status](#file-status)
-29. [Directory Iteration](#directory-iteration)
-30. [Path Canonicalization](#path-canonicalization)
-31. [Path Utilities](#path-utilities)
-32. [User Database](#user-database)
-33. [Group Database](#group-database)
-34. [Time Formatting](#time-formatting)
-35. [Locale Support](#locale-support)
-36. [Time Retrieval](#time-retrieval)
-37. [Sleep Functions](#sleep-functions)
-38. [Interval Timers](#interval-timers)
-39. [Raw System Calls](#raw-system-calls)
-40. [Non-local Jumps](#non-local-jumps)
-41. [Limitations](#limitations)
-42. [Conclusion](#conclusion)
-43. [Logging](#logging)
-44. [Path Expansion](#path-expansion)
-45. [Filesystem Statistics](#filesystem-statistics)
+19. [System Information](#system-information)
+20. [Basic File I/O](#basic-file-io)
+21. [File Descriptor Helpers](#file-descriptor-helpers)
+22. [File Control](#file-control)
+23. [Terminal Attributes](#terminal-attributes)
+24. [Standard Streams](#standard-streams)
+25. [Temporary Files](#temporary-files)
+26. [Networking](#networking)
+27. [I/O Multiplexing](#io-multiplexing)
+28. [File Permissions](#file-permissions)
+29. [File Status](#file-status)
+30. [Directory Iteration](#directory-iteration)
+31. [Path Canonicalization](#path-canonicalization)
+32. [Path Utilities](#path-utilities)
+33. [User Database](#user-database)
+34. [Group Database](#group-database)
+35. [Time Formatting](#time-formatting)
+36. [Locale Support](#locale-support)
+37. [Time Retrieval](#time-retrieval)
+38. [Sleep Functions](#sleep-functions)
+39. [Interval Timers](#interval-timers)
+40. [Raw System Calls](#raw-system-calls)
+41. [Non-local Jumps](#non-local-jumps)
+42. [Limitations](#limitations)
+43. [Conclusion](#conclusion)
+44. [Logging](#logging)
+45. [Path Expansion](#path-expansion)
+46. [Filesystem Statistics](#filesystem-statistics)
 
 ## Overview
 
@@ -648,6 +649,17 @@ int main(int argc, char **argv, char **envp) {
     const char *v = getenv("FOO");
     unsetenv("FOO");
     return 0;
+}
+```
+
+## System Information
+
+Use `uname` from `sys/utsname.h` to query the running operating system:
+
+```c
+struct utsname u;
+if (uname(&u) == 0) {
+    printf("%s %s\n", u.sysname, u.release);
 }
 ```
 


### PR DESCRIPTION
## Summary
- expose `struct utsname` and `uname()`
- implement uname via BSD `sysctl` or host fallback
- test uname in the suite
- document retrieving system info

## Testing
- `make test` *(fails: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685989c1f7e883249a74f5363e1458cc