### PR TITLE
Implement strsep and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ char word[16];
 sscanf("42 example", "%d %s", &num, word);
 ```
 
+## String Helpers
+
+vlibc ships common routines like `strdup`, `strndup`, `strlcpy`, and `strlcat`.
+Tokenizers `strtok`, `strtok_r`, and the lightweight `strsep` help split
+strings based on delimiters.
+
 Launching a program in a new process with `posix_spawn` is similarly easy:
 
 ```c

--- a/include/string.h
+++ b/include/string.h
@@ -39,6 +39,7 @@ char *strrchr(const char *s, int c);
 char *strstr(const char *haystack, const char *needle);
 char *strtok(char *str, const char *delim);
 char *strtok_r(char *str, const char *delim, char **saveptr);
+char *strsep(char **stringp, const char *delim);
 int strcasecmp(const char *s1, const char *s2);
 int strncasecmp(const char *s1, const char *s2, size_t n);
 int strcoll(const char *s1, const char *s2);

--- a/src/string_extra.c
+++ b/src/string_extra.c
@@ -174,3 +174,25 @@ size_t strxfrm(char *dest, const char *src, size_t n)
     return len;
 }
 
+char *strsep(char **stringp, const char *delim)
+{
+    if (!stringp || !*stringp)
+        return NULL;
+    char *s = *stringp;
+    char *tok = s;
+    while (*s) {
+        const char *d = delim;
+        while (*d) {
+            if (*s == *d) {
+                *s = '\0';
+                *stringp = s + 1;
+                return tok;
+            }
+            d++;
+        }
+        s++;
+    }
+    *stringp = NULL;
+    return tok;
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -766,6 +766,21 @@ static const char *test_strtok_r_basic(void)
     return 0;
 }
 
+static const char *test_strsep_basic(void)
+{
+    char buf[] = "x:y:z";
+    char *p = buf;
+    char *tok = strsep(&p, ":");
+    mu_assert("sep1", tok && strcmp(tok, "x") == 0);
+    tok = strsep(&p, ":");
+    mu_assert("sep2", tok && strcmp(tok, "y") == 0);
+    tok = strsep(&p, ":");
+    mu_assert("sep3", tok && strcmp(tok, "z") == 0);
+    tok = strsep(&p, ":");
+    mu_assert("sep end", tok == NULL);
+    return 0;
+}
+
 static const char *test_printf_functions(void)
 {
     char buf[64];
@@ -2026,6 +2041,7 @@ static const char *all_tests(void)
     mu_run_test(test_wctype_checks);
     mu_run_test(test_strtok_basic);
     mu_run_test(test_strtok_r_basic);
+    mu_run_test(test_strsep_basic);
     mu_run_test(test_printf_functions);
     mu_run_test(test_scanf_functions);
     mu_run_test(test_vscanf_variants);


### PR DESCRIPTION
## Summary
- implement `strsep` in the string helpers
- export `strsep` in the public header
- add basic unit test for `strsep`
- document the helper in README

## Testing
- `make test` *(fails: command timed out)*


------
https://chatgpt.com/codex/tasks/task_e_685992fe8cc083249b2104eba57315cc