### PR TITLE
Add wait status macros and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ install: $(LIB)
 	# ensure iconv.h is installed
 	install -m 644 include/iconv.h $(DESTDIR)$(PREFIX)/include
 	install -d $(DESTDIR)$(PREFIX)/include/sys
+	# install system headers including wait.h
 	install -m 644 include/sys/*.h $(DESTDIR)$(PREFIX)/include/sys
 
 clean:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ programs. Key features include:
 - File I/O wrappers
 - Permission checks with `access()` and `faccessat()`
 - Process creation and control
-- Wait for children with `wait()` or `waitpid()`
+- Wait for children with `wait()` or `waitpid()` and decode results
+  with macros from `<sys/wait.h>`
 - Basic session and process-group APIs
 - Threading primitives and simple read-write locks
 - Thread-local storage helpers

--- a/include/sys/wait.h
+++ b/include/sys/wait.h
@@ -1,0 +1,27 @@
+#ifndef SYS_WAIT_H
+#define SYS_WAIT_H
+
+#include <sys/types.h>
+
+/* Waitpid option flags */
+#ifndef WNOHANG
+#define WNOHANG    1
+#endif
+#ifndef WUNTRACED
+#define WUNTRACED  2
+#endif
+#ifndef WCONTINUED
+#define WCONTINUED 8
+#endif
+
+/* Status decoding macros */
+#define WEXITSTATUS(status)   (((status) >> 8) & 0xff)
+#define WTERMSIG(status)      ((status) & 0x7f)
+#define WSTOPSIG(status)      WEXITSTATUS(status)
+#define WIFEXITED(status)     (WTERMSIG(status) == 0)
+#define WIFSIGNALED(status)   (WTERMSIG(status) != 0 && WTERMSIG(status) != 0x7f)
+#define WIFSTOPPED(status)    (((status) & 0xff) == 0x7f)
+#define WIFCONTINUED(status)  ((status) == 0xffff)
+#define WCOREDUMP(status)     ((status) & 0x80)
+
+#endif /* SYS_WAIT_H */

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -538,6 +538,15 @@ argument array on behalf of the caller. `execl` and `execlp` accept a
 variable list of arguments terminated by `NULL`. `execle` is similar but
 takes a custom environment pointer after the final `NULL` argument.
 
+### Wait Status Helpers
+
+Macros in `<sys/wait.h>` decode the integer status returned by `wait()`
+and `waitpid()`. Use `WIFEXITED(status)` to detect normal termination
+and `WEXITSTATUS(status)` to read the child's exit code. When a signal
+causes termination, `WIFSIGNALED(status)` becomes true and
+`WTERMSIG(status)` yields the signal number. `WIFSTOPPED(status)` tests
+if the child was stopped by a signal.
+
 The convenience `system()` call executes a shell command by forking and
 invoking `/bin/sh -c command`. It returns the raw status from `waitpid`
 and is intended only for simple helper tasks.


### PR DESCRIPTION
## Summary
- add `<sys/wait.h>` with portable macros for decoding `wait` status
- install system headers including the new one
- document wait status helpers in `vlibcdoc.md`
- mention `<sys/wait.h>` in README feature list

## Testing
- `make test` *(fails: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685a11f50eac8324a9a2fc9017882991