### PR TITLE
Implement getpass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ SRC := \
     src/tempfile.c \
     src/sysconf.c \
     src/syslog.c \
+    src/getpass.c \
     src/getline.c \
     src/pwd.c \
     src/grp.c \

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -26,6 +26,7 @@ int setegid(gid_t egid);
 
 long sysconf(int name);
 int getpagesize(void);
+char *getpass(const char *prompt);
 
 #ifndef STDIN_FILENO
 #define STDIN_FILENO 0

--- a/src/getpass.c
+++ b/src/getpass.c
@@ -1,0 +1,43 @@
+#include "unistd.h"
+#include "fcntl.h"
+#include "termios.h"
+#include "string.h"
+#include "io.h"
+
+char *getpass(const char *prompt)
+{
+    static char buf[128];
+    int fd = open("/dev/tty", O_RDWR);
+    if (fd < 0)
+        fd = STDIN_FILENO;
+
+    if (prompt)
+        write(fd, prompt, strlen(prompt));
+
+    struct termios oldt;
+    struct termios newt;
+    int have_termios = (tcgetattr(fd, &oldt) == 0);
+    if (have_termios) {
+        newt = oldt;
+        newt.c_lflag &= ~(unsigned)ECHO;
+        tcsetattr(fd, TCSANOW, &newt);
+    }
+
+    size_t i = 0;
+    while (i < sizeof(buf) - 1) {
+        char c;
+        ssize_t n = read(fd, &c, 1);
+        if (n <= 0 || c == '\n' || c == '\r')
+            break;
+        buf[i++] = c;
+    }
+    buf[i] = '\0';
+
+    if (have_termios)
+        tcsetattr(fd, TCSANOW, &oldt);
+    write(fd, "\n", 1);
+
+    if (fd != STDIN_FILENO)
+        close(fd);
+    return buf;
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -52,6 +52,7 @@ This document outlines the architecture, planned modules, and API design for **v
 46. [Path Expansion](#path-expansion)
 47. [Filesystem Statistics](#filesystem-statistics)
 48. [Resource Limits](#resource-limits)
+49. [Password Input](#password-input)
 
 ## Overview
 
@@ -1212,6 +1213,18 @@ if (getrlimit(RLIMIT_NOFILE, &lim) == 0) {
            (unsigned long)lim.rlim_max);
 }
 ```
+
+## Password Input
+
+`getpass` reads a password from `/dev/tty` with echo disabled and
+returns it in a static buffer.
+
+```c
+char *pw = getpass("Password: ");
+```
+
+The function toggles the terminal `ECHO` flag via `tcsetattr` and
+restores the original settings after reading the line.
 
 ## Logging
 


### PR DESCRIPTION
## Summary
- implement `getpass` for reading from `/dev/tty`
- expose prototype in `<unistd.h>`
- build `getpass.c`
- document password input in `vlibcdoc.md`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6859da9d5ad88324900ca0d25bd0fc81