### PR TITLE
Implement pathconf functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ SRC := \
     src/realpath.c \
     src/chroot.c \
     src/path.c \
+    src/pathconf.c \
     src/mkfifo.c \
     src/mknod.c \
     $(SYS_SRC) \

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ programs. Key features include:
 - FIFO creation with `mkfifo()` and `mkfifoat()`
 - Device node creation with `mknod()`
 - Generic descriptor control with `ioctl()`
+- Filesystem limits with `pathconf()` and `fpathconf()`
 - Simple alarm timers with `alarm()`
 - Basic character set conversion with `iconv`
 

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -28,6 +28,9 @@ int setegid(gid_t egid);
 long sysconf(int name);
 int getpagesize(void);
 
+long pathconf(const char *path, int name);
+long fpathconf(int fd, int name);
+
 char *getlogin(void);
 char *getpass(const char *prompt);
 

--- a/src/pathconf.c
+++ b/src/pathconf.c
@@ -1,0 +1,44 @@
+#include "unistd.h"
+#include "sys/statvfs.h"
+#include "errno.h"
+#include <limits.h>
+
+long pathconf(const char *path, int name)
+{
+    struct statvfs sv;
+    switch (name) {
+    case _PC_NAME_MAX:
+        if (statvfs(path, &sv) < 0)
+            return -1;
+        return (long)sv.f_namemax;
+    case _PC_PATH_MAX:
+#ifdef PATH_MAX
+        return PATH_MAX;
+#else
+        return 4096;
+#endif
+    default:
+        errno = EINVAL;
+        return -1;
+    }
+}
+
+long fpathconf(int fd, int name)
+{
+    struct statvfs sv;
+    switch (name) {
+    case _PC_NAME_MAX:
+        if (fstatvfs(fd, &sv) < 0)
+            return -1;
+        return (long)sv.f_namemax;
+    case _PC_PATH_MAX:
+#ifdef PATH_MAX
+        return PATH_MAX;
+#else
+        return 4096;
+#endif
+    default:
+        errno = EINVAL;
+        return -1;
+    }
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2159,6 +2159,18 @@ static const char *test_realpath_basic(void)
     return 0;
 }
 
+static const char *test_pathconf_basic(void)
+{
+    long n = pathconf("/", _PC_NAME_MAX);
+    mu_assert("pathconf", n > 0);
+    int fd = open("/", O_RDONLY);
+    mu_assert("open root", fd >= 0);
+    long nf = fpathconf(fd, _PC_NAME_MAX);
+    close(fd);
+    mu_assert("fpathconf", nf == n);
+    return 0;
+}
+
 static const char *test_dirent(void)
 {
     DIR *d = opendir("tests");
@@ -2680,6 +2692,7 @@ static const char *all_tests(void)
     mu_run_test(test_atexit_handler);
     mu_run_test(test_getcwd_chdir);
     mu_run_test(test_realpath_basic);
+    mu_run_test(test_pathconf_basic);
     mu_run_test(test_passwd_lookup);
     mu_run_test(test_group_lookup);
     mu_run_test(test_getlogin_fn);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -1180,6 +1180,14 @@ if (statvfs("/", &sv) == 0) {
 }
 ```
 
+`pathconf` and `fpathconf` query limits such as the maximum filename
+length for a given directory. vlibc uses `sysconf` together with the
+host `statvfs` implementation on BSD systems to answer these queries.
+
+```c
+long n = pathconf("/", _PC_NAME_MAX); /* typically 255 */
+```
+
 ## Directory Iteration
 
 Use `opendir`, `readdir`, and `closedir` from `dirent.h` to traverse


### PR DESCRIPTION
## Summary
- add pathconf/fpathconf implementations
- expose the APIs in unistd.h
- document filesystem limit helpers
- mention new feature in README
- test NAME_MAX queries via pathconf

## Testing
- `timeout 30s make test` *(fails: terminated)*

------
https://chatgpt.com/codex/tasks/task_e_685ae2b67f0c83248eb9d84af5dbb630