### PR TITLE
Add BSD sysconf support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ SRC := \
     src/wchar_conv.c \
     src/tempfile.c \
     src/syslog.c \
+    src/sysconf.c \
     src/getline.c \
     src/pwd.c \
     src/grp.c \

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -19,6 +19,28 @@ uid_t geteuid(void);
 gid_t getgid(void);
 gid_t getegid(void);
 
+/* sysconf keys */
+#ifndef _SC_ARG_MAX
+#define _SC_ARG_MAX 1
+#endif
+#ifndef _SC_PAGESIZE
+#define _SC_PAGESIZE 2
+#endif
+#ifndef _SC_PAGE_SIZE
+#define _SC_PAGE_SIZE _SC_PAGESIZE
+#endif
+#ifndef _SC_OPEN_MAX
+#define _SC_OPEN_MAX 3
+#endif
+#ifndef _SC_NPROCESSORS_ONLN
+#define _SC_NPROCESSORS_ONLN 4
+#endif
+#ifndef _SC_CLK_TCK
+#define _SC_CLK_TCK 5
+#endif
+
+long sysconf(int name);
+
 #ifndef STDIN_FILENO
 #define STDIN_FILENO 0
 #endif

--- a/src/sysconf.c
+++ b/src/sysconf.c
@@ -1,0 +1,70 @@
+#include "unistd.h"
+#include "errno.h"
+
+#include <sys/types.h>
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+#include <sys/sysctl.h>
+#include <sys/resource.h>
+#include <unistd.h>
+#endif
+
+long sysconf(int name)
+{
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    size_t len;
+    int mib[2];
+    switch (name) {
+    case _SC_PAGESIZE:
+    case _SC_PAGE_SIZE: {
+        int page;
+        mib[0] = CTL_HW; mib[1] = HW_PAGESIZE;
+        len = sizeof(page);
+        if (sysctl(mib, 2, &page, &len, NULL, 0) == 0)
+            return page;
+        break;
+    }
+    case _SC_OPEN_MAX: {
+        struct rlimit rl;
+        if (getrlimit(RLIMIT_NOFILE, &rl) == 0)
+            return (long)rl.rlim_cur;
+        break;
+    }
+    case _SC_NPROCESSORS_ONLN: {
+        int ncpu;
+        mib[0] = CTL_HW; mib[1] = HW_NCPU;
+        len = sizeof(ncpu);
+        if (sysctl(mib, 2, &ncpu, &len, NULL, 0) == 0)
+            return ncpu;
+        break;
+    }
+    case _SC_ARG_MAX: {
+        int argmax;
+        mib[0] = CTL_KERN; mib[1] = KERN_ARGMAX;
+        len = sizeof(argmax);
+        if (sysctl(mib, 2, &argmax, &len, NULL, 0) == 0)
+            return argmax;
+        break;
+    }
+    case _SC_CLK_TCK: {
+#ifdef KERN_CLOCKRATE
+        struct clockinfo ci;
+        mib[0] = CTL_KERN; mib[1] = KERN_CLOCKRATE;
+        len = sizeof(ci);
+        if (sysctl(mib, 2, &ci, &len, NULL, 0) == 0)
+            return ci.hz;
+#endif
+        break;
+    }
+    default:
+        errno = EINVAL;
+        return -1;
+    }
+    errno = EINVAL;
+    return -1;
+#else
+    extern long host_sysconf(int) __asm("sysconf");
+    return host_sysconf(name);
+#endif
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1720,6 +1720,17 @@ static const char *test_group_lookup(void)
     return 0;
 }
 
+static const char *test_sysconf_basic(void)
+{
+    long ps = sysconf(_SC_PAGESIZE);
+    mu_assert("pagesize", ps > 0);
+    long om = sysconf(_SC_OPEN_MAX);
+    mu_assert("openmax", om >= 0);
+    long cpu = sysconf(_SC_NPROCESSORS_ONLN);
+    mu_assert("ncpu", cpu >= 1);
+    return 0;
+}
+
 static int int_cmp(const void *a, const void *b)
 {
     int ia = *(const int *)a;
@@ -2021,6 +2032,7 @@ static const char *all_tests(void)
     mu_run_test(test_realpath_basic);
     mu_run_test(test_passwd_lookup);
     mu_run_test(test_group_lookup);
+    mu_run_test(test_sysconf_basic);
     mu_run_test(test_dirent);
     mu_run_test(test_qsort_int);
     mu_run_test(test_qsort_strings);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -42,13 +42,14 @@ This document outlines the architecture, planned modules, and API design for **v
 36. [Time Retrieval](#time-retrieval)
 37. [Sleep Functions](#sleep-functions)
 38. [Interval Timers](#interval-timers)
-39. [Raw System Calls](#raw-system-calls)
-40. [Non-local Jumps](#non-local-jumps)
-41. [Limitations](#limitations)
-42. [Conclusion](#conclusion)
-43. [Logging](#logging)
-44. [Path Expansion](#path-expansion)
-45. [Filesystem Statistics](#filesystem-statistics)
+39. [Runtime Limits](#runtime-limits)
+40. [Raw System Calls](#raw-system-calls)
+41. [Non-local Jumps](#non-local-jumps)
+42. [Limitations](#limitations)
+43. [Conclusion](#conclusion)
+44. [Logging](#logging)
+45. [Path Expansion](#path-expansion)
+46. [Filesystem Statistics](#filesystem-statistics)
 
 ## Overview
 
@@ -1052,6 +1053,19 @@ returns the remaining time and interval.
 struct itimerval it = { {1, 0}, {1, 0} };
 setitimer(ITIMER_REAL, &it, NULL);
 ```
+
+## Runtime Limits
+
+`sysconf` queries runtime parameters such as page size and descriptor limits.
+Supported keys include:
+
+- `_SC_PAGESIZE` / `_SC_PAGE_SIZE` – size of a memory page
+- `_SC_OPEN_MAX` – maximum number of open files
+- `_SC_NPROCESSORS_ONLN` – number of available CPUs
+- `_SC_ARG_MAX` – maximum length of command line arguments
+- `_SC_CLK_TCK` – clock ticks per second
+
+The function returns the limit value or `-1` when the key is not supported.
 
 ## Logging
 


### PR DESCRIPTION
## Summary
- expose `sysconf()` prototype and key constants in `unistd.h`
- implement `sysconf` using BSD `sysctl` and `getrlimit`
- document runtime limit queries
- compile new source file
- test runtime limit helper

## Testing
- `make -j2`
- `make test` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685989a9ddf4832499d4decfc4974ae7