### PR TITLE
Add clock_getres wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ SRC := \
     src/uname.c \
     src/sleep.c \
     src/clock_gettime.c \
+    src/clock_getres.c \
     src/time.c \
     src/time_conv.c \
     src/time_r.c \

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ clock_gettime(CLOCK_MONOTONIC, &ts);
 ```
 
 `CLOCK_REALTIME` returns the wall-clock time.
+`clock_getres` queries the resolution of a given clock.
 
 ## Time Formatting
 

--- a/include/time.h
+++ b/include/time.h
@@ -59,6 +59,7 @@ struct tm {
 #endif
 
 int clock_gettime(int clk_id, struct timespec *ts);
+int clock_getres(int clk_id, struct timespec *res);
 
 time_t time(time_t *t);
 int gettimeofday(struct timeval *tv, void *tz);

--- a/src/clock_getres.c
+++ b/src/clock_getres.c
@@ -1,0 +1,25 @@
+#include "time.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int clock_getres(int clk_id, struct timespec *res)
+{
+#ifdef SYS_clock_getres
+    long ret = vlibc_syscall(SYS_clock_getres, clk_id, (long)res, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_clock_getres(int, struct timespec *) __asm__("clock_getres");
+    return host_clock_getres(clk_id, res);
+#else
+    (void)clk_id; (void)res;
+    errno = ENOSYS;
+    return -1;
+#endif
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -1234,6 +1234,13 @@ struct timespec ts;
 clock_gettime(CLOCK_REALTIME, &ts);
 ```
 
+The resolution of a clock can be determined with `clock_getres`:
+
+```c
+struct timespec res;
+clock_getres(CLOCK_MONOTONIC, &res);
+```
+
 Thread-safe variants `gmtime_r` and `localtime_r` fill a user-provided
 `struct tm` using the same conversion logic.  `tzset` updates the active
 timezone by reading the `TZ` environment variable on BSD systems.


### PR DESCRIPTION
## Summary
- expose `clock_getres` in `time.h`
- implement `clock_getres` wrapper
- build the new wrapper
- document clock resolution retrieval
- mention the helper in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685a0b2b7ad8832495b4e61e19d2c3a0