### PR TITLE
Add qsort_r with callback context

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ programs. Key features include:
 - Syslog-style logging
 - Change root directories with `chroot()` when supported
 - Directory scanning helpers
+- Array sorting with `qsort`, `qsort_r` and `bsearch`
 - Standard `assert` macro for runtime checks
 - Extended math helpers
 - Descriptor-based printing with `dprintf()`/`vdprintf()`

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -34,6 +34,8 @@ double atof(const char *nptr);
 /* Sorting helpers */
 void qsort(void *base, size_t nmemb, size_t size,
            int (*compar)(const void *, const void *));
+void qsort_r(void *base, size_t nmemb, size_t size,
+             int (*compar)(const void *, const void *, void *), void *ctx);
 void *bsearch(const void *key, const void *base, size_t nmemb, size_t size,
               int (*compar)(const void *, const void *));
 

--- a/src/qsort.c
+++ b/src/qsort.c
@@ -23,6 +23,20 @@ void qsort(void *base, size_t nmemb, size_t size,
     }
 }
 
+void qsort_r(void *base, size_t nmemb, size_t size,
+             int (*compar)(const void *, const void *, void *), void *ctx)
+{
+    char *b = base;
+    for (size_t i = 0; i < nmemb; i++) {
+        for (size_t j = i + 1; j < nmemb; j++) {
+            char *pi = b + i * size;
+            char *pj = b + j * size;
+            if (compar(pi, pj, ctx) > 0)
+                swap(pi, pj, size);
+        }
+    }
+}
+
 void *bsearch(const void *key, const void *base, size_t nmemb, size_t size,
               int (*compar)(const void *, const void *))
 {

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2131,6 +2131,25 @@ static const char *test_qsort_strings(void)
     return 0;
 }
 
+static int int_cmp_dir(const void *a, const void *b, void *ctx)
+{
+    int dir = *(int *)ctx;
+    int ia = *(const int *)a;
+    int ib = *(const int *)b;
+    return dir * ((ia > ib) - (ia < ib));
+}
+
+static const char *test_qsort_r_desc(void)
+{
+    int arr[] = {4, 2, 7, 1, -1};
+    int dir = -1;
+    qsort_r(arr, 5, sizeof(int), int_cmp_dir, &dir);
+    int sorted[] = {7, 4, 2, 1, -1};
+    for (int i = 0; i < 5; ++i)
+        mu_assert("qsort_r", arr[i] == sorted[i]);
+    return 0;
+}
+
 static const char *test_regex_backref_basic(void)
 {
     regex_t re;
@@ -2410,6 +2429,7 @@ static const char *all_tests(void)
     mu_run_test(test_ftw_walk);
     mu_run_test(test_qsort_int);
     mu_run_test(test_qsort_strings);
+    mu_run_test(test_qsort_r_desc);
     mu_run_test(test_regex_backref_basic);
     mu_run_test(test_regex_backref_fail);
     mu_run_test(test_math_functions);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -413,12 +413,31 @@ state in a user-provided variable so it can be used in threaded code.
 
 `qsort` sorts an array in place using a user-supplied comparison
 function while `bsearch` performs binary search on a sorted array.
+`qsort_r` acts like `qsort` but forwards a caller provided context
+pointer to the comparison callback.
 
 ```c
 int values[] = {4, 2, 7};
 qsort(values, 3, sizeof(int), cmp_int);
 int key = 7;
 int *found = bsearch(&key, values, 3, sizeof(int), cmp_int);
+```
+
+`qsort_r` accepts an extra context pointer which is passed to the
+comparison function. This can be used to change the sort order
+dynamically:
+
+```c
+static int cmp_dir(const void *a, const void *b, void *ctx)
+{
+    int dir = *(int *)ctx;        // 1 for ascending, -1 for descending
+    int x = *(const int *)a;
+    int y = *(const int *)b;
+    return dir * ((x > y) - (x < y));
+}
+
+int desc = -1;
+qsort_r(values, 3, sizeof(int), cmp_dir, &desc);
 ```
 
 ## Regular Expressions


### PR DESCRIPTION
## Summary
- expose `qsort_r` declaration in `<stdlib.h>`
- implement `qsort_r` alongside existing sort helpers
- document `qsort_r` with an example
- update README feature list
- test `qsort_r` using new unit test

## Testing
- `timeout 5 ./tests/run_tests` *(fails: exit status 124)*

------
https://chatgpt.com/codex/tasks/task_e_685a1f27dbe083249055eaf347072d84