### PR TITLE
Add ioctl wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ SRC := \
     src/inet_ntop.c \
     src/fd.c \
     src/fcntl.c \
+    src/ioctl.c \
     src/isatty.c \
     src/termios.c \
     src/file.c \

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ programs. Key features include:
 - Large-file aware seeks
 - Memory synchronization with `msync()`
 - Advisory file locking with `flock()`
+- Generic descriptor control with `ioctl()`
 - Simple alarm timers with `alarm()`
 - Basic character set conversion with `iconv`
 

--- a/include/sys/ioctl.h
+++ b/include/sys/ioctl.h
@@ -1,0 +1,16 @@
+#ifndef SYS_IOCTL_H
+#define SYS_IOCTL_H
+
+#include <sys/types.h>
+
+#if defined(__has_include)
+#  if __has_include("/usr/include/x86_64-linux-gnu/sys/ioctl.h")
+#    include "/usr/include/x86_64-linux-gnu/sys/ioctl.h"
+#  elif __has_include("/usr/include/sys/ioctl.h")
+#    include "/usr/include/sys/ioctl.h"
+#  endif
+#endif
+
+int ioctl(int fd, unsigned long req, ...);
+
+#endif /* SYS_IOCTL_H */

--- a/src/ioctl.c
+++ b/src/ioctl.c
@@ -1,0 +1,32 @@
+#include "sys/ioctl.h"
+#include <stdarg.h>
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int ioctl(int fd, unsigned long req, ...)
+{
+    va_list ap;
+    va_start(ap, req);
+    unsigned long arg = va_arg(ap, unsigned long);
+    va_end(ap);
+#ifdef SYS_ioctl
+    long ret = vlibc_syscall(SYS_ioctl, fd, req, arg, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#else
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_ioctl(int, unsigned long, ...) __asm__("ioctl");
+    return host_ioctl(fd, req, arg);
+#else
+    (void)fd; (void)req; (void)arg;
+    errno = ENOSYS;
+    return -1;
+#endif
+#endif
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -812,6 +812,14 @@ fcntl(fd, F_SETFL, fl | O_NONBLOCK);
 fcntl(fd, F_SETFD, FD_CLOEXEC);
 ```
 
+`ioctl` performs device-specific operations on a descriptor. Requests are
+platform-specific:
+
+```c
+struct winsize ws;
+ioctl(STDIN_FILENO, TIOCGWINSZ, &ws);
+```
+
 ## File Locking
 
 Use `flock` to coordinate access to files between multiple processes.


### PR DESCRIPTION
## Summary
- expose ioctl in new header include/sys/ioctl.h
- implement ioctl wrapper in src/ioctl.c
- add new source file to Makefile build
- document ioctl in File Control section of vlibcdoc
- note ioctl capability in README feature list

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6859f99497b8832498c0e30fdec57b3c