### PR TITLE
Add resource limit wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ SRC := \
     src/uid.c \
     src/math.c \
     src/math_extra.c \
+    src/rlimit.c \
     src/regex.c \
     src/fnmatch.c \
     src/scandir.c \

--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -1,0 +1,79 @@
+#ifndef SYS_RESOURCE_H
+#define SYS_RESOURCE_H
+
+#include <sys/types.h>
+
+/* Resource limits */
+#ifndef RLIMIT_CPU
+#define RLIMIT_CPU        0
+#endif
+#ifndef RLIMIT_FSIZE
+#define RLIMIT_FSIZE      1
+#endif
+#ifndef RLIMIT_DATA
+#define RLIMIT_DATA       2
+#endif
+#ifndef RLIMIT_STACK
+#define RLIMIT_STACK      3
+#endif
+#ifndef RLIMIT_CORE
+#define RLIMIT_CORE       4
+#endif
+#ifndef RLIMIT_RSS
+#define RLIMIT_RSS        5
+#endif
+#ifndef RLIMIT_NPROC
+#define RLIMIT_NPROC      6
+#endif
+#ifndef RLIMIT_NOFILE
+#define RLIMIT_NOFILE     7
+#endif
+#ifndef RLIMIT_MEMLOCK
+#define RLIMIT_MEMLOCK    8
+#endif
+#ifndef RLIMIT_AS
+#define RLIMIT_AS         9
+#endif
+#ifndef RLIMIT_LOCKS
+#define RLIMIT_LOCKS      10
+#endif
+#ifndef RLIMIT_SIGPENDING
+#define RLIMIT_SIGPENDING 11
+#endif
+#ifndef RLIMIT_MSGQUEUE
+#define RLIMIT_MSGQUEUE   12
+#endif
+#ifndef RLIMIT_NICE
+#define RLIMIT_NICE       13
+#endif
+#ifndef RLIMIT_RTPRIO
+#define RLIMIT_RTPRIO     14
+#endif
+#ifndef RLIMIT_RTTIME
+#define RLIMIT_RTTIME     15
+#endif
+#ifndef RLIMIT_NLIMITS
+#define RLIMIT_NLIMITS    16
+#endif
+
+#ifndef RLIMIT_OFILE
+#define RLIMIT_OFILE RLIMIT_NOFILE
+#endif
+
+/* Infinite resource limit */
+#ifndef RLIM_INFINITY
+#define RLIM_INFINITY ((rlim_t)-1)
+#endif
+
+/* Type for resource limits */
+typedef unsigned long rlim_t;
+
+struct rlimit {
+    rlim_t rlim_cur;
+    rlim_t rlim_max;
+};
+
+int getrlimit(int resource, struct rlimit *rlim);
+int setrlimit(int resource, const struct rlimit *rlim);
+
+#endif /* SYS_RESOURCE_H */

--- a/src/rlimit.c
+++ b/src/rlimit.c
@@ -1,0 +1,45 @@
+#include "sys/resource.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int getrlimit(int resource, struct rlimit *rlim)
+{
+#if defined(SYS_getrlimit)
+    long ret = vlibc_syscall(SYS_getrlimit, resource, (long)rlim, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_getrlimit(int, struct rlimit *) __asm("getrlimit");
+    return host_getrlimit(resource, rlim);
+#else
+    (void)resource; (void)rlim;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+int setrlimit(int resource, const struct rlimit *rlim)
+{
+#if defined(SYS_setrlimit)
+    long ret = vlibc_syscall(SYS_setrlimit, resource, (long)rlim, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_setrlimit(int, const struct rlimit *) __asm("setrlimit");
+    return host_setrlimit(resource, rlim);
+#else
+    (void)resource; (void)rlim;
+    errno = ENOSYS;
+    return -1;
+#endif
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -50,6 +50,7 @@ This document outlines the architecture, planned modules, and API design for **v
 44. [Logging](#logging)
 45. [Path Expansion](#path-expansion)
 46. [Filesystem Statistics](#filesystem-statistics)
+47. [Resource Limits](#resource-limits)
 
 ## Overview
 
@@ -1071,6 +1072,20 @@ returns the remaining time and interval.
 ```c
 struct itimerval it = { {1, 0}, {1, 0} };
 setitimer(ITIMER_REAL, &it, NULL);
+```
+
+## Resource Limits
+
+Processes may query and update operating system limits using
+`getrlimit` and `setrlimit` from `sys/resource.h`.
+
+```c
+struct rlimit lim;
+if (getrlimit(RLIMIT_NOFILE, &lim) == 0) {
+    printf("soft: %lu hard: %lu\n",
+           (unsigned long)lim.rlim_cur,
+           (unsigned long)lim.rlim_max);
+}
 ```
 
 ## Logging


### PR DESCRIPTION
## Summary
- add `<sys/resource.h>` with `struct rlimit` and limit constants
- implement `getrlimit`/`setrlimit` wrappers
- compile new source in build
- document resource limit usage in the manual

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68598c426c3c83249ff420484aeb1b78