### PR TITLE
Add more strftime specifiers

### DIFF
--- a/src/strftime.c
+++ b/src/strftime.c
@@ -1,6 +1,15 @@
 #include "time.h"
 #include "string.h"
 
+static const char *wd_short[7] = {
+    "Sun","Mon","Tue","Wed","Thu","Fri","Sat"
+};
+
+static const char *mon_short[12] = {
+    "Jan","Feb","Mar","Apr","May","Jun",
+    "Jul","Aug","Sep","Oct","Nov","Dec"
+};
+
 static int fmt_int(char *buf, size_t size, int val, int width)
 {
     char tmp[16];
@@ -43,6 +52,26 @@ size_t strftime(char *s, size_t max, const char *format, const struct tm *tm)
                 return 0;
             s[pos++] = '%';
             break;
+        case 'a': {
+            const char *wd = (tm->tm_wday >= 0 && tm->tm_wday < 7) ?
+                wd_short[tm->tm_wday] : "";
+            len = (int)strlen(wd);
+            if (pos + (size_t)len >= max)
+                return 0;
+            memcpy(s + pos, wd, (size_t)len);
+            pos += (size_t)len;
+            break;
+        }
+        case 'b': {
+            const char *mn = (tm->tm_mon >= 0 && tm->tm_mon < 12) ?
+                mon_short[tm->tm_mon] : "";
+            len = (int)strlen(mn);
+            if (pos + (size_t)len >= max)
+                return 0;
+            memcpy(s + pos, mn, (size_t)len);
+            pos += (size_t)len;
+            break;
+        }
         case 'Y':
             len = fmt_int(buf, sizeof(buf), tm->tm_year + 1900, 4);
             if (pos + (size_t)len >= max)
@@ -80,6 +109,33 @@ size_t strftime(char *s, size_t max, const char *format, const struct tm *tm)
             break;
         case 'S':
             len = fmt_int(buf, sizeof(buf), tm->tm_sec, 2);
+            if (pos + (size_t)len >= max)
+                return 0;
+            memcpy(s + pos, buf, (size_t)len);
+            pos += (size_t)len;
+            break;
+        case 'Z':
+            len = 3;
+            if (pos + (size_t)len >= max)
+                return 0;
+            memcpy(s + pos, "UTC", (size_t)len);
+            pos += (size_t)len;
+            break;
+        case 'z':
+            if (pos + 5 >= max)
+                return 0;
+            memcpy(s + pos, "+0000", 5);
+            pos += 5;
+            break;
+        case 'w':
+            len = fmt_int(buf, sizeof(buf), tm->tm_wday, 1);
+            if (pos + (size_t)len >= max)
+                return 0;
+            memcpy(s + pos, buf, (size_t)len);
+            pos += (size_t)len;
+            break;
+        case 'u':
+            len = fmt_int(buf, sizeof(buf), tm->tm_wday == 0 ? 7 : tm->tm_wday, 1);
             if (pos + (size_t)len >= max)
                 return 0;
             memcpy(s + pos, buf, (size_t)len);

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1257,6 +1257,24 @@ static const char *test_strftime_basic(void)
     return 0;
 }
 
+static const char *test_strftime_extended(void)
+{
+    struct tm tm = {
+        .tm_year = 123,
+        .tm_mon = 4,
+        .tm_mday = 6,
+        .tm_wday = 6,
+        .tm_hour = 7,
+        .tm_min = 8,
+        .tm_sec = 9
+    };
+    char buf[64];
+    size_t n = strftime(buf, sizeof(buf), "%a %b %d %Y %H:%M:%S %Z %z %w %u", &tm);
+    mu_assert("strftime len2", n == strlen("Sat May 06 2023 07:08:09 UTC +0000 6 6"));
+    mu_assert("strftime str2", strcmp(buf, "Sat May 06 2023 07:08:09 UTC +0000 6 6") == 0);
+    return 0;
+}
+
 static const char *test_strptime_basic(void)
 {
     struct tm tm;
@@ -2008,6 +2026,7 @@ static const char *all_tests(void)
     mu_run_test(test_poll_pipe);
     mu_run_test(test_sleep_functions);
     mu_run_test(test_strftime_basic);
+    mu_run_test(test_strftime_extended);
     mu_run_test(test_strptime_basic);
     mu_run_test(test_time_conversions);
     mu_run_test(test_time_r_conversions);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -296,10 +296,12 @@ size_t prefix = strspn("abc123", "abc");
 ```
 
 Basic time formatting is available via `strftime` and the matching
-`strptime` parser. Only a small subset of conversions is implemented
-(`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`) and the
- output uses the current locale. Non-`"C"` locales work when the host
- `setlocale(3)` accepts them (primarily on BSD systems).
+`strptime` parser. `strftime` handles common conversions like
+`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`, `%a`, `%b`, `%Z`, `%z`, and weekday
+numbers (`%w`/`%u`). The parser continues to accept the numeric
+fields (`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`). The output uses the current
+locale. Non-`"C"` locales work when the host `setlocale(3)` accepts them
+(primarily on BSD systems).
 
 The library also includes simple conversion routines `gmtime`, `localtime`,
 `mktime`, and `ctime`. They convert between `time_t` and `struct tm` or
@@ -1027,8 +1029,25 @@ running tests.
 
 ## Time Formatting
 
-A minimal `strftime` supports `%Y`, `%m`, `%d`, `%H`, `%M`, and `%S`.
-The `strptime` helper parses those same fields back into a `struct tm` and returns a pointer to the first unparsed character or `NULL` on failure.
+`strftime` understands `%Y`, `%m`, `%d`, `%H`, `%M`, and `%S` along with `%a`, `%b`, `%Z`, `%z`, and weekday numbers (`%w`/`%u`).
+`strptime` still parses the numeric fields (`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`) back into a `struct tm` and returns a pointer to the first unparsed character or `NULL` on failure.
+
+Example:
+
+```c
+struct tm tm = {
+    .tm_year = 123, // 2023
+    .tm_mon  = 4,   // May
+    .tm_mday = 6,
+    .tm_wday = 6,
+    .tm_hour = 7,
+    .tm_min  = 8,
+    .tm_sec  = 9
+};
+char buf[64];
+strftime(buf, sizeof(buf), "%a %b %d %Y %H:%M:%S %Z %z", &tm);
+// "Sat May 06 2023 07:08:09 UTC +0000"
+```
 `timegm` converts a `struct tm` in UTC back to `time_t` using the same logic as `mktime` but without timezone adjustments.
 
 ## Locale Support


### PR DESCRIPTION
## Summary
- implement `%a`, `%b`, `%Z`, `%z`, and weekday numbering in `strftime`
- document new conversions in `vlibcdoc.md`
- test the extended formatting

## Testing
- `make test` *(fails: command hung in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68598c4c6b248324a0b8d783c652db2c