### PR TITLE
Add comments for stdio helpers

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -11,20 +11,28 @@
 #include <sys/types.h>
 
 typedef struct {
-    int fd;
-    unsigned char *buf;
-    size_t bufsize;
-    size_t bufpos;
-    size_t buflen;
-    int buf_owned;
-    int error;
-    int eof;
-    int have_ungot;
-    unsigned char ungot_char;
-    int is_mem;
-    char **mem_bufp;
-    size_t *mem_sizep;
+    int fd;                      /* underlying file descriptor */
+    unsigned char *buf;          /* optional I/O buffer */
+    size_t bufsize;              /* size of the buffer */
+    size_t bufpos;               /* current read/write position in buf */
+    size_t buflen;               /* valid data length in buf */
+    int buf_owned;               /* buffer should be freed on close */
+    int error;                   /* error indicator */
+    int eof;                     /* end-of-file indicator */
+    int have_ungot;              /* ungetc() character available */
+    unsigned char ungot_char;    /* character from ungetc() */
+    int is_mem;                  /* stream operates on memory rather than fd */
+    char **mem_bufp;             /* pointer to buffer pointer for mem streams */
+    size_t *mem_sizep;           /* pointer to size for mem streams */
 } FILE;
+
+/*
+ * A FILE may maintain an internal buffer for efficiency. Data written with
+ * fwrite() accumulates in the buffer until it is full or fflush() is called.
+ * Reads fill the buffer from the descriptor and bytes are consumed from bufpos
+ * until empty. flush_buffer() in stdio.c performs the actual write back to the
+ * descriptor or memory region when the buffer needs to be drained.
+ */
 
 #define _IOFBF 0
 #define _IOLBF 1

--- a/src/printf.c
+++ b/src/printf.c
@@ -58,6 +58,11 @@ static void out_str(char *dst, size_t size, size_t *pos,
         out_char(dst, size, pos, s[i]);
 }
 
+/*
+ * vsnprintf_impl handles the core of formatted output. It parses the format
+ * string and builds a temporary result in the caller provided buffer. Only a
+ * small subset of printf formatting is implemented.
+ */
 static int vsnprintf_impl(char *str, size_t size, const char *fmt, va_list ap)
 {
     size_t pos = 0;
@@ -204,6 +209,10 @@ int sprintf(char *str, const char *format, ...)
     return r;
 }
 
+/*
+ * vfdprintf formats to a fixed-size buffer and writes the result to a
+ * file descriptor. It is the low level helper used by printf and friends.
+ */
 static int vfdprintf(int fd, const char *format, va_list ap)
 {
     char buf[1024];
@@ -227,6 +236,11 @@ int dprintf(int fd, const char *format, ...)
     return r;
 }
 
+/*
+ * vfprintf sends formatted output to a FILE stream. Memory-backed streams
+ * are handled specially by formatting into a temporary buffer and then
+ * writing with fwrite(). For regular files, vfdprintf performs the work.
+ */
 int vfprintf(FILE *stream, const char *format, va_list ap)
 {
     if (stream && stream->is_mem) {
@@ -263,6 +277,10 @@ int fprintf(FILE *stream, const char *format, ...)
     return r;
 }
 
+/*
+ * printf formats the arguments according to the format string and writes the
+ * result to standard output. It delegates most of the work to vprintf.
+ */
 int printf(const char *format, ...)
 {
     va_list ap;

--- a/src/stdio.c
+++ b/src/stdio.c
@@ -20,6 +20,11 @@ FILE *stdin = NULL;
 FILE *stdout = NULL;
 FILE *stderr = NULL;
 
+/*
+ * flush_buffer writes any pending data in the FILE's buffer to the
+ * underlying file descriptor or memory region. It is invoked when the
+ * buffer is full or when an explicit flush/seek occurs.
+ */
 static int flush_buffer(FILE *stream)
 {
     if (!stream || !stream->buf || stream->buflen == 0)
@@ -56,6 +61,12 @@ static int flush_buffer(FILE *stream)
     return 0;
 }
 
+/*
+ * fopen opens the file at the given path and returns a new FILE structure.
+ * Only simple mode strings like "r", "w" and "a" are understood. The
+ * returned stream starts without a buffer; callers typically call
+ * setvbuf() or rely on default buffering.
+ */
 FILE *fopen(const char *path, const char *mode)
 {
     int flags = -1;

--- a/src/wprintf.c
+++ b/src/wprintf.c
@@ -45,6 +45,11 @@ static void wout_str(wchar_t *dst, size_t size, size_t *pos,
         wout_char(dst, size, pos, s[i]);
 }
 
+/*
+ * vswprintf_impl is the wide-character equivalent of vsnprintf_impl. It
+ * builds formatted output in a caller-provided buffer and supports a
+ * minimal subset of format specifiers.
+ */
 static int vswprintf_impl(wchar_t *str, size_t size, const wchar_t *fmt, va_list ap)
 {
     size_t pos = 0;
@@ -177,6 +182,10 @@ int swprintf(wchar_t *str, size_t size, const wchar_t *format, ...)
     return r;
 }
 
+/*
+ * vfdwprintf performs wide-character formatted output directly to a file
+ * descriptor. It converts the wide buffer to multibyte text before writing.
+ */
 static int vfdwprintf(int fd, const wchar_t *format, va_list ap)
 {
     wchar_t wbuf[1024];
@@ -200,6 +209,10 @@ int vwprintf(const wchar_t *format, va_list ap)
     return vfdwprintf(1, format, ap);
 }
 
+/*
+ * fwprintf is the wide-character variant of fprintf and writes formatted
+ * output to the given FILE stream.
+ */
 int fwprintf(FILE *stream, const wchar_t *format, ...)
 {
     va_list ap;
@@ -209,6 +222,9 @@ int fwprintf(FILE *stream, const wchar_t *format, ...)
     return r;
 }
 
+/*
+ * wprintf prints a formatted wide-character string to standard output.
+ */
 int wprintf(const wchar_t *format, ...)
 {
     va_list ap;


### PR DESCRIPTION
## Summary
- document buffer management in `FILE`
- comment flush, fopen, vfprintf and printf helpers
- add notes for wide character printing as well

## Testing
- `make test` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685b3917e3908324b46abe9082ba9aa9