### PR TITLE
Add mknod syscall wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ SRC := \
     src/chroot.c \
     src/path.c \
     src/mkfifo.c \
+    src/mknod.c \
     $(SYS_SRC) \
     src/mmap.c \
     src/msync.c \

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ programs. Key features include:
 - Memory synchronization with `msync()`
 - Advisory file locking with `flock()`
 - FIFO creation with `mkfifo()` and `mkfifoat()`
+- Device node creation with `mknod()`
 - Generic descriptor control with `ioctl()`
 - Simple alarm timers with `alarm()`
 - Basic character set conversion with `iconv`

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -17,6 +17,7 @@ int stat(const char *path, struct stat *buf);
 int fstat(int fd, struct stat *buf);
 int fstatat(int dirfd, const char *path, struct stat *buf, int flags);
 int lstat(const char *path, struct stat *buf);
+int mknod(const char *path, mode_t mode, dev_t dev);
 int mkfifo(const char *path, mode_t mode);
 int mkfifoat(int dirfd, const char *path, mode_t mode);
 

--- a/src/mknod.c
+++ b/src/mknod.c
@@ -1,0 +1,28 @@
+#include "sys/stat.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+#ifndef SYS_mknod
+extern int host_mknod(const char *path, mode_t mode, dev_t dev) __asm__("mknod");
+#endif
+
+int mknod(const char *path, mode_t mode, dev_t dev)
+{
+#ifdef SYS_mknod
+    long ret = vlibc_syscall(SYS_mknod, (long)path, mode, dev, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#else
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    return host_mknod(path, mode, dev);
+#else
+    (void)path; (void)mode; (void)dev; errno = ENOSYS; return -1;
+#endif
+#endif
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -1008,7 +1008,10 @@ chown("data.txt", 1000, 1000);
 fchmod(fd, 0644);
 fchown(fd, 1000, 1000);
 lchown("symlink", 1000, 1000);
+mknod("/tmp/loop0", S_IFBLK | 0600, makedev(7, 0));
 ```
+`mknod` creates special files like block or character devices when given a
+device number.
 `fchmodat` and `fchownat` perform the same operations relative to a directory
 file descriptor.
 


### PR DESCRIPTION
## Summary
- expose `mknod()` in `sys/stat.h`
- implement syscall wrapper with BSD fallback
- compile new source in the Makefile
- document device node creation in `vlibcdoc.md`
- mention `mknod()` in the README feature list

## Testing
- `make test` *(fails: process hangs)*

------
https://chatgpt.com/codex/tasks/task_e_685a0b24ac4c8324941fc3d95ca8b0ef