### PR TITLE
Add stream state helpers and docs

### DIFF
--- a/src/stdio.c
+++ b/src/stdio.c
@@ -165,6 +165,8 @@ int fseek(FILE *stream, long offset, int whence)
     }
     stream->bufpos = 0;
     stream->buflen = 0;
+    stream->eof = 0;
+    stream->have_ungot = 0;
     return 0;
 }
 
@@ -191,6 +193,9 @@ void rewind(FILE *stream)
         stream->err = 1;
     stream->bufpos = 0;
     stream->buflen = 0;
+    stream->eof = 0;
+    stream->err = 0;
+    stream->have_ungot = 0;
 }
 
 int fgetc(FILE *stream)

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -712,6 +712,13 @@ if (getcwd(path, sizeof(path)))
 chdir("/");
 ```
 
+Additional helpers inspect and reset a stream's state. `feof(stream)`
+returns non-zero once the end of input has been reached while
+`ferror(stream)` indicates an I/O error.  Call `clearerr(stream)` to reset
+both flags.  `fileno(stream)` exposes the underlying descriptor number and
+`ungetc(c, stream)` pushes a single byte back so the next `fgetc` returns
+it.
+
 ## File Descriptor Helpers
 
 Low-level descriptor routines perform simple tasks such as repositioning a file,


### PR DESCRIPTION
## Summary
- maintain EOF and error flags in `fseek` and `rewind`
- describe `fileno`, `feof`, `ferror`, `clearerr` and `ungetc` in docs

## Testing
- `make test` *(fails: no output from run_tests)*

------
https://chatgpt.com/codex/tasks/task_e_685995a5abf08324a6fe2eb0ad34a637