### PR TITLE
Add basic iconv support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ CFLAGS += -std=c11
 AR ?= ar
 ARCH ?= $(shell uname -m)
 
-# Detect availability of sbrk
+	# Detect availability of sbrk
 HAVE_SBRK := $(shell printf '#include <unistd.h>\nint main(){void *p=sbrk(0);return 0;}' | $(CC) -x c - -Werror -c -o /dev/null 2>/dev/null && echo 1 || echo 0)
 ifeq ($(HAVE_SBRK),1)
 CFLAGS += -DHAVE_SBRK
 endif
 
-# Detect optional syscalls used by vlibc
+	# Detect optional syscalls used by vlibc
 HAVE_ACCEPT4 := $(shell printf '#include <sys/syscall.h>\nint main(){return SYS_accept4;}' | $(CC) -x c - -Werror -c -o /dev/null 2>/dev/null && echo 1 || echo 0)
 ifeq ($(HAVE_ACCEPT4),1)
 CFLAGS += -DVLIBC_HAVE_ACCEPT4=1
@@ -43,9 +43,9 @@ else ifeq ($(TARGET_OS),Windows_NT)
 SYS_SRC := src/arch/win32/syscall.c
 endif
 
-# Use the system implementations of select(2) and poll(2) on the BSD
-# family. These wrappers are only needed on Linux where direct
-# syscalls are issued.
+	# Use the system implementations of select(2) and poll(2) on the BSD
+	# family. These wrappers are only needed on Linux where direct
+	# syscalls are issued.
 SELECT_SRC := src/select.c
 ifneq (,$(filter $(TARGET_OS),FreeBSD NetBSD OpenBSD DragonFly))
 SELECT_SRC :=
@@ -179,6 +179,8 @@ install: $(LIB)
 	install -m 644 include/unistd.h $(DESTDIR)$(PREFIX)/include
 	# ensure the new assert.h header is installed
 	install -m 644 include/assert.h $(DESTDIR)$(PREFIX)/include
+	# ensure iconv.h is installed
+	install -m 644 include/iconv.h $(DESTDIR)$(PREFIX)/include
 	install -d $(DESTDIR)$(PREFIX)/include/sys
 	install -m 644 include/sys/*.h $(DESTDIR)$(PREFIX)/include/sys
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ programs. Key features include:
 - Standard `assert` macro for runtime checks
 - Extended math helpers
 - Large-file aware seeks
+- Basic character set conversion with `iconv`
 
 **Note**: vlibc provides only a small subset of the standard C library. Some
 functions depend on system calls that are currently implemented for Linux. BSD

--- a/include/iconv.h
+++ b/include/iconv.h
@@ -1,0 +1,13 @@
+#ifndef ICONV_H
+#define ICONV_H
+
+#include <stddef.h>
+
+typedef void *iconv_t;
+
+iconv_t iconv_open(const char *tocode, const char *fromcode);
+size_t iconv(iconv_t cd, char **inbuf, size_t *inbytesleft,
+             char **outbuf, size_t *outbytesleft);
+int iconv_close(iconv_t cd);
+
+#endif /* ICONV_H */

--- a/src/iconv.c
+++ b/src/iconv.c
@@ -1,0 +1,172 @@
+#include "iconv.h"
+#include "string.h"
+#include "stdlib.h"
+#include "errno.h"
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+#define iconv_open host_iconv_open
+#define iconv host_iconv_func
+#define iconv_close host_iconv_close
+#include_next <iconv.h>
+#undef iconv_open
+#undef iconv
+#undef iconv_close
+extern iconv_t host_iconv_open(const char *, const char *);
+extern size_t host_iconv(iconv_t, char **, size_t *, char **, size_t *);
+extern int host_iconv_close(iconv_t);
+#endif
+
+enum {
+    CD_ASCII_ASCII,
+    CD_ASCII_UTF8,
+    CD_UTF8_ASCII,
+    CD_UTF8_UTF8,
+    CD_HOST
+};
+
+typedef struct iconv_cd {
+    int type;
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    iconv_t host;
+#endif
+} iconv_cd;
+
+static int is_ascii_cs(const char *name)
+{
+    return name && (!strcasecmp(name, "ASCII") || !strcasecmp(name, "US-ASCII"));
+}
+
+static int is_utf8_cs(const char *name)
+{
+    return name && (!strcasecmp(name, "UTF-8") || !strcasecmp(name, "UTF8"));
+}
+
+iconv_t iconv_open(const char *tocode, const char *fromcode)
+{
+    if (!tocode || !fromcode) {
+        errno = EINVAL;
+        return (iconv_t)-1;
+    }
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    iconv_t h = host_iconv_open(tocode, fromcode);
+    if (h != (iconv_t)-1) {
+        iconv_cd *cd = malloc(sizeof(*cd));
+        if (!cd) {
+            host_iconv_close(h);
+            errno = ENOMEM;
+            return (iconv_t)-1;
+        }
+        cd->type = CD_HOST;
+        cd->host = h;
+        return (iconv_t)cd;
+    }
+#endif
+
+    iconv_cd *cd = malloc(sizeof(*cd));
+    if (!cd) {
+        errno = ENOMEM;
+        return (iconv_t)-1;
+    }
+
+    if (is_ascii_cs(fromcode) && is_ascii_cs(tocode))
+        cd->type = CD_ASCII_ASCII;
+    else if (is_ascii_cs(fromcode) && is_utf8_cs(tocode))
+        cd->type = CD_ASCII_UTF8;
+    else if (is_utf8_cs(fromcode) && is_ascii_cs(tocode))
+        cd->type = CD_UTF8_ASCII;
+    else if (is_utf8_cs(fromcode) && is_utf8_cs(tocode))
+        cd->type = CD_UTF8_UTF8;
+    else {
+        free(cd);
+        errno = EINVAL;
+        return (iconv_t)-1;
+    }
+
+    return (iconv_t)cd;
+}
+
+size_t iconv(iconv_t cd_, char **inbuf, size_t *inbytesleft,
+             char **outbuf, size_t *outbytesleft)
+{
+    iconv_cd *cd = (iconv_cd *)cd_;
+    if (!cd) {
+        errno = EINVAL;
+        return (size_t)-1;
+    }
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    if (cd->type == CD_HOST)
+        return host_iconv(cd->host, inbuf, inbytesleft, outbuf, outbytesleft);
+#endif
+
+    char *src = inbuf ? *inbuf : NULL;
+    char *dst = outbuf ? *outbuf : NULL;
+    size_t inleft = inbytesleft ? *inbytesleft : 0;
+    size_t outleft = outbytesleft ? *outbytesleft : 0;
+    size_t converted = 0;
+
+    while (inleft > 0) {
+        if (outleft == 0) {
+            errno = E2BIG;
+            return (size_t)-1;
+        }
+        unsigned char c = (unsigned char)*src;
+        if (cd->type == CD_ASCII_ASCII || cd->type == CD_ASCII_UTF8) {
+            if (c >= 0x80) {
+                errno = EILSEQ;
+                return (size_t)-1;
+            }
+            *dst++ = *src++;
+            inleft--; outleft--; converted++;
+        } else if (cd->type == CD_UTF8_ASCII) {
+            if (c >= 0x80) {
+                errno = EILSEQ;
+                return (size_t)-1;
+            }
+            *dst++ = *src++;
+            inleft--; outleft--; converted++;
+        } else if (cd->type == CD_UTF8_UTF8) {
+            *dst++ = *src++;
+            inleft--; outleft--; converted++;
+        } else {
+            errno = EINVAL;
+            return (size_t)-1;
+        }
+    }
+
+    if (inbuf)
+        *inbuf = src;
+    if (inbytesleft)
+        *inbytesleft = inleft;
+    if (outbuf)
+        *outbuf = dst;
+    if (outbytesleft)
+        *outbytesleft = outleft;
+
+    return converted;
+}
+
+int iconv_close(iconv_t cd_)
+{
+    iconv_cd *cd = (iconv_cd *)cd_;
+    if (!cd)
+        return -1;
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    if (cd->type == CD_HOST) {
+        int r = host_iconv_close(cd->host);
+        free(cd);
+        return r;
+    }
+#endif
+
+    free(cd);
+    return 0;
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -23,6 +23,7 @@
 #include "../include/stdlib.h"
 #include "../include/wchar.h"
 #include "../include/wctype.h"
+#include "../include/iconv.h"
 #include "../include/env.h"
 #include "../include/sys/utsname.h"
 #include "../include/pwd.h"
@@ -769,6 +770,39 @@ static const char *test_wctype_checks(void)
     mu_assert("iswxdigit", iswxdigit(L'F'));
     mu_assert("towlower", towlower(L'A') == L'a');
     mu_assert("towupper", towupper(L'a') == L'A');
+    return 0;
+}
+
+static const char *test_iconv_ascii_roundtrip(void)
+{
+    iconv_t cd = iconv_open("UTF-8", "ASCII");
+    mu_assert("iconv open", cd != (iconv_t)-1);
+    char inbuf[] = "abc";
+    char *in = inbuf;
+    size_t inleft = 3;
+    char out[8] = {0};
+    char *outp = out;
+    size_t outleft = sizeof(out);
+    size_t r = iconv(cd, &in, &inleft, &outp, &outleft);
+    mu_assert("iconv ok", r != (size_t)-1 && strcmp(out, "abc") == 0);
+    mu_assert("iconv all consumed", inleft == 0);
+    iconv_close(cd);
+    return 0;
+}
+
+static const char *test_iconv_invalid_byte(void)
+{
+    iconv_t cd = iconv_open("ASCII", "UTF-8");
+    mu_assert("iconv open2", cd != (iconv_t)-1);
+    char in[2] = { (char)0xC3, (char)0x81 }; /* \xC3\x81 = U+00C1 */
+    char *pin = in;
+    size_t inleft = 2;
+    char out[4];
+    char *pout = out;
+    size_t outleft = sizeof(out);
+    size_t r = iconv(cd, &pin, &inleft, &pout, &outleft);
+    mu_assert("iconv bad", r == (size_t)-1);
+    iconv_close(cd);
     return 0;
 }
 
@@ -2264,6 +2298,8 @@ static const char *all_tests(void)
     mu_run_test(test_widechar_conv);
     mu_run_test(test_widechar_width);
     mu_run_test(test_wctype_checks);
+    mu_run_test(test_iconv_ascii_roundtrip);
+    mu_run_test(test_iconv_invalid_byte);
     mu_run_test(test_strtok_basic);
     mu_run_test(test_strtok_r_basic);
     mu_run_test(test_strsep_basic);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -176,6 +176,7 @@ setjmp.h     - non-local jump helpers
 stdio.h      - simple stream I/O
 stdlib.h     - basic utilities
 string.h     - string manipulation
+iconv.h      - character set conversion helpers
 regex.h     - simple regular expression matching
 termios.h   - terminal attribute helpers
 unistd.h    - POSIX I/O and process helpers
@@ -335,6 +336,15 @@ are delegated to the host implementation.
 int c = wcwidth(L'A');               // 1
 int w = wcswidth(L"hello", 5);      // 5
 ```
+
+### Character Set Conversion
+
+`iconv_open` returns a descriptor for translating between character
+sets.  vlibc understands only conversions between `"ASCII"` and
+`"UTF-8"`.  The `iconv` function copies bytes from the input buffer to
+the output buffer and fails with `EILSEQ` on bytes that cannot be
+represented.  On BSD systems other conversions are delegated to the
+host `iconv` implementation when present.
 
 ## Character Classification
 


### PR DESCRIPTION
## Summary
- provide `<iconv.h>` header and add install rule
- implement minimal ASCII/UTF‑8 converter with BSD fallback
- document the new API and update feature list
- cover iconv with unit tests

## Testing
- `make -j$(nproc)`
- `make test` *(fails: tests hang)*

------
https://chatgpt.com/codex/tasks/task_e_6859af27e0008324947e22f9ab8f5cc7