### PR TITLE
Add confstr wrapper and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ SRC := \
     src/wctype.c \
     src/memstream.c \
     src/tempfile.c \
+    src/confstr.c \
     src/sysconf.c \
     src/syslog.c \
     src/getline.c \

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ programs. Key features include:
 - Device node creation with `mknod()`
 - Generic descriptor control with `ioctl()`
 - Filesystem limits with `pathconf()` and `fpathconf()`
+- Query configuration strings with `confstr()`
 - Simple alarm timers with `alarm()`
 - Basic character set conversion with `iconv`
 

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -28,6 +28,8 @@ int setegid(gid_t egid);
 long sysconf(int name);
 int getpagesize(void);
 
+size_t confstr(int name, char *buf, size_t len);
+
 long pathconf(const char *path, int name);
 long fpathconf(int fd, int name);
 

--- a/src/confstr.c
+++ b/src/confstr.c
@@ -1,0 +1,21 @@
+#include "unistd.h"
+#include "errno.h"
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+extern size_t host_confstr(int, char *, size_t) __asm("confstr");
+
+size_t confstr(int name, char *buf, size_t len)
+{
+    return host_confstr(name, buf, len);
+}
+#else
+size_t confstr(int name, char *buf, size_t len)
+{
+    (void)name;
+    (void)buf;
+    (void)len;
+    errno = EINVAL;
+    return 0;
+}
+#endif

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1738,6 +1738,28 @@ static const char *test_uname_fn(void)
     return 0;
 }
 
+static const char *test_confstr_path(void)
+{
+#ifdef _CS_PATH
+    char buf[256];
+    errno = 0;
+    size_t n = confstr(_CS_PATH, buf, sizeof(buf));
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    mu_assert("confstr path", n > 0 && n < sizeof(buf));
+    mu_assert("non-empty", buf[0] != '\0');
+#else
+    mu_assert("confstr unsupported", n == 0);
+    mu_assert("errno EINVAL", errno == EINVAL);
+#endif
+#else
+    errno = 0;
+    size_t n = confstr(0, NULL, 0);
+    mu_assert("confstr absent", n == 0 && errno == EINVAL);
+#endif
+    return 0;
+}
+
 static const char *test_error_reporting(void)
 {
     errno = ENOENT;
@@ -2671,6 +2693,7 @@ static const char *all_tests(void)
     mu_run_test(test_locale_from_env);
     mu_run_test(test_gethostname_fn);
     mu_run_test(test_uname_fn);
+    mu_run_test(test_confstr_path);
     mu_run_test(test_error_reporting);
     mu_run_test(test_strsignal_names);
     mu_run_test(test_system_fn);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -827,6 +827,17 @@ if (uname(&u) == 0) {
 }
 ```
 
+The `confstr()` function retrieves string-valued system parameters such as
+`_CS_PATH`. When the query is unsupported it returns `0` and sets `errno` to
+`EINVAL`.
+
+```c
+char path[256];
+size_t n = confstr(_CS_PATH, path, sizeof(path));
+if (n > 0 && n < sizeof(path))
+    printf("search path: %s\n", path);
+```
+
 ## Basic File I/O
 
 Thin wrappers around the kernel's file APIs live in `io.h`. Functions


### PR DESCRIPTION
## Summary
- implement `confstr` wrapper with BSD fallback
- expose `confstr` in `unistd.h`
- document `confstr` usage
- mention `confstr` feature in README
- add unit test for `_CS_PATH`

## Testing
- `make test` *(fails: tests hang in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_685ae840a9c08324b4db74f1fe902d97