### PR TITLE
Add getrusage implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ SRC := \
     src/math.c \
     src/math_extra.c \
     src/rlimit.c \
+    src/getrusage.c \
     src/regex.c \
     src/fnmatch.c \
     src/scandir.c \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ programs. Key features include:
 - Query configuration strings with `confstr()`
 - Simple alarm timers with `alarm()`
 - POSIX interval timers with `timer_create` and `timer_settime()`
+- Resource usage statistics with `getrusage()`
 - Basic character set conversion with `iconv`
 
 **Note**: vlibc provides only a small subset of the standard C library. Some

--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -2,6 +2,7 @@
 #define SYS_RESOURCE_H
 
 #include <sys/types.h>
+#include "../time.h"
 
 /* Resource limits */
 #ifndef RLIMIT_CPU
@@ -72,6 +73,38 @@ struct rlimit {
     rlim_t rlim_cur;
     rlim_t rlim_max;
 };
+
+/* Resource usage targets */
+#ifndef RUSAGE_SELF
+#define RUSAGE_SELF 0
+#endif
+#ifndef RUSAGE_CHILDREN
+#define RUSAGE_CHILDREN -1
+#endif
+#ifndef RUSAGE_THREAD
+#define RUSAGE_THREAD 1
+#endif
+
+struct rusage {
+    struct timeval ru_utime;  /* user CPU time used */
+    struct timeval ru_stime;  /* system CPU time used */
+    long ru_maxrss;           /* maximum resident set size */
+    long ru_ixrss;            /* integral shared memory size */
+    long ru_idrss;            /* integral unshared data size */
+    long ru_isrss;            /* integral unshared stack size */
+    long ru_minflt;           /* page reclaims */
+    long ru_majflt;           /* page faults */
+    long ru_nswap;            /* swaps */
+    long ru_inblock;          /* block input operations */
+    long ru_oublock;          /* block output operations */
+    long ru_msgsnd;           /* IPC messages sent */
+    long ru_msgrcv;           /* IPC messages received */
+    long ru_nsignals;         /* signals received */
+    long ru_nvcsw;            /* voluntary context switches */
+    long ru_nivcsw;           /* involuntary context switches */
+};
+
+int getrusage(int who, struct rusage *usage);
 
 int getrlimit(int resource, struct rlimit *rlim);
 int setrlimit(int resource, const struct rlimit *rlim);

--- a/src/getrusage.c
+++ b/src/getrusage.c
@@ -1,0 +1,25 @@
+#include "sys/resource.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int getrusage(int who, struct rusage *usage)
+{
+#if defined(SYS_getrusage)
+    long ret = vlibc_syscall(SYS_getrusage, who, (long)usage, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_getrusage(int, struct rusage *) __asm("getrusage");
+    return host_getrusage(who, usage);
+#else
+    (void)who; (void)usage;
+    errno = ENOSYS;
+    return -1;
+#endif
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -43,6 +43,7 @@
 #include <sys/wait.h>
 #include <signal.h>
 #include "../include/time.h"
+#include "../include/sys/resource.h"
 #include "../include/sys/mman.h"
 
 /* use host printf for test output */
@@ -1561,6 +1562,18 @@ static const char *test_timer_basic(void)
     return 0;
 }
 
+static const char *test_getrusage_self(void)
+{
+    struct rusage r;
+    volatile long sink = 0;
+    for (long i = 0; i < 1000000; ++i)
+        sink += i;
+    (void)sink;
+    mu_assert("getrusage", getrusage(RUSAGE_SELF, &r) == 0);
+    mu_assert("have utime", r.ru_utime.tv_sec > 0 || r.ru_utime.tv_usec > 0);
+    return 0;
+}
+
 static const char *test_strftime_basic(void)
 {
     struct tm tm = {
@@ -2698,6 +2711,7 @@ static const char *all_tests(void)
     mu_run_test(test_poll_pipe);
     mu_run_test(test_sleep_functions);
     mu_run_test(test_timer_basic);
+    mu_run_test(test_getrusage_self);
     mu_run_test(test_strftime_basic);
     mu_run_test(test_strftime_extended);
     mu_run_test(test_wcsftime_basic);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -1460,6 +1460,18 @@ if (getrlimit(RLIMIT_NOFILE, &lim) == 0) {
 }
 ```
 
+`getrusage` reports detailed statistics about CPU time and other
+resources consumed by a process. Call it with `RUSAGE_SELF` to inspect
+the current process or `RUSAGE_CHILDREN` for exited children.
+
+```c
+struct rusage ru;
+getrusage(RUSAGE_SELF, &ru);
+printf("user: %ld.%06ld sys: %ld.%06ld\n",
+       (long)ru.ru_utime.tv_sec, (long)ru.ru_utime.tv_usec,
+       (long)ru.ru_stime.tv_sec, (long)ru.ru_stime.tv_usec);
+```
+
 ## Logging
 
 `syslog.h` provides simple helpers to send log messages to `/dev/log` on


### PR DESCRIPTION
## Summary
- implement BSD-friendly getrusage in src/getrusage.c
- expose struct rusage and getrusage in <sys/resource.h>
- document resource usage API
- list getrusage in README features
- test getrusage results

## Testing
- `make test` *(fails: tests run hang, command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_685afb95c9708324b1fbafbee6b18c90