### PR TITLE
Add pthread_mutex_trylock

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ programs. Key features include:
 - Basic session and process-group APIs
 - Threading primitives and simple read-write locks
 - Thread-local storage helpers
+- Non-blocking mutex acquisition with `pthread_mutex_trylock()`
 - Query the current thread ID with `pthread_self()` and compare IDs with `pthread_equal()`
 - Networking sockets
 - Interface enumeration via `getifaddrs`

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -42,6 +42,7 @@ int pthread_equal(pthread_t a, pthread_t b);
 int pthread_mutex_init(pthread_mutex_t *mutex, void *attr);
 int pthread_mutex_destroy(pthread_mutex_t *mutex);
 int pthread_mutex_lock(pthread_mutex_t *mutex);
+int pthread_mutex_trylock(pthread_mutex_t *mutex);
 int pthread_mutex_unlock(pthread_mutex_t *mutex);
 
 int pthread_cond_init(pthread_cond_t *cond, void *attr);

--- a/src/pthread.c
+++ b/src/pthread.c
@@ -23,6 +23,14 @@ int pthread_mutex_lock(pthread_mutex_t *mutex)
     return 0;
 }
 
+int pthread_mutex_trylock(pthread_mutex_t *mutex)
+{
+    if (atomic_flag_test_and_set_explicit(&mutex->locked,
+                                          memory_order_acquire))
+        return EBUSY;
+    return 0;
+}
+
 int pthread_mutex_unlock(pthread_mutex_t *mutex)
 {
     atomic_flag_clear_explicit(&mutex->locked, memory_order_release);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -594,6 +594,7 @@ int pthread_equal(pthread_t a, pthread_t b);
 int pthread_mutex_init(pthread_mutex_t *mutex, void *attr);
 int pthread_mutex_destroy(pthread_mutex_t *mutex);
 int pthread_mutex_lock(pthread_mutex_t *mutex);
+int pthread_mutex_trylock(pthread_mutex_t *mutex);
 int pthread_mutex_unlock(pthread_mutex_t *mutex);
 
 int pthread_cond_init(pthread_cond_t *cond, void *attr);
@@ -625,9 +626,11 @@ returned by the start routine. It should only be called once per thread.
 automatically when it terminates. Detached threads cannot be joined.
 
 Mutex routines provide minimal mutual exclusion. `pthread_mutex_init()`
-initializes a mutex, `pthread_mutex_lock()` acquires it, and
-`pthread_mutex_unlock()` releases it.  Destroying a locked mutex with
-`pthread_mutex_destroy()` is undefined.
+initializes a mutex, `pthread_mutex_lock()` acquires it,
+`pthread_mutex_trylock()` attempts to lock without blocking and returns
+`EBUSY` if the mutex is already held, and `pthread_mutex_unlock()`
+releases it.  Destroying a locked mutex with `pthread_mutex_destroy()` is
+undefined.
 
 Condition variables provide simple waiting semantics. A thread calls
 `pthread_cond_wait()` with a locked mutex and blocks until another thread


### PR DESCRIPTION
## Summary
- expose pthread_mutex_trylock in headers
- implement pthread_mutex_trylock for spinlock mutex
- document trylock behaviour
- mention the function in the feature list

## Testing
- `make clean`
- `make`
- `make test` *(fails: tests hang or run indefinitely)*

------
https://chatgpt.com/codex/tasks/task_e_685a0b16c7d08324b5c715e3ca23651d