### PR TITLE
Add reentrant password and group lookup APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,8 @@ SRC := \
     src/getline.c \
     src/getpass.c \
     src/getlogin.c \
+    src/pwd_r.c \
+    src/grp_r.c \
     src/pwd.c \
     src/grp.c \
     src/uid.c \

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ programs. Key features include:
 - Environment variable handling
 - Host name queries and changes
 - Login name retrieval with `getlogin()`
+- Thread-safe user and group lookups with `getpwuid_r`, `getpwnam_r`,
+  `getgrgid_r`, and `getgrnam_r`
 - Secure password input with `getpass()`
 - Syslog-style logging
 - Change root directories with `chroot()` when supported

--- a/include/grp.h
+++ b/include/grp.h
@@ -2,6 +2,7 @@
 #define GRP_H
 
 #include <sys/types.h>
+#include <stddef.h>
 
 struct group {
     char *gr_name;
@@ -12,5 +13,9 @@ struct group {
 
 struct group *getgrgid(gid_t gid);
 struct group *getgrnam(const char *name);
+int getgrgid_r(gid_t gid, struct group *grp, char *buf, size_t buflen,
+               struct group **result);
+int getgrnam_r(const char *name, struct group *grp, char *buf, size_t buflen,
+               struct group **result);
 
 #endif /* GRP_H */

--- a/include/pwd.h
+++ b/include/pwd.h
@@ -2,6 +2,7 @@
 #define PWD_H
 
 #include <sys/types.h>
+#include <stddef.h>
 
 struct passwd {
     char *pw_name;
@@ -15,5 +16,9 @@ struct passwd {
 
 struct passwd *getpwuid(uid_t uid);
 struct passwd *getpwnam(const char *name);
+int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf, size_t buflen,
+               struct passwd **result);
+int getpwnam_r(const char *name, struct passwd *pwd, char *buf, size_t buflen,
+               struct passwd **result);
 
 #endif /* PWD_H */

--- a/src/grp_r.c
+++ b/src/grp_r.c
@@ -1,0 +1,150 @@
+#include "grp.h"
+#include "io.h"
+#include "string.h"
+#include "stdlib.h"
+#include "env.h"
+#include <fcntl.h>
+#include <unistd.h>
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+
+static const char *group_path(void)
+{
+    const char *p = getenv("VLIBC_GROUP");
+    if (p && *p)
+        return p;
+    return "/etc/group";
+}
+
+static int parse_line_r(const char *line, struct group *gr,
+                        char *buf, size_t buflen)
+{
+    char lbuf[256];
+    strncpy(lbuf, line, sizeof(lbuf) - 1);
+    lbuf[sizeof(lbuf) - 1] = '\0';
+
+    char *save;
+    char *name = strtok_r(lbuf, ":", &save);
+    char *passwd = strtok_r(NULL, ":", &save);
+    char *gid_s = strtok_r(NULL, ":", &save);
+    char *mem_list = strtok_r(NULL, ":\n", &save);
+    if (!name || !passwd || !gid_s || !mem_list)
+        return -1;
+
+    /* count members */
+    char list_copy[256];
+    strncpy(list_copy, mem_list, sizeof(list_copy) - 1);
+    list_copy[sizeof(list_copy) - 1] = '\0';
+    int count = 0;
+    char *save_m;
+    for (char *m = strtok_r(list_copy, ",", &save_m); m; m = strtok_r(NULL, ",", &save_m))
+        count++;
+
+    size_t need = (count + 1) * sizeof(char *);
+    if (need > buflen)
+        return -1;
+    char **memarr = (char **)buf;
+    buf += need;
+    buflen -= need;
+
+    size_t len;
+    len = strlcpy(buf, name, buflen);
+    if (len >= buflen)
+        return -1;
+    gr->gr_name = buf; buf += len + 1; buflen -= len + 1;
+
+    len = strlcpy(buf, passwd, buflen);
+    if (len >= buflen)
+        return -1;
+    gr->gr_passwd = buf; buf += len + 1; buflen -= len + 1;
+
+    gr->gr_gid = (gid_t)atoi(gid_s);
+
+    strncpy(list_copy, mem_list, sizeof(list_copy) - 1);
+    list_copy[sizeof(list_copy) - 1] = '\0';
+    int i = 0;
+    for (char *m = strtok_r(list_copy, ",", &save_m); m && i < count;
+         m = strtok_r(NULL, ",", &save_m)) {
+        len = strlcpy(buf, m, buflen);
+        if (len >= buflen)
+            return -1;
+        memarr[i++] = buf;
+        buf += len + 1;
+        buflen -= len + 1;
+    }
+    memarr[i] = NULL;
+    gr->gr_mem = memarr;
+    return 0;
+}
+
+static int lookup_r(const char *name, gid_t gid, int by_name,
+                    struct group *grp, char *buf, size_t buflen,
+                    struct group **result)
+{
+    if (!grp || !buf || !result)
+        return -1;
+    *result = NULL;
+
+    int fd = open(group_path(), O_RDONLY, 0);
+    if (fd < 0)
+        return -1;
+    char filebuf[4096];
+    ssize_t n = read(fd, filebuf, sizeof(filebuf) - 1);
+    close(fd);
+    if (n <= 0)
+        return -1;
+    filebuf[n] = '\0';
+
+    char *save_line;
+    for (char *line = strtok_r(filebuf, "\n", &save_line); line;
+         line = strtok_r(NULL, "\n", &save_line)) {
+        if (parse_line_r(line, grp, buf, buflen) != 0)
+            continue;
+        if (by_name) {
+            if (strcmp(grp->gr_name, name) == 0) {
+                *result = grp;
+                return 0;
+            }
+        } else {
+            if (grp->gr_gid == gid) {
+                *result = grp;
+                return 0;
+            }
+        }
+    }
+    return -1;
+}
+
+int getgrgid_r(gid_t gid, struct group *grp, char *buf, size_t buflen,
+               struct group **result)
+{
+    return lookup_r(NULL, gid, 0, grp, buf, buflen, result);
+}
+
+int getgrnam_r(const char *name, struct group *grp, char *buf, size_t buflen,
+               struct group **result)
+{
+    return lookup_r(name, 0, 1, grp, buf, buflen, result);
+}
+
+#else
+
+extern int host_getgrgid_r(gid_t, struct group *, char *, size_t,
+                           struct group **) __asm("getgrgid_r");
+extern int host_getgrnam_r(const char *, struct group *, char *, size_t,
+                           struct group **) __asm("getgrnam_r");
+
+int getgrgid_r(gid_t gid, struct group *grp, char *buf, size_t buflen,
+               struct group **result)
+{
+    return host_getgrgid_r(gid, grp, buf, buflen, result);
+}
+
+int getgrnam_r(const char *name, struct group *grp, char *buf, size_t buflen,
+               struct group **result)
+{
+    return host_getgrnam_r(name, grp, buf, buflen, result);
+}
+
+#endif

--- a/src/pwd_r.c
+++ b/src/pwd_r.c
@@ -1,0 +1,139 @@
+#include "pwd.h"
+#include "io.h"
+#include "string.h"
+#include "stdlib.h"
+#include "env.h"
+#include <fcntl.h>
+#include <unistd.h>
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+
+static const char *passwd_path(void)
+{
+    const char *p = getenv("VLIBC_PASSWD");
+    if (p && *p)
+        return p;
+    return "/etc/passwd";
+}
+
+static int parse_line_r(const char *line, struct passwd *pw,
+                        char *buf, size_t buflen)
+{
+    char lbuf[256];
+    strncpy(lbuf, line, sizeof(lbuf) - 1);
+    lbuf[sizeof(lbuf) - 1] = '\0';
+
+    char *save;
+    char *name = strtok_r(lbuf, ":", &save);
+    char *passwd = strtok_r(NULL, ":", &save);
+    char *uid_s = strtok_r(NULL, ":", &save);
+    char *gid_s = strtok_r(NULL, ":", &save);
+    char *gecos = strtok_r(NULL, ":", &save);
+    char *dir = strtok_r(NULL, ":", &save);
+    char *shell = strtok_r(NULL, ":\n", &save);
+    if (!name || !passwd || !uid_s || !gid_s || !gecos || !dir || !shell)
+        return -1;
+
+    size_t len;
+
+    len = strlcpy(buf, name, buflen);
+    if (len >= buflen)
+        return -1;
+    pw->pw_name = buf; buf += len + 1; buflen -= len + 1;
+
+    len = strlcpy(buf, passwd, buflen);
+    if (len >= buflen)
+        return -1;
+    pw->pw_passwd = buf; buf += len + 1; buflen -= len + 1;
+
+    len = strlcpy(buf, gecos, buflen);
+    if (len >= buflen)
+        return -1;
+    pw->pw_gecos = buf; buf += len + 1; buflen -= len + 1;
+
+    len = strlcpy(buf, dir, buflen);
+    if (len >= buflen)
+        return -1;
+    pw->pw_dir = buf; buf += len + 1; buflen -= len + 1;
+
+    len = strlcpy(buf, shell, buflen);
+    if (len >= buflen)
+        return -1;
+    pw->pw_shell = buf; buf += len + 1; buflen -= len + 1;
+
+    pw->pw_uid = (uid_t)atoi(uid_s);
+    pw->pw_gid = (gid_t)atoi(gid_s);
+    return 0;
+}
+
+static int lookup_r(const char *name, uid_t uid, int by_name,
+                    struct passwd *pwd, char *buf, size_t buflen,
+                    struct passwd **result)
+{
+    if (!pwd || !buf || !result)
+        return -1;
+    *result = NULL;
+
+    int fd = open(passwd_path(), O_RDONLY, 0);
+    if (fd < 0)
+        return -1;
+    char filebuf[4096];
+    ssize_t n = read(fd, filebuf, sizeof(filebuf) - 1);
+    close(fd);
+    if (n <= 0)
+        return -1;
+    filebuf[n] = '\0';
+
+    char *save_line;
+    for (char *line = strtok_r(filebuf, "\n", &save_line); line;
+         line = strtok_r(NULL, "\n", &save_line)) {
+        if (parse_line_r(line, pwd, buf, buflen) != 0)
+            continue;
+        if (by_name) {
+            if (strcmp(pwd->pw_name, name) == 0) {
+                *result = pwd;
+                return 0;
+            }
+        } else {
+            if (pwd->pw_uid == uid) {
+                *result = pwd;
+                return 0;
+            }
+        }
+    }
+    return -1;
+}
+
+int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf, size_t buflen,
+               struct passwd **result)
+{
+    return lookup_r(NULL, uid, 0, pwd, buf, buflen, result);
+}
+
+int getpwnam_r(const char *name, struct passwd *pwd, char *buf, size_t buflen,
+               struct passwd **result)
+{
+    return lookup_r(name, 0, 1, pwd, buf, buflen, result);
+}
+
+#else
+
+extern int host_getpwuid_r(uid_t, struct passwd *, char *, size_t,
+                           struct passwd **) __asm("getpwuid_r");
+extern int host_getpwnam_r(const char *, struct passwd *, char *, size_t,
+                           struct passwd **) __asm("getpwnam_r");
+
+int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf, size_t buflen,
+               struct passwd **result)
+{
+    return host_getpwuid_r(uid, pwd, buf, buflen, result);
+}
+
+int getpwnam_r(const char *name, struct passwd *pwd, char *buf, size_t buflen,
+               struct passwd **result)
+{
+    return host_getpwnam_r(name, pwd, buf, buflen, result);
+}
+
+#endif

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -1190,11 +1190,18 @@ struct passwd {
 
 struct passwd *getpwuid(uid_t uid);
 struct passwd *getpwnam(const char *name);
+int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf, size_t buflen,
+               struct passwd **result);
+int getpwnam_r(const char *name, struct passwd *pwd, char *buf, size_t buflen,
+               struct passwd **result);
 char *getlogin(void);
 ```
 
 On BSD systems vlibc parses the file directly. The location can be
 overridden via the `VLIBC_PASSWD` environment variable for testing.
+
+`getpwuid_r()` and `getpwnam_r()` perform the same search but store
+results in caller supplied memory so they are safe for concurrent use.
 
 `getlogin()` obtains the user name for the current UID using
 `getpwuid(getuid())`.  The resulting string is cached in thread-local
@@ -1214,11 +1221,16 @@ struct group {
 
 struct group *getgrgid(gid_t gid);
 struct group *getgrnam(const char *name);
+int getgrgid_r(gid_t gid, struct group *grp, char *buf, size_t buflen,
+               struct group **result);
+int getgrnam_r(const char *name, struct group *grp, char *buf, size_t buflen,
+               struct group **result);
 ```
 
 As with the password file, BSD platforms parse the group database directly.
 The path can be overridden via the `VLIBC_GROUP` environment variable when
-running tests.
+running tests. The `*_r` variants fill caller provided buffers and are
+thread-safe.
 
 ## Time Formatting
 


### PR DESCRIPTION
## Summary
- expose `getpwuid_r`, `getpwnam_r`, `getgrgid_r`, and `getgrnam_r`
- implement new thread-safe lookup routines for BSD text databases
- document the new functions in README and vlibcdoc

## Testing
- `make test` *(fails: command interrupted / environment limitation)*

------
https://chatgpt.com/codex/tasks/task_e_685a1468e9988324ac5aa3fed80c92ea