### PR TITLE
Add network interface enumeration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ SRC := \
     src/netdb.c \
     src/inet_pton.c \
     src/inet_ntop.c \
+    src/ifaddrs.c \
     src/fd.c \
     src/fcntl.c \
     src/ioctl.c \

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ programs. Key features include:
 - Threading primitives and simple read-write locks
 - Thread-local storage helpers
 - Networking sockets
+- Interface enumeration via `getifaddrs`
 - Dynamic loading
 - Environment variable handling
 - Host name queries and changes
@@ -157,6 +158,20 @@ struct msghdr msg = {0};
 msg.msg_iov = iov;
 msg.msg_iovlen = 2;
 sendmsg(sock, &msg, 0);
+```
+
+### Interface Enumeration
+
+`getifaddrs` returns a linked list describing each network interface. Iterate
+through the list and free it with `freeifaddrs` when finished.
+
+```c
+struct ifaddrs *ifs;
+if (getifaddrs(&ifs) == 0) {
+    for (struct ifaddrs *i = ifs; i; i = i->ifa_next)
+        printf("%s\n", i->ifa_name);
+    freeifaddrs(ifs);
+}
 ```
 
 ## Path Utilities

--- a/include/ifaddrs.h
+++ b/include/ifaddrs.h
@@ -1,0 +1,26 @@
+#ifndef IFADDRS_H
+#define IFADDRS_H
+
+#include <sys/socket.h>
+#include <stddef.h>
+
+struct ifaddrs {
+    struct ifaddrs  *ifa_next;
+    char            *ifa_name;
+    unsigned int     ifa_flags;
+    struct sockaddr *ifa_addr;
+    struct sockaddr *ifa_netmask;
+    union {
+        struct sockaddr *ifu_broadaddr;
+        struct sockaddr *ifu_dstaddr;
+    } ifa_ifu;
+    void            *ifa_data;
+};
+
+#define ifa_broadaddr ifa_ifu.ifu_broadaddr
+#define ifa_dstaddr   ifa_ifu.ifu_dstaddr
+
+int getifaddrs(struct ifaddrs **ifap);
+void freeifaddrs(struct ifaddrs *ifa);
+
+#endif /* IFADDRS_H */

--- a/src/ifaddrs.c
+++ b/src/ifaddrs.c
@@ -1,0 +1,119 @@
+#define _GNU_SOURCE
+#include "ifaddrs.h"
+#include "memory.h"
+#include "string.h"
+#include "errno.h"
+#include "unistd.h"
+#include "sys/socket.h"
+#include "sys/ioctl.h"
+#include <sys/types.h>
+#include <net/if.h>
+#include <netinet/in.h>
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+
+extern int host_getifaddrs(struct ifaddrs **) __asm("getifaddrs");
+extern void host_freeifaddrs(struct ifaddrs *) __asm("freeifaddrs");
+
+int getifaddrs(struct ifaddrs **ifap)
+{
+    return host_getifaddrs(ifap);
+}
+
+void freeifaddrs(struct ifaddrs *ifa)
+{
+    host_freeifaddrs(ifa);
+}
+
+#else
+
+static void free_list(struct ifaddrs *ifa)
+{
+    while (ifa) {
+        struct ifaddrs *next = ifa->ifa_next;
+        free(ifa->ifa_name);
+        free(ifa->ifa_addr);
+        free(ifa->ifa_netmask);
+        free(ifa->ifa_ifu.ifu_broadaddr);
+        free(ifa);
+        ifa = next;
+    }
+}
+
+int getifaddrs(struct ifaddrs **ifap)
+{
+    if (!ifap) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0)
+        return -1;
+
+    struct ifconf ifc;
+    char buf[4096];
+    memset(buf, 0, sizeof(buf));
+    ifc.ifc_len = sizeof(buf);
+    ifc.ifc_buf = buf;
+    if (ioctl(fd, SIOCGIFCONF, &ifc) < 0) {
+        close(fd);
+        return -1;
+    }
+
+    struct ifaddrs *head = NULL;
+    struct ifaddrs **nextp = &head;
+    int n = ifc.ifc_len / sizeof(struct ifreq);
+    struct ifreq *ifr = ifc.ifc_req;
+
+    for (int i = 0; i < n; i++) {
+        struct ifreq *r = &ifr[i];
+        struct ifaddrs *cur = calloc(1, sizeof(*cur));
+        if (!cur) {
+            free_list(head);
+            close(fd);
+            return -1;
+        }
+        cur->ifa_name = strdup(r->ifr_name);
+        if (r->ifr_addr.sa_family != AF_UNSPEC) {
+            cur->ifa_addr = malloc(sizeof(struct sockaddr));
+            if (cur->ifa_addr)
+                memcpy(cur->ifa_addr, &r->ifr_addr, sizeof(struct sockaddr));
+        }
+
+        struct ifreq req;
+        memset(&req, 0, sizeof(req));
+        strncpy(req.ifr_name, r->ifr_name, IFNAMSIZ - 1);
+        if (ioctl(fd, SIOCGIFFLAGS, &req) == 0)
+            cur->ifa_flags = (unsigned int)req.ifr_flags;
+        if (ioctl(fd, SIOCGIFNETMASK, &req) == 0) {
+            cur->ifa_netmask = malloc(sizeof(struct sockaddr));
+            if (cur->ifa_netmask)
+                memcpy(cur->ifa_netmask, &req.ifr_netmask,
+                       sizeof(struct sockaddr));
+        }
+#ifdef SIOCGIFBRDADDR
+        if (ioctl(fd, SIOCGIFBRDADDR, &req) == 0) {
+            cur->ifa_ifu.ifu_broadaddr = malloc(sizeof(struct sockaddr));
+            if (cur->ifa_ifu.ifu_broadaddr)
+                memcpy(cur->ifa_ifu.ifu_broadaddr, &req.ifr_broadaddr,
+                       sizeof(struct sockaddr));
+        }
+#endif
+        *nextp = cur;
+        nextp = &cur->ifa_next;
+    }
+
+    close(fd);
+    *ifap = head;
+    return 0;
+}
+
+void freeifaddrs(struct ifaddrs *ifa)
+{
+    free_list(ifa);
+}
+
+#endif
+

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -957,6 +957,19 @@ if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0) {
 }
 ```
 
+Network interfaces can be enumerated with `getifaddrs` which fills a list of
+`struct ifaddrs`. Each entry describes an interface name, flags and optional
+addresses. Free the list with `freeifaddrs` when done.
+
+```c
+struct ifaddrs *ifas;
+if (getifaddrs(&ifas) == 0) {
+    for (struct ifaddrs *i = ifas; i; i = i->ifa_next)
+        printf("%s\n", i->ifa_name);
+    freeifaddrs(ifas);
+}
+```
+
 ## I/O Multiplexing
 
 `select` and `poll` wait for activity on multiple file descriptors.


### PR DESCRIPTION
## Summary
- define `struct ifaddrs` with prototypes for `getifaddrs` and `freeifaddrs`
- implement `src/ifaddrs.c` with BSD delegation or ioctl based fallback
- build new source and document interface enumeration
- mention feature in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685a07e76b308324ba0701160c8c08d0