### PR TITLE
Add wcsftime and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ SRC := \
     src/time_r.c \
     src/itimer.c \
     src/strftime.c \
+    src/wcsftime.c \
     src/strptime.c \
     src/stat.c \
     src/statvfs.c \

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -45,4 +45,9 @@ int vwscanf(const wchar_t *format, va_list ap);
 int vfwscanf(FILE *stream, const wchar_t *format, va_list ap);
 int vswscanf(const wchar_t *str, const wchar_t *format, va_list ap);
 
+/* Time formatting */
+#include "time.h"
+size_t wcsftime(wchar_t *s, size_t max, const wchar_t *format,
+                const struct tm *tm);
+
 #endif /* WCHAR_H */

--- a/src/wcsftime.c
+++ b/src/wcsftime.c
@@ -1,0 +1,33 @@
+#include "wchar.h"
+#include "time.h"
+#include "stdlib.h"
+
+size_t wcsftime(wchar_t *s, size_t max, const wchar_t *format, const struct tm *tm)
+{
+    if (!s || !format || !tm || max == 0)
+        return 0;
+
+    size_t flen = wcstombs(NULL, format, 0);
+    char *fmt = malloc(flen + 1);
+    if (!fmt)
+        return 0;
+    wcstombs(fmt, format, flen + 1);
+
+    char *buf = malloc(max);
+    if (!buf) {
+        free(fmt);
+        return 0;
+    }
+
+    size_t n = strftime(buf, max, fmt, tm);
+    if (n > 0) {
+        for (size_t i = 0; i < n && i < max; i++)
+            s[i] = (unsigned char)buf[i];
+        if (n < max)
+            s[n] = 0;
+    }
+
+    free(buf);
+    free(fmt);
+    return n;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1581,6 +1581,42 @@ static const char *test_strftime_extended(void)
     return 0;
 }
 
+static const char *test_wcsftime_basic(void)
+{
+    struct tm tm = {
+        .tm_year = 123,
+        .tm_mon = 4,
+        .tm_mday = 6,
+        .tm_hour = 7,
+        .tm_min = 8,
+        .tm_sec = 9
+    };
+    wchar_t buf[32];
+    size_t n = wcsftime(buf, sizeof(buf)/sizeof(wchar_t), L"%Y-%m-%d %H:%M:%S", &tm);
+    mu_assert("wcsftime len", n == wcslen(L"2023-05-06 07:08:09"));
+    mu_assert("wcsftime str", wcscmp(buf, L"2023-05-06 07:08:09") == 0);
+    return 0;
+}
+
+static const char *test_wcsftime_extended(void)
+{
+    struct tm tm = {
+        .tm_year = 123,
+        .tm_mon = 4,
+        .tm_mday = 6,
+        .tm_wday = 6,
+        .tm_hour = 7,
+        .tm_min = 8,
+        .tm_sec = 9
+    };
+    wchar_t buf[64];
+    size_t n = wcsftime(buf, sizeof(buf)/sizeof(wchar_t),
+                        L"%a %b %d %Y %H:%M:%S %Z %z %w %u", &tm);
+    mu_assert("wcsftime len2", n == wcslen(L"Sat May 06 2023 07:08:09 UTC +0000 6 6"));
+    mu_assert("wcsftime str2", wcscmp(buf, L"Sat May 06 2023 07:08:09 UTC +0000 6 6") == 0);
+    return 0;
+}
+
 static const char *test_strptime_basic(void)
 {
     struct tm tm;
@@ -2598,6 +2634,8 @@ static const char *all_tests(void)
     mu_run_test(test_sleep_functions);
     mu_run_test(test_strftime_basic);
     mu_run_test(test_strftime_extended);
+    mu_run_test(test_wcsftime_basic);
+    mu_run_test(test_wcsftime_extended);
     mu_run_test(test_strptime_basic);
     mu_run_test(test_time_conversions);
     mu_run_test(test_time_r_conversions);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -1354,6 +1354,7 @@ char buf[64];
 strftime(buf, sizeof(buf), "%a %b %d %Y %H:%M:%S %Z %z", &tm);
 // "Sat May 06 2023 07:08:09 UTC +0000"
 ```
+`wcsftime` performs the same conversion but writes to a wide-character buffer.
 `timegm` converts a `struct tm` in UTC back to `time_t` using the same logic as `mktime` but without timezone adjustments.
 
 ## Locale Support


### PR DESCRIPTION
## Summary
- implement `wcsftime` using `strftime`
- expose prototype in `wchar.h`
- test wide-character time formatting
- document the API

## Testing
- `make test` *(fails: tests hang in this environment)*
- `timeout 5 ./tests/run_tests` *(fails: exit code 124)*

------
https://chatgpt.com/codex/tasks/task_e_685ad4d70f20832490fd6a55d3c00672