### PR TITLE
Add msync implementation and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ SRC := \
     src/path.c \
     $(SYS_SRC) \
     src/mmap.c \
+    src/msync.c \
     src/env.c \
     src/hostname.c \
     src/uname.c \

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ programs. Key features include:
 - Extended math helpers
 - Descriptor-based printing with `dprintf()`/`vdprintf()`
 - Large-file aware seeks
+- Memory synchronization with `msync()`
 - Simple alarm timers with `alarm()`
 - Basic character set conversion with `iconv`
 

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -15,6 +15,7 @@
 void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
 int munmap(void *addr, size_t length);
 int mprotect(void *addr, size_t length, int prot);
+int msync(void *addr, size_t length, int flags);
 
 /*
  * Some BSD systems expose MAP_ANON instead of MAP_ANONYMOUS.  Provide
@@ -50,6 +51,13 @@ int mprotect(void *addr, size_t length, int prot);
 #endif
 #ifndef MAP_ANON
 #define MAP_ANON MAP_ANONYMOUS
+#endif
+
+#ifndef MS_SYNC
+#define MS_SYNC 4
+#endif
+#ifndef MS_ASYNC
+#define MS_ASYNC 1
 #endif
 
 #endif /* MMAN_H */

--- a/src/msync.c
+++ b/src/msync.c
@@ -1,0 +1,25 @@
+#include "sys/mman.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int msync(void *addr, size_t length, int flags)
+{
+#ifdef SYS_msync
+    long ret = vlibc_syscall(SYS_msync, (long)addr, length, flags, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_msync(void *, size_t, int) __asm__("msync");
+    return host_msync(addr, length, flags);
+#else
+    (void)addr; (void)length; (void)flags;
+    errno = ENOSYS;
+    return -1;
+#endif
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -255,10 +255,13 @@ memory mapping facilities. Available functions are:
 void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
 int munmap(void *addr, size_t length);
 int mprotect(void *addr, size_t length, int prot);
+int msync(void *addr, size_t length, int flags);
 ```
 
 `mmap` creates new mappings, `munmap` releases them and `mprotect` changes
-their access protections.
+their access protections.  `msync` flushes modified pages back to their
+underlying file.  When the raw syscall is unavailable the BSD wrapper is
+used instead, so some platforms may ignore unsupported flags.
 
 ## String Handling
 


### PR DESCRIPTION
## Summary
- add `msync` syscall wrapper with BSD fallback
- expose `msync` and related flags in `sys/mman.h`
- build new file
- document memory synchronization API
- mention feature in README

## Testing
- `make test` *(fails: no output due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_6859da83c5ac83249865c925c67fe78e