### PR TITLE
Add minimal wide-character I/O

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,9 @@ SRC := \
     src/fnmatch.c \
     src/scandir.c \
     src/ftw.c \
-    src/glob.c
+    src/glob.c \
+    src/wprintf.c \
+    src/wscanf.c
 
 ARCH_SRC := $(wildcard src/arch/$(ARCH)/*.c)
 SRC += $(if $(ARCH_SRC),$(ARCH_SRC),src/setjmp.c)

--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ int c = wcwidth(L'A');                // 1
 int w = wcswidth(L"hello", 5);       // 5
 ```
 
+## Wide-Character I/O
+
+Basic wide-character formatting and scanning are available through
+`wprintf` and `wscanf`. Only the subset of conversion specifiers handled
+by the regular `printf` implementation is currently recognized.
+
 ## Platform Support
 
 The library currently targets Linux but aims to run on other POSIX systems as

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -2,6 +2,8 @@
 #define WCHAR_H
 
 #include <stddef.h>
+#include <stdarg.h>
+#include "stdio.h"
 
 #ifndef __wchar_t_defined
 typedef int wchar_t;
@@ -21,5 +23,21 @@ size_t mbstowcs(wchar_t *dst, const char *src, size_t n);
 size_t wcstombs(char *dst, const wchar_t *src, size_t n);
 size_t mbrlen(const char *s, size_t n, mbstate_t *ps);
 int mbsinit(const mbstate_t *ps);
+
+/* Wide-character formatted output */
+int wprintf(const wchar_t *format, ...);
+int fwprintf(FILE *stream, const wchar_t *format, ...);
+int swprintf(wchar_t *str, size_t size, const wchar_t *format, ...);
+int vwprintf(const wchar_t *format, va_list ap);
+int vfwprintf(FILE *stream, const wchar_t *format, va_list ap);
+int vswprintf(wchar_t *str, size_t size, const wchar_t *format, va_list ap);
+
+/* Wide-character formatted input */
+int wscanf(const wchar_t *format, ...);
+int fwscanf(FILE *stream, const wchar_t *format, ...);
+int swscanf(const wchar_t *str, const wchar_t *format, ...);
+int vwscanf(const wchar_t *format, va_list ap);
+int vfwscanf(FILE *stream, const wchar_t *format, va_list ap);
+int vswscanf(const wchar_t *str, const wchar_t *format, va_list ap);
 
 #endif /* WCHAR_H */

--- a/src/wprintf.c
+++ b/src/wprintf.c
@@ -1,0 +1,212 @@
+#include "stdio.h"
+#include "wchar.h"
+#include "memory.h"
+#include "io.h"
+#include <stdarg.h>
+#include <string.h>
+#include <stdint.h>
+
+static int wuint_to_base(unsigned long value, unsigned base, int upper,
+                        wchar_t *buf, size_t size)
+{
+    const char *digits = upper ? "0123456789ABCDEF" : "0123456789abcdef";
+    char tmp[32];
+    size_t i = 0;
+    do {
+        tmp[i++] = digits[value % base];
+        value /= base;
+    } while (value && i < sizeof(tmp));
+    if (i > size)
+        i = size;
+    for (size_t j = 0; j < i; ++j)
+        buf[j] = (wchar_t)tmp[i - j - 1];
+    return (int)i;
+}
+
+static void wout_char(wchar_t *dst, size_t size, size_t *pos, wchar_t c)
+{
+    if (*pos + 1 < size)
+        dst[*pos] = c;
+    (*pos)++;
+}
+
+static void wout_str(wchar_t *dst, size_t size, size_t *pos,
+                    const wchar_t *s, size_t len)
+{
+    for (size_t i = 0; i < len; i++)
+        wout_char(dst, size, pos, s[i]);
+}
+
+static int vswprintf_impl(wchar_t *str, size_t size, const wchar_t *fmt, va_list ap)
+{
+    size_t pos = 0;
+    for (const wchar_t *p = fmt; *p; ++p) {
+        if (*p != L'%') {
+            wout_char(str, size, &pos, *p);
+            continue;
+        }
+        ++p;
+        if (*p == L'%') {
+            wout_char(str, size, &pos, L'%');
+            continue;
+        }
+
+        int width = 0;
+        int precision = -1;
+        while (*p >= L'0' && *p <= L'9') {
+            width = width * 10 + (*p - L'0');
+            ++p;
+        }
+        if (*p == L'.') {
+            ++p;
+            precision = 0;
+            while (*p >= L'0' && *p <= L'9') {
+                precision = precision * 10 + (*p - L'0');
+                ++p;
+            }
+        }
+
+        wchar_t spec = *p;
+        wchar_t buf[64];
+        int len = 0;
+        const wchar_t *prefix = L"";
+        int prefix_len = 0;
+        int sign = 0;
+
+        switch (spec) {
+        case L's': {
+            const wchar_t *s = va_arg(ap, const wchar_t *);
+            if (!s)
+                s = L"(null)";
+            size_t slen = wcslen(s);
+            if (precision >= 0 && (size_t)precision < slen)
+                slen = (size_t)precision;
+            if (width > 0 && (int)slen < width) {
+                for (int i = 0; i < width - (int)slen; i++)
+                    wout_char(str, size, &pos, L' ');
+            }
+            wout_str(str, size, &pos, s, slen);
+            break;
+        }
+        case L'd': {
+            int v = va_arg(ap, int);
+            sign = v < 0;
+            len = wuint_to_base(sign ? (unsigned int)-v : (unsigned int)v,
+                              10, 0, buf, sizeof(buf)/sizeof(wchar_t));
+            break;
+        }
+        case L'u': {
+            unsigned int v = va_arg(ap, unsigned int);
+            len = wuint_to_base(v, 10, 0, buf, sizeof(buf)/sizeof(wchar_t));
+            break;
+        }
+        case L'x':
+        case L'X': {
+            unsigned int v = va_arg(ap, unsigned int);
+            len = wuint_to_base(v, 16, spec == L'X', buf, sizeof(buf)/sizeof(wchar_t));
+            break;
+        }
+        case L'o': {
+            unsigned int v = va_arg(ap, unsigned int);
+            len = wuint_to_base(v, 8, 0, buf, sizeof(buf)/sizeof(wchar_t));
+            break;
+        }
+        case L'p': {
+            uintptr_t v = (uintptr_t)va_arg(ap, void *);
+            prefix = L"0x";
+            prefix_len = 2;
+            len = wuint_to_base(v, 16, 0, buf, sizeof(buf)/sizeof(wchar_t));
+            break;
+        }
+        case L'c': {
+            buf[0] = (wchar_t)va_arg(ap, int);
+            len = 1;
+            break;
+        }
+        default:
+            wout_char(str, size, &pos, L'%');
+            if (spec)
+                wout_char(str, size, &pos, spec);
+            continue;
+        }
+
+        int num_len = len;
+        if (precision > num_len)
+            num_len = precision;
+        int total = prefix_len + (sign ? 1 : 0) + num_len;
+        if (width > total) {
+            for (int i = 0; i < width - total; i++)
+                wout_char(str, size, &pos, L' ');
+        }
+        if (sign)
+            wout_char(str, size, &pos, L'-');
+        wout_str(str, size, &pos, prefix, (size_t)prefix_len);
+        for (int i = 0; i < num_len - len; i++)
+            wout_char(str, size, &pos, L'0');
+        wout_str(str, size, &pos, buf, (size_t)len);
+    }
+
+    if (size > 0) {
+        if (pos >= size)
+            str[size - 1] = L'\0';
+        else
+            str[pos] = L'\0';
+    }
+    return (int)pos;
+}
+
+int vswprintf(wchar_t *str, size_t size, const wchar_t *format, va_list ap)
+{
+    return vswprintf_impl(str, size, format, ap);
+}
+
+int swprintf(wchar_t *str, size_t size, const wchar_t *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    int r = vswprintf(str, size, format, ap);
+    va_end(ap);
+    return r;
+}
+
+static int vfdwprintf(int fd, const wchar_t *format, va_list ap)
+{
+    wchar_t wbuf[1024];
+    int len = vswprintf(wbuf, sizeof(wbuf)/sizeof(wchar_t), format, ap);
+    if (len > 0 && fd >= 0) {
+        char buf[4096];
+        size_t out = wcstombs(buf, wbuf, sizeof(buf));
+        if (out != (size_t)-1)
+            write(fd, buf, out);
+    }
+    return len;
+}
+
+int vfwprintf(FILE *stream, const wchar_t *format, va_list ap)
+{
+    return vfdwprintf(stream ? stream->fd : -1, format, ap);
+}
+
+int vwprintf(const wchar_t *format, va_list ap)
+{
+    return vfdwprintf(1, format, ap);
+}
+
+int fwprintf(FILE *stream, const wchar_t *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    int r = vfwprintf(stream, format, ap);
+    va_end(ap);
+    return r;
+}
+
+int wprintf(const wchar_t *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    int r = vwprintf(format, ap);
+    va_end(ap);
+    return r;
+}
+

--- a/src/wscanf.c
+++ b/src/wscanf.c
@@ -1,0 +1,211 @@
+#include "stdio.h"
+#include "wchar.h"
+#include "wctype.h"
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const wchar_t *skip_ws_w(const wchar_t *s)
+{
+    while (*s && iswspace(*s))
+        s++;
+    return s;
+}
+
+static long wstrtol_wrap(const wchar_t *s, const wchar_t **end, int base)
+{
+    char buf[128];
+    size_t len = wcstombs(buf, s, sizeof(buf) - 1);
+    if (len == (size_t)-1)
+        len = 0;
+    buf[len] = '\0';
+    char *endp;
+    long v = strtol(buf, &endp, base);
+    if (end)
+        *end = s + (endp - buf);
+    return v;
+}
+
+static unsigned long wstrtoul_wrap(const wchar_t *s, const wchar_t **end, int base)
+{
+    char buf[128];
+    size_t len = wcstombs(buf, s, sizeof(buf) - 1);
+    if (len == (size_t)-1)
+        len = 0;
+    buf[len] = '\0';
+    char *endp;
+    unsigned long v = strtoul(buf, &endp, base);
+    if (end)
+        *end = s + (endp - buf);
+    return v;
+}
+
+static double wstrtod_wrap(const wchar_t *s, const wchar_t **end)
+{
+    char buf[128];
+    size_t len = wcstombs(buf, s, sizeof(buf) - 1);
+    if (len == (size_t)-1)
+        len = 0;
+    buf[len] = '\0';
+    char *endp;
+    double v = strtod(buf, &endp);
+    if (end)
+        *end = s + (endp - buf);
+    return v;
+}
+
+static int vswscanf_impl(const wchar_t *str, const wchar_t *fmt, va_list ap)
+{
+    const wchar_t *s = str;
+    int count = 0;
+    for (; *fmt; ++fmt) {
+        if (iswspace(*fmt)) {
+            while (iswspace(*fmt))
+                fmt++;
+            fmt--;
+            s = skip_ws_w(s);
+            continue;
+        }
+        if (*fmt != L'%') {
+            if (*s != *fmt)
+                return count;
+            if (*s)
+                s++;
+            continue;
+        }
+        fmt++;
+        int long_mod = 0;
+        if (*fmt == L'l') {
+            long_mod = 1;
+            fmt++;
+        }
+        if (*fmt == L'd') {
+            s = skip_ws_w(s);
+            const wchar_t *end;
+            long v = wstrtol_wrap(s, &end, 10);
+            if (end == s)
+                return count;
+            *va_arg(ap, int *) = (int)v;
+            s = end;
+            count++;
+        } else if (*fmt == L'u') {
+            s = skip_ws_w(s);
+            const wchar_t *end;
+            long v = wstrtol_wrap(s, &end, 10);
+            if (end == s || v < 0)
+                return count;
+            *va_arg(ap, unsigned *) = (unsigned)v;
+            s = end;
+            count++;
+        } else if (*fmt == L'x' || *fmt == L'X') {
+            s = skip_ws_w(s);
+            const wchar_t *end;
+            unsigned long v = wstrtoul_wrap(s, &end, 16);
+            if (end == s)
+                return count;
+            *va_arg(ap, unsigned *) = (unsigned)v;
+            s = end;
+            count++;
+        } else if (*fmt == L'o') {
+            s = skip_ws_w(s);
+            const wchar_t *end;
+            unsigned long v = wstrtoul_wrap(s, &end, 8);
+            if (end == s)
+                return count;
+            *va_arg(ap, unsigned *) = (unsigned)v;
+            s = end;
+            count++;
+        } else if (*fmt == L'f' || *fmt == L'F' ||
+                   *fmt == L'e' || *fmt == L'E' ||
+                   *fmt == L'g' || *fmt == L'G') {
+            s = skip_ws_w(s);
+            const wchar_t *end;
+            double v = wstrtod_wrap(s, &end);
+            if (end == s)
+                return count;
+            if (long_mod)
+                *va_arg(ap, double *) = v;
+            else
+                *va_arg(ap, float *) = (float)v;
+            s = end;
+            count++;
+        } else if (*fmt == L's') {
+            s = skip_ws_w(s);
+            wchar_t *out = va_arg(ap, wchar_t *);
+            if (!*s)
+                return count;
+            while (*s && !iswspace(*s))
+                *out++ = *s++;
+            *out = L'\0';
+            count++;
+        } else if (*fmt == L'%') {
+            if (*s != L'%')
+                return count;
+            if (*s)
+                s++;
+        } else {
+            return count;
+        }
+    }
+    return count;
+}
+
+int vswscanf(const wchar_t *str, const wchar_t *format, va_list ap)
+{
+    return vswscanf_impl(str, format, ap);
+}
+
+int swscanf(const wchar_t *str, const wchar_t *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    int r = vswscanf_impl(str, format, ap);
+    va_end(ap);
+    return r;
+}
+
+static int vfwscanf_impl(FILE *stream, const wchar_t *format, va_list ap)
+{
+    char buf[256];
+    size_t pos = 0;
+    int c;
+    while (pos + 1 < sizeof(buf) && (c = fgetc(stream)) != -1) {
+        buf[pos++] = (char)c;
+        if (c == '\n')
+            break;
+    }
+    buf[pos] = '\0';
+    wchar_t wbuf[256];
+    mbstowcs(wbuf, buf, sizeof(wbuf)/sizeof(wchar_t));
+    return vswscanf_impl(wbuf, format, ap);
+}
+
+int vfwscanf(FILE *stream, const wchar_t *format, va_list ap)
+{
+    return vfwscanf_impl(stream, format, ap);
+}
+
+int vwscanf(const wchar_t *format, va_list ap)
+{
+    return vfwscanf_impl(stdin, format, ap);
+}
+
+int fwscanf(FILE *stream, const wchar_t *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    int r = vfwscanf(stream, format, ap);
+    va_end(ap);
+    return r;
+}
+
+int wscanf(const wchar_t *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    int r = vfwscanf_impl(stdin, format, ap);
+    va_end(ap);
+    return r;
+}
+
+


### PR DESCRIPTION
## Summary
- prototype wprintf family and wscanf family in `<wchar.h>`
- implement simplified wide-character formatting in `wprintf.c`
- implement minimal wide-character scanning in `wscanf.c`
- build new sources
- document wide-character I/O

## Testing
- `make test` *(fails: tests hang in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6859a72737e883249fbe5edd792237c8