### PR TITLE
Implement pthread_self wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ programs. Key features include:
 - Basic session and process-group APIs
 - Threading primitives and simple read-write locks
 - Thread-local storage helpers
+- Query the current thread ID with `pthread_self()` and compare IDs with `pthread_equal()`
 - Networking sockets
 - Dynamic loading
 - Environment variable handling

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -36,6 +36,8 @@ int pthread_create(pthread_t *thread, const void *attr,
                    void *(*start_routine)(void *), void *arg);
 int pthread_join(pthread_t thread, void **retval);
 int pthread_detach(pthread_t thread);
+pthread_t pthread_self(void);
+int pthread_equal(pthread_t a, pthread_t b);
 
 int pthread_mutex_init(pthread_mutex_t *mutex, void *attr);
 int pthread_mutex_destroy(pthread_mutex_t *mutex);

--- a/src/pthread.c
+++ b/src/pthread.c
@@ -4,6 +4,9 @@
 #include <stdatomic.h>
 #include "time.h"
 
+extern pthread_t host_pthread_self(void) __asm__("pthread_self");
+extern int host_pthread_equal(pthread_t, pthread_t) __asm__("pthread_equal");
+
 /* simple spinlock based mutex */
 int pthread_mutex_init(pthread_mutex_t *mutex, void *attr)
 {
@@ -124,4 +127,14 @@ int pthread_once(pthread_once_t *once_control, void (*init_routine)(void))
     }
     pthread_mutex_unlock(&once_lock);
     return 0;
+}
+
+pthread_t pthread_self(void)
+{
+    return host_pthread_self();
+}
+
+int pthread_equal(pthread_t a, pthread_t b)
+{
+    return host_pthread_equal(a, b);
 }

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -588,6 +588,8 @@ int pthread_create(pthread_t *thread, const void *attr,
                    void *(*start)(void *), void *arg);
 int pthread_join(pthread_t thread, void **retval);
 int pthread_detach(pthread_t thread);
+pthread_t pthread_self(void);
+int pthread_equal(pthread_t a, pthread_t b);
 
 int pthread_mutex_init(pthread_mutex_t *mutex, void *attr);
 int pthread_mutex_destroy(pthread_mutex_t *mutex);
@@ -608,6 +610,9 @@ int pthread_rwlock_destroy(pthread_rwlock_t *rwlock);
 
 Threads share the process address space and use a simple spinlock-based
 mutex for synchronization.
+
+`pthread_self()` returns the identifier of the calling thread while
+`pthread_equal()` compares two thread IDs for equality.
 
 `pthread_create()` spawns a new thread running the `start` routine with the
 given argument. The thread identifier is written to `thread` and can later be


### PR DESCRIPTION
## Summary
- add `pthread_self` and `pthread_equal` declarations
- implement wrappers that call the host pthread library
- document the new functions in README and vlibcdoc

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685a07d0376c8324b03af19b7b8e1092