### PR TITLE
Add mkfifo wrappers and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ SRC := \
     src/realpath.c \
     src/chroot.c \
     src/path.c \
+    src/mkfifo.c \
     $(SYS_SRC) \
     src/mmap.c \
     src/msync.c \

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ programs. Key features include:
 - Large-file aware seeks
 - Memory synchronization with `msync()`
 - Advisory file locking with `flock()`
+- FIFO creation with `mkfifo()` and `mkfifoat()`
 - Generic descriptor control with `ioctl()`
 - Simple alarm timers with `alarm()`
 - Basic character set conversion with `iconv`

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -17,5 +17,7 @@ int stat(const char *path, struct stat *buf);
 int fstat(int fd, struct stat *buf);
 int fstatat(int dirfd, const char *path, struct stat *buf, int flags);
 int lstat(const char *path, struct stat *buf);
+int mkfifo(const char *path, mode_t mode);
+int mkfifoat(int dirfd, const char *path, mode_t mode);
 
 #endif /* SYS_STAT_H */

--- a/src/mkfifo.c
+++ b/src/mkfifo.c
@@ -1,0 +1,45 @@
+#include "sys/stat.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+#ifndef AT_FDCWD
+#define AT_FDCWD -100
+#endif
+
+#ifndef SYS_mkfifo
+extern int host_mkfifo(const char *path, mode_t mode) __asm__("mkfifo");
+#endif
+
+#ifndef SYS_mkfifoat
+extern int host_mkfifoat(int dirfd, const char *path, mode_t mode) __asm__("mkfifoat");
+#endif
+
+int mkfifo(const char *path, mode_t mode)
+{
+#ifdef SYS_mkfifo
+    long ret = vlibc_syscall(SYS_mkfifo, (long)path, mode, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#else
+    return host_mkfifo(path, mode);
+#endif
+}
+
+int mkfifoat(int dirfd, const char *path, mode_t mode)
+{
+#ifdef SYS_mkfifoat
+    long ret = vlibc_syscall(SYS_mkfifoat, dirfd, (long)path, mode, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#else
+    return host_mkfifoat(dirfd, path, mode);
+#endif
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -904,7 +904,11 @@ int fd = mkstemp(path);
 FILE *anon = tmpfile();
 char dir[] = "/tmp/exampledirXXXXXX";
 mkdtemp(dir);
+mkfifo("/tmp/myfifo", 0600);
 ```
+
+`mkfifo` creates a FIFO special file. The `mkfifoat` variant allows
+specifying a directory file descriptor in addition to the path.
 
 ## Networking
 


### PR DESCRIPTION
## Summary
- expose `mkfifo` and `mkfifoat` in `sys/stat.h`
- implement the wrappers with optional syscalls
- build new object in `Makefile`
- document FIFO creation in README and vlibcdoc

## Testing
- `make test` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_685a07bea060832495e0dca65634e5cc