### PR TITLE
Add dprintf wrappers and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ programs. Key features include:
 - Syslog-style logging
 - Directory scanning helpers
 - Extended math helpers
+- Descriptor-based printing with `dprintf()`/`vdprintf()`
 
 **Note**: vlibc provides only a small subset of the standard C library. Some
 functions depend on system calls that are currently implemented for Linux. BSD

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -56,6 +56,8 @@ int snprintf(char *str, size_t size, const char *format, ...);
 int sprintf(char *str, const char *format, ...);
 int asprintf(char **strp, const char *format, ...);
 int vasprintf(char **strp, const char *format, va_list ap);
+int dprintf(int fd, const char *format, ...);
+int vdprintf(int fd, const char *format, va_list ap);
 int vprintf(const char *format, va_list ap);
 int vfprintf(FILE *stream, const char *format, va_list ap);
 int vsnprintf(char *str, size_t size, const char *format, va_list ap);

--- a/src/printf.c
+++ b/src/printf.c
@@ -205,6 +205,20 @@ static int vfdprintf(int fd, const char *format, va_list ap)
     return len;
 }
 
+int vdprintf(int fd, const char *format, va_list ap)
+{
+    return vfdprintf(fd, format, ap);
+}
+
+int dprintf(int fd, const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    int r = vdprintf(fd, format, ap);
+    va_end(ap);
+    return r;
+}
+
 int vfprintf(FILE *stream, const char *format, va_list ap)
 {
     return vfdprintf(stream ? stream->fd : -1, format, ap);

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -863,6 +863,46 @@ static const char *test_printf_functions(void)
     return 0;
 }
 
+static int call_vdprintf(int fd, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    int r = vdprintf(fd, fmt, ap);
+    va_end(ap);
+    return r;
+}
+
+static const char *test_dprintf_functions(void)
+{
+    int fd = open("tmp_dpr", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    mu_assert("open dprintf", fd >= 0);
+    dprintf(fd, "val=%d", 5);
+    close(fd);
+
+    char buf[16] = {0};
+    fd = open("tmp_dpr", O_RDONLY);
+    ssize_t r = read(fd, buf, sizeof(buf) - 1);
+    close(fd);
+    unlink("tmp_dpr");
+    mu_assert("dprintf read", r > 0);
+    mu_assert("dprintf content", strcmp(buf, "val=5") == 0);
+
+    fd = open("tmp_vdpr", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    mu_assert("open vdprintf", fd >= 0);
+    call_vdprintf(fd, "num=%u", 10u);
+    close(fd);
+
+    char buf2[16] = {0};
+    fd = open("tmp_vdpr", O_RDONLY);
+    r = read(fd, buf2, sizeof(buf2) - 1);
+    close(fd);
+    unlink("tmp_vdpr");
+    mu_assert("vdprintf read", r > 0);
+    mu_assert("vdprintf content", strcmp(buf2, "num=10") == 0);
+
+    return 0;
+}
+
 static const char *test_scanf_functions(void)
 {
     vlibc_init();
@@ -973,6 +1013,7 @@ static int call_vfscanf(FILE *f, const char *fmt, ...)
     va_end(ap);
     return r;
 }
+
 
 static const char *test_vscanf_variants(void)
 {
@@ -2230,6 +2271,7 @@ static const char *all_tests(void)
     mu_run_test(test_strtok_r_basic);
     mu_run_test(test_strsep_basic);
     mu_run_test(test_printf_functions);
+    mu_run_test(test_dprintf_functions);
     mu_run_test(test_scanf_functions);
     mu_run_test(test_vscanf_variants);
     mu_run_test(test_fseek_rewind);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -793,7 +793,7 @@ if (tcgetattr(STDIN_FILENO, &t) == 0) {
 descriptors 0, 1 and 2. They can be used with the provided `fread`,
 `fwrite`, `fseek`, `ftell`, `rewind`, `fgetc`, `fputc`, `ungetc`, `fgets`,
 `fputs`, `sprintf`, `snprintf`, `asprintf`, `vasprintf`, `vsprintf`,
-`vsnprintf`, `fprintf`, `vfprintf`, `printf`, `vprintf`, `vsscanf`, `vfscanf`, `vscanf`,
+`vsnprintf`, `fprintf`, `vfprintf`, `dprintf`, `vdprintf`, `printf`, `vprintf`, `vsscanf`, `vfscanf`, `vscanf`,
 `sscanf`, `fscanf`, `scanf`, `getline`, and `getdelim` helpers.  Query
 stream state with `feof`, `ferror`, and `clearerr`, obtain the descriptor
 number via `fileno`, or wrap an existing descriptor with `fdopen`.


### PR DESCRIPTION
## Summary
- expose `dprintf`/`vdprintf` in `stdio.h`
- implement wrappers calling existing `vfdprintf`
- document the new helpers in README and vlibcdoc
- add tests for the new functions

## Testing
- `timeout 20s make test` *(fails: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6859ad0f5740832487052c1697a52b25