### PR TITLE
Add pty support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ SRC := \
     src/ioctl.c \
     src/isatty.c \
     src/termios.c \
+    src/pty.c \
     src/file.c \
     src/file_perm.c \
     src/flock.c \

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ programs. Key features include:
 - FIFO creation with `mkfifo()` and `mkfifoat()`
 - Device node creation with `mknod()`
 - Generic descriptor control with `ioctl()`
+- Pseudo-terminal helpers with `openpty()` and `forkpty()`
 - Filesystem limits with `pathconf()` and `fpathconf()`
 - Query configuration strings with `confstr()`
 - Simple alarm timers with `alarm()`

--- a/include/pty.h
+++ b/include/pty.h
@@ -1,0 +1,13 @@
+#ifndef PTY_H
+#define PTY_H
+
+#include <sys/types.h>
+#include <termios.h>
+#include "sys/ioctl.h"
+
+int openpty(int *amaster, int *aslave, char *name,
+            struct termios *termp, struct winsize *winp);
+int forkpty(int *amaster, char *name,
+            struct termios *termp, struct winsize *winp);
+
+#endif /* PTY_H */

--- a/src/pty.c
+++ b/src/pty.c
@@ -1,0 +1,104 @@
+#include "pty.h"
+#include "io.h"
+#include "process.h"
+#include "unistd.h"
+#include "errno.h"
+#include "string.h"
+#include "stdlib.h"
+#include <fcntl.h>
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+extern int host_openpty(int *, int *, char *, struct termios *, struct winsize *) __asm("openpty");
+extern int host_forkpty(int *, char *, struct termios *, struct winsize *) __asm("forkpty");
+
+int openpty(int *amaster, int *aslave, char *name,
+            struct termios *termp, struct winsize *winp)
+{
+    return host_openpty(amaster, aslave, name, termp, winp);
+}
+
+int forkpty(int *amaster, char *name,
+            struct termios *termp, struct winsize *winp)
+{
+    return host_forkpty(amaster, name, termp, winp);
+}
+
+#else
+
+extern int host_posix_openpt(int) __asm("posix_openpt");
+extern int host_grantpt(int) __asm("grantpt");
+extern int host_unlockpt(int) __asm("unlockpt");
+extern int host_ptsname_r(int, char *, size_t) __asm("ptsname_r");
+
+static int do_openpty(int *amaster, int *aslave, char *name,
+                      struct termios *termp, struct winsize *winp)
+{
+    int m = host_posix_openpt(O_RDWR | O_NOCTTY);
+    if (m < 0)
+        return -1;
+    if (host_grantpt(m) < 0 || host_unlockpt(m) < 0) {
+        close(m);
+        return -1;
+    }
+    char buf[64];
+    if (host_ptsname_r(m, buf, sizeof(buf))) {
+        close(m);
+        return -1;
+    }
+    int s = open(buf, O_RDWR | O_NOCTTY);
+    if (s < 0) {
+        close(m);
+        return -1;
+    }
+    if (termp)
+        tcsetattr(s, TCSAFLUSH, termp);
+    if (winp)
+        ioctl(s, TIOCSWINSZ, winp);
+    if (name)
+        strncpy(name, buf, strlen(buf) + 1);
+    *amaster = m;
+    *aslave = s;
+    return 0;
+}
+
+int openpty(int *amaster, int *aslave, char *name,
+            struct termios *termp, struct winsize *winp)
+{
+    if (!amaster || !aslave)
+        return (errno = EINVAL, -1);
+    return do_openpty(amaster, aslave, name, termp, winp);
+}
+
+int forkpty(int *amaster, char *name,
+            struct termios *termp, struct winsize *winp)
+{
+    int m, s;
+    if (openpty(&m, &s, name, termp, winp) < 0)
+        return -1;
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(m);
+        close(s);
+        return -1;
+    }
+    if (pid == 0) {
+        close(m);
+        setsid();
+#ifdef TIOCSCTTY
+        ioctl(s, TIOCSCTTY, 0);
+#endif
+        dup2(s, STDIN_FILENO);
+        dup2(s, STDOUT_FILENO);
+        dup2(s, STDERR_FILENO);
+        if (s > STDERR_FILENO)
+            close(s);
+        return 0;
+    }
+    close(s);
+    *amaster = m;
+    return pid;
+}
+
+#endif
+

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -28,26 +28,27 @@ This document outlines the architecture, planned modules, and API design for **v
 22. [File Control](#file-control)
 23. [File Locking](#file-locking)
 24. [Terminal Attributes](#terminal-attributes)
-25. [Secure Password Input](#secure-password-input)
-26. [Standard Streams](#standard-streams)
-27. [Temporary Files](#temporary-files)
-28. [Networking](#networking)
-29. [I/O Multiplexing](#io-multiplexing)
-30. [File Permissions](#file-permissions)
-31. [Filesystem *at Wrappers](#filesystem-at-wrappers)
-32. [File Status](#file-status)
-33. [Directory Iteration](#directory-iteration)
-34. [Path Canonicalization](#path-canonicalization)
-35. [Path Utilities](#path-utilities)
-36. [User Database](#user-database)
-37. [Group Database](#group-database)
-38. [Time Formatting](#time-formatting)
-39. [Locale Support](#locale-support)
-40. [Time Retrieval](#time-retrieval)
-41. [Sleep Functions](#sleep-functions)
-42. [Interval Timers](#interval-timers)
-43. [Raw System Calls](#raw-system-calls)
-44. [Non-local Jumps](#non-local-jumps)
+25. [Pseudo-terminals](#pseudo-terminals)
+26. [Secure Password Input](#secure-password-input)
+27. [Standard Streams](#standard-streams)
+28. [Temporary Files](#temporary-files)
+29. [Networking](#networking)
+30. [I/O Multiplexing](#io-multiplexing)
+31. [File Permissions](#file-permissions)
+32. [Filesystem *at Wrappers](#filesystem-at-wrappers)
+33. [File Status](#file-status)
+34. [Directory Iteration](#directory-iteration)
+35. [Path Canonicalization](#path-canonicalization)
+36. [Path Utilities](#path-utilities)
+37. [User Database](#user-database)
+38. [Group Database](#group-database)
+39. [Time Formatting](#time-formatting)
+40. [Locale Support](#locale-support)
+41. [Time Retrieval](#time-retrieval)
+42. [Sleep Functions](#sleep-functions)
+43. [Interval Timers](#interval-timers)
+44. [Raw System Calls](#raw-system-calls)
+45. [Non-local Jumps](#non-local-jumps)
 45. [Limitations](#limitations)
 46. [Conclusion](#conclusion)
 47. [Logging](#logging)
@@ -963,6 +964,22 @@ if (tcgetattr(STDIN_FILENO, &t) == 0) {
     cfmakeraw(&t);
     tcsetattr(STDIN_FILENO, TCSANOW, &t);
 }
+```
+
+## Pseudo-terminals
+
+`openpty` creates a master/slave pair of descriptors. Optional `termios` and
+`winsize` parameters configure the initial terminal settings. `forkpty` combines
+`openpty` with `fork` and attaches the slave as the controlling terminal of the
+child.
+
+```c
+int mfd;
+pid_t pid = forkpty(&mfd, NULL, NULL, NULL);
+if (pid == 0) {
+    execlp("/bin/sh", "sh", NULL);
+}
+write(mfd, "echo hi\n", 8);
 ```
 
 ## Secure Password Input


### PR DESCRIPTION
## Summary
- implement portable `openpty`/`forkpty`
- add new header `pty.h`
- document pseudo-terminal support
- test forkpty communication

## Testing
- `make test` *(fails: command hung in environment)*

------
https://chatgpt.com/codex/tasks/task_e_685b1d0bbf9483249d21c0a3bdf6c3d5