### PR TITLE
Add chroot wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ SRC := \
     src/access.c \
     src/getcwd.c \
     src/realpath.c \
+    src/chroot.c \
     src/path.c \
     $(SYS_SRC) \
     src/mmap.c \

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ programs. Key features include:
 - Environment variable handling
 - Host name queries and changes
 - Syslog-style logging
+- Change root directories with `chroot()` when supported
 - Directory scanning helpers
 - Standard `assert` macro for runtime checks
 - Extended math helpers
@@ -207,6 +208,8 @@ well. BSD compatibility has been tested on FreeBSD, though some modules still
 rely on Linux-only system calls. Portable helpers like `sysconf()` and
 `getpagesize()` ease porting, but non-Linux builds may still require additional
 work.
+The `chroot()` wrapper is one such case and returns `ENOSYS` when the
+underlying kernel lacks the system call.
 
 ## Running Tests
 

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -14,6 +14,7 @@
 
 int isatty(int fd);
 int daemon(int nochdir, int noclose);
+int chroot(const char *path);
 
 uid_t getuid(void);
 uid_t geteuid(void);

--- a/src/chroot.c
+++ b/src/chroot.c
@@ -1,0 +1,26 @@
+#include "unistd.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include "syscall.h"
+
+int chroot(const char *path)
+{
+#ifdef SYS_chroot
+    long ret = vlibc_syscall(SYS_chroot, (long)path, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#else
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_chroot(const char *) __asm__("chroot");
+    return host_chroot(path);
+#else
+    (void)path;
+    errno = ENOSYS;
+    return -1;
+#endif
+#endif
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -755,6 +755,10 @@ if (getcwd(path, sizeof(path)))
 chdir("/");
 ```
 
+`chroot` confines the process to a new root directory. The wrapper simply
+invokes the `chroot(2)` system call when available and fails with `ENOSYS`
+on platforms lacking the call.
+
 Additional helpers inspect and reset a stream's state. `feof(stream)`
 returns non-zero once the end of input has been reached while
 `ferror(stream)` indicates an I/O error.  Call `clearerr(stream)` to reset


### PR DESCRIPTION
## Summary
- implement `chroot` syscall wrapper
- expose `chroot` in `unistd.h`
- build the new file
- document usage and portability

## Testing
- `make -j$(nproc)`
- `make test` *(fails: command hangs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6859da8de2208324b8cee514941e74f1