### PR TITLE
Add semaphore support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ SRC := \
     src/statvfs.c \
     src/utime.c \
     src/pthread.c \
+    src/semaphore.c \
     src/dirent.c \
     src/default_shell.c \
     src/popen.c \
@@ -169,13 +170,16 @@ test: $(TEST_BIN)
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
+
 install: $(LIB)
 	install -d $(DESTDIR)$(PREFIX)/lib
 	install -m 644 $(LIB) $(DESTDIR)$(PREFIX)/lib
 	install -d $(DESTDIR)$(PREFIX)/include
 	install -m 644 include/*.h $(DESTDIR)$(PREFIX)/include
-	# ensure the new unistd.h header is installed
+# ensure the new unistd.h header is installed
 	install -m 644 include/unistd.h $(DESTDIR)$(PREFIX)/include
+# install semaphore header
+	install -m 644 include/semaphore.h $(DESTDIR)$(PREFIX)/include
 	install -d $(DESTDIR)$(PREFIX)/include/sys
 	install -m 644 include/sys/*.h $(DESTDIR)$(PREFIX)/include/sys
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Values are set with `pthread_setspecific` and retrieved with
 The `pthread_once` helper ensures an initializer runs only once across
 all threads.
 
+## Semaphores
+
+Counting semaphores coordinate work between threads. Call `sem_init`
+to create one, `sem_wait` to decrement and block when zero, and
+`sem_post` to increment the counter.
+
 ## Time Retrieval
 
 Use `clock_gettime` for precise timestamps.

--- a/include/semaphore.h
+++ b/include/semaphore.h
@@ -1,0 +1,30 @@
+#ifndef SEMAPHORE_H
+#define SEMAPHORE_H
+
+#include <sys/types.h>
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+#  if defined(__has_include)
+#    if __has_include_next(<semaphore.h>)
+#      include_next <semaphore.h>
+#      define VLIBC_SEM_NATIVE 1
+#    endif
+#  endif
+#endif
+
+#ifndef VLIBC_SEM_NATIVE
+#include <stdatomic.h>
+
+typedef struct {
+    atomic_int value;
+} sem_t;
+#endif
+
+int sem_init(sem_t *sem, int pshared, unsigned value);
+int sem_destroy(sem_t *sem);
+int sem_wait(sem_t *sem);
+int sem_post(sem_t *sem);
+int sem_trywait(sem_t *sem);
+
+#endif /* SEMAPHORE_H */

--- a/src/semaphore.c
+++ b/src/semaphore.c
@@ -1,0 +1,93 @@
+#include "semaphore.h"
+#include "errno.h"
+#include "time.h"
+#include <stdatomic.h>
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+
+/* use host pthread semaphore implementation */
+extern int host_sem_init(sem_t *, int, unsigned) __asm("sem_init");
+extern int host_sem_destroy(sem_t *) __asm("sem_destroy");
+extern int host_sem_wait(sem_t *) __asm("sem_wait");
+extern int host_sem_post(sem_t *) __asm("sem_post");
+extern int host_sem_trywait(sem_t *) __asm("sem_trywait");
+
+int sem_init(sem_t *sem, int pshared, unsigned value)
+{
+    return host_sem_init(sem, pshared, value);
+}
+
+int sem_destroy(sem_t *sem)
+{
+    return host_sem_destroy(sem);
+}
+
+int sem_wait(sem_t *sem)
+{
+    return host_sem_wait(sem);
+}
+
+int sem_trywait(sem_t *sem)
+{
+    return host_sem_trywait(sem);
+}
+
+int sem_post(sem_t *sem)
+{
+    return host_sem_post(sem);
+}
+
+#else
+
+int sem_init(sem_t *sem, int pshared, unsigned value)
+{
+    (void)pshared;
+    if (!sem)
+        return -1;
+    atomic_store(&sem->value, (int)value);
+    return 0;
+}
+
+int sem_destroy(sem_t *sem)
+{
+    (void)sem;
+    return 0;
+}
+
+int sem_wait(sem_t *sem)
+{
+    while (1) {
+        int val = atomic_load_explicit(&sem->value, memory_order_acquire);
+        while (val <= 0) {
+            struct timespec ts = {0, 1000000};
+            nanosleep(&ts, NULL);
+            val = atomic_load_explicit(&sem->value, memory_order_acquire);
+        }
+        if (atomic_compare_exchange_weak_explicit(&sem->value, &val, val - 1,
+                                                  memory_order_acquire,
+                                                  memory_order_relaxed))
+            return 0;
+    }
+}
+
+int sem_trywait(sem_t *sem)
+{
+    int val = atomic_load_explicit(&sem->value, memory_order_acquire);
+    while (val > 0) {
+        if (atomic_compare_exchange_weak_explicit(&sem->value, &val, val - 1,
+                                                  memory_order_acquire,
+                                                  memory_order_relaxed))
+            return 0;
+    }
+    errno = EAGAIN;
+    return -1;
+}
+
+int sem_post(sem_t *sem)
+{
+    atomic_fetch_add_explicit(&sem->value, 1, memory_order_release);
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
## Summary
- add `semaphore.h` header
- implement counting semaphores in `src/semaphore.c`
- install new header in Makefile
- document semaphore API in README and docs
- add basic semaphore test

## Testing
- `make test` *(fails: tests hang)*

------
https://chatgpt.com/codex/tasks/task_e_6859ab5e4bb88324b9fb01f7694836b3