### PR TITLE
Implement gai_strerror and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ programs. Key features include:
 - Non-blocking mutex acquisition with `pthread_mutex_trylock()`
 - Query the current thread ID with `pthread_self()` and compare IDs with `pthread_equal()`
 - Networking sockets
+- Human-readable address errors with `gai_strerror()`
 - Interface enumeration via `getifaddrs`
 - Dynamic loading
 - Environment variable handling

--- a/include/netdb.h
+++ b/include/netdb.h
@@ -43,4 +43,20 @@ struct hostent {
 struct hostent *gethostbyname(const char *name);
 struct hostent *gethostbyaddr(const void *addr, socklen_t len, int type);
 
+/* getaddrinfo error codes */
+#ifndef EAI_BADFLAGS
+#define EAI_BADFLAGS    -1
+#define EAI_NONAME      -2
+#define EAI_AGAIN       -3
+#define EAI_FAIL        -4
+#define EAI_FAMILY      -6
+#define EAI_SOCKTYPE    -7
+#define EAI_SERVICE     -8
+#define EAI_MEMORY      -10
+#define EAI_SYSTEM      -11
+#define EAI_OVERFLOW    -12
+#endif
+
+const char *gai_strerror(int errcode);
+
 #endif /* NETDB_H */

--- a/src/netdb.c
+++ b/src/netdb.c
@@ -388,3 +388,33 @@ struct hostent *gethostbyaddr(const void *addr, socklen_t len, int type)
     errno = EAFNOSUPPORT;
     return NULL;
 }
+
+struct gai_entry {
+    int code;
+    const char *msg;
+};
+
+static const struct gai_entry gai_table[] = {
+    { EAI_BADFLAGS, "Invalid value for ai_flags" },
+    { EAI_NONAME, "Name or service not known" },
+    { EAI_AGAIN, "Temporary failure in name resolution" },
+    { EAI_FAIL, "Non-recoverable failure in name resolution" },
+    { EAI_FAMILY, "Address family not supported" },
+    { EAI_SOCKTYPE, "Socket type not supported" },
+    { EAI_SERVICE, "Service not supported for socket type" },
+    { EAI_MEMORY, "Memory allocation failure" },
+    { EAI_SYSTEM, "System error" },
+    { EAI_OVERFLOW, "Argument buffer overflow" },
+    { 0, NULL }
+};
+
+const char *gai_strerror(int errcode)
+{
+    for (size_t i = 0; gai_table[i].msg; i++) {
+        if (gai_table[i].code == errcode)
+            return gai_table[i].msg;
+    }
+    static char buf[32];
+    snprintf(buf, sizeof(buf), "Unknown error %d", errcode);
+    return buf;
+}

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -963,6 +963,16 @@ int fd = socket(AF_INET, SOCK_STREAM, 0);
 }
 ```
 
+When `getaddrinfo` fails it returns an `EAI_*` code. Use
+`gai_strerror` to obtain a human readable description:
+
+```c
+struct addrinfo *ai;
+int r = getaddrinfo("nosuch.host", NULL, NULL, &ai);
+if (r != 0)
+    fprintf(stderr, "%s\n", gai_strerror(r));
+```
+
 ### Legacy Lookup API
 
 Older programs may still rely on `gethostbyname` and `gethostbyaddr`.


### PR DESCRIPTION
## Summary
- support common `EAI_*` codes in `<netdb.h>`
- implement `gai_strerror` in `src/netdb.c`
- document the function in the networking section
- mention the helper in README

## Testing
- `make` *(builds library)*
- `make test` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685a16e3878883249fc482f4868b5a0e