### PR TITLE
Add getlogin support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ SRC := \
     src/sysconf.c \
     src/syslog.c \
     src/getline.c \
+    src/getlogin.c \
     src/pwd.c \
     src/grp.c \
     src/uid.c \

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ programs. Key features include:
 - Dynamic loading
 - Environment variable handling
 - Host name queries and changes
+- Login name retrieval with `getlogin()`
 - Syslog-style logging
 - Change root directories with `chroot()` when supported
 - Directory scanning helpers

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -28,6 +28,8 @@ int setegid(gid_t egid);
 long sysconf(int name);
 int getpagesize(void);
 
+char *getlogin(void);
+
 #ifndef STDIN_FILENO
 #define STDIN_FILENO 0
 #endif

--- a/src/getlogin.c
+++ b/src/getlogin.c
@@ -1,0 +1,16 @@
+#include "unistd.h"
+#include "pwd.h"
+#include "string.h"
+
+char *getlogin(void)
+{
+    static __thread char name[64];
+    if (name[0])
+        return name;
+    struct passwd *pw = getpwuid(getuid());
+    if (!pw || !pw->pw_name)
+        return NULL;
+    strncpy(name, pw->pw_name, sizeof(name) - 1);
+    name[sizeof(name) - 1] = '\0';
+    return name;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2077,6 +2077,13 @@ static const char *test_group_lookup(void)
     return 0;
 }
 
+static const char *test_getlogin_fn(void)
+{
+    char *name = getlogin();
+    mu_assert("getlogin", name && *name != '\0');
+    return 0;
+}
+
 static int int_cmp(const void *a, const void *b)
 {
     int ia = *(const int *)a;
@@ -2393,6 +2400,7 @@ static const char *all_tests(void)
     mu_run_test(test_realpath_basic);
     mu_run_test(test_passwd_lookup);
     mu_run_test(test_group_lookup);
+    mu_run_test(test_getlogin_fn);
     mu_run_test(test_dirent);
     mu_run_test(test_ftw_walk);
     mu_run_test(test_qsort_int);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -1130,10 +1130,15 @@ struct passwd {
 
 struct passwd *getpwuid(uid_t uid);
 struct passwd *getpwnam(const char *name);
+char *getlogin(void);
 ```
 
 On BSD systems vlibc parses the file directly. The location can be
 overridden via the `VLIBC_PASSWD` environment variable for testing.
+
+`getlogin()` obtains the user name for the current UID using
+`getpwuid(getuid())`.  The resulting string is cached in thread-local
+storage so repeated calls are inexpensive.
 
 ## Group Database
 


### PR DESCRIPTION
## Summary
- expose `getlogin()` in unistd.h
- implement `getlogin` using `getpwuid(getuid())`
- compile new file in Makefile
- add simple test for `getlogin`
- document feature in README and vlibcdoc

## Testing
- `make test` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6859f9c8a6d88324a2fc1516d622276d