### PR TITLE
Add alarm timer wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ programs. Key features include:
 - Standard `assert` macro for runtime checks
 - Extended math helpers
 - Large-file aware seeks
+- Simple alarm timers with `alarm()`
 
 **Note**: vlibc provides only a small subset of the standard C library. Some
 functions depend on system calls that are currently implemented for Linux. BSD

--- a/include/time.h
+++ b/include/time.h
@@ -71,6 +71,7 @@ int nanosleep(const struct timespec *req, struct timespec *rem);
 int setitimer(int which, const struct itimerval *new,
               struct itimerval *old);
 int getitimer(int which, struct itimerval *curr);
+unsigned int alarm(unsigned int seconds);
 
 size_t strftime(char *s, size_t max, const char *format, const struct tm *tm);
 char *strptime(const char *s, const char *format, struct tm *tm);

--- a/src/time.c
+++ b/src/time.c
@@ -75,3 +75,21 @@ int gettimeofday(struct timeval *tv, void *tz)
     return host_gettimeofday(tv, tz);
 #endif
 }
+
+unsigned int alarm(unsigned int seconds)
+{
+#ifdef SYS_alarm
+    long ret = vlibc_syscall(SYS_alarm, seconds, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return 0;
+    }
+    return (unsigned int)ret;
+#else
+    struct itimerval it = { {0, 0}, { (time_t)seconds, 0 } };
+    struct itimerval old;
+    if (setitimer(ITIMER_REAL, &it, &old) < 0)
+        return 0;
+    return (unsigned int)old.it_value.tv_sec;
+#endif
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -1167,6 +1167,7 @@ Delay helpers are available in `time.h`:
 unsigned sleep(unsigned seconds);
 int usleep(useconds_t usec);
 int nanosleep(const struct timespec *req, struct timespec *rem);
+unsigned int alarm(unsigned int seconds);
 ```
 
 ## Interval Timers


### PR DESCRIPTION
## Summary
- add `alarm` prototype to `time.h`
- implement `alarm` using `setitimer` or the alarm syscall
- document the new function
- mention it briefly in the README

## Testing
- `make test` *(fails: tests hang in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6859af39b92483249750363527e8a80c