### PR TITLE
Implement portable sysconf and getpagesize helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ SRC := \
     src/wchar.c \
     src/wchar_conv.c \
     src/tempfile.c \
+    src/sysconf.c \
     src/syslog.c \
     src/getline.c \
     src/pwd.c \

--- a/README.md
+++ b/README.md
@@ -164,8 +164,9 @@ int w = wcswidth(L"hello", 5);       // 5
 
 The library currently targets Linux but aims to run on other POSIX systems as
 well. BSD compatibility has been tested on FreeBSD, though some modules still
-rely on Linux-only system calls. Non-Linux builds may therefore require
-additional work.
+rely on Linux-only system calls. Portable helpers like `sysconf()` and
+`getpagesize()` ease porting, but non-Linux builds may still require additional
+work.
 
 ## Running Tests
 

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -20,6 +20,9 @@ uid_t geteuid(void);
 gid_t getgid(void);
 gid_t getegid(void);
 
+long sysconf(int name);
+int getpagesize(void);
+
 #ifndef STDIN_FILENO
 #define STDIN_FILENO 0
 #endif

--- a/src/sysconf.c
+++ b/src/sysconf.c
@@ -1,0 +1,67 @@
+#include "unistd.h"
+#include "errno.h"
+
+#if defined(__has_include)
+#  if __has_include_next(<unistd.h>)
+#    include_next <unistd.h>
+#  endif
+#endif
+
+/*
+ * On most platforms the system provides a sysconf() implementation.
+ * Expose it so we can fall back to it when needed.
+ */
+extern long host_sysconf(int name) __asm("sysconf");
+extern int host_getpagesize(void) __asm("getpagesize");
+
+int getpagesize(void)
+{
+#ifdef PAGE_SIZE
+    return PAGE_SIZE;
+#elif defined(PAGESIZE)
+    return PAGESIZE;
+#else
+# if defined(_SC_PAGESIZE)
+    long r = host_sysconf(_SC_PAGESIZE);
+    if (r > 0)
+        return (int)r;
+# elif defined(_SC_PAGE_SIZE)
+    long r = host_sysconf(_SC_PAGE_SIZE);
+    if (r > 0)
+        return (int)r;
+# endif
+    /* default to 4096 if everything else fails */
+    return 4096;
+#endif
+}
+
+long sysconf(int name)
+{
+    switch (name) {
+#ifdef _SC_PAGESIZE
+    case _SC_PAGESIZE:
+#endif
+#if defined(_SC_PAGE_SIZE) && _SC_PAGE_SIZE != _SC_PAGESIZE
+    case _SC_PAGE_SIZE:
+#endif
+        return getpagesize();
+#ifdef _SC_OPEN_MAX
+    case _SC_OPEN_MAX:
+        return host_sysconf(name);
+#endif
+#ifdef _SC_NPROCESSORS_ONLN
+    case _SC_NPROCESSORS_ONLN:
+        return host_sysconf(name);
+#endif
+#ifdef _SC_NPROCESSORS_CONF
+    case _SC_NPROCESSORS_CONF:
+        return host_sysconf(name);
+#endif
+#ifdef _SC_CLK_TCK
+    case _SC_CLK_TCK:
+        return host_sysconf(name);
+#endif
+    default:
+        return host_sysconf(name);
+    }
+}


### PR DESCRIPTION
## Summary
- add `sysconf()` implementation with fallbacks
- expose new helpers in unistd.h
- compile the new source file
- mention sysconf/getpagesize portability in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68598e8ba8708324bbb3431d04b381d2