### PR TITLE
Add assert header and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,8 @@ install: $(LIB)
 	install -m 644 include/*.h $(DESTDIR)$(PREFIX)/include
 	# ensure the new unistd.h header is installed
 	install -m 644 include/unistd.h $(DESTDIR)$(PREFIX)/include
+	# ensure the new assert.h header is installed
+	install -m 644 include/assert.h $(DESTDIR)$(PREFIX)/include
 	install -d $(DESTDIR)$(PREFIX)/include/sys
 	install -m 644 include/sys/*.h $(DESTDIR)$(PREFIX)/include/sys
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ programs. Key features include:
 - Host name queries and changes
 - Syslog-style logging
 - Directory scanning helpers
+- Standard `assert` macro for runtime checks
 
 **Note**: vlibc provides only a small subset of the standard C library. Some
 functions depend on system calls that are currently implemented for Linux. BSD

--- a/include/assert.h
+++ b/include/assert.h
@@ -1,0 +1,17 @@
+#ifndef ASSERT_H
+#define ASSERT_H
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef NDEBUG
+#define assert(expr) ((expr) ? (void)0 : (fprintf(stderr, "assertion failed: %s (%s:%d)\n", #expr, __FILE__, __LINE__), abort()))
+#else
+#define assert(expr) ((void)0)
+#endif
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define static_assert _Static_assert
+#endif
+
+#endif /* ASSERT_H */

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -164,6 +164,7 @@ io.h         - unbuffered I/O primitives
 locale.h     - locale helpers
 math.h       - basic math routines
 memory.h     - heap allocation
+assert.h     - runtime assertion checks
 netdb.h      - address resolution helpers
 arpa/inet.h  - IPv4/IPv6 presentation conversion helpers
 ftw.h        - directory tree traversal helpers


### PR DESCRIPTION
## Summary
- implement a minimal `<assert.h>`
- install it alongside other headers
- document the header in `vlibcdoc.md`
- mention the new assert support in the README feature list

## Testing
- `make test` *(fails: make test hung / interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6859ab44b7ec8324b816f60beb1dce5e