### PR TITLE
Document time APIs

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -95,10 +95,30 @@ typedef struct vlibc_timer *timer_t;
 #endif
 
 int clock_gettime(int clk_id, struct timespec *ts);
+/*
+ * Retrieve the current value of the given clock. When the
+ * SYS_clock_gettime syscall is available it is used; otherwise
+ * gettimeofday() provides CLOCK_REALTIME.
+ */
 int clock_getres(int clk_id, struct timespec *res);
+/*
+ * Return the resolution for the specified clock ID. On BSD
+ * systems the host clock_getres implementation is called if
+ * no direct syscall is present.
+ */
 
 time_t time(time_t *t);
+/*
+ * Seconds elapsed since the Unix epoch. Uses SYS_time when
+ * available, otherwise falls back to clock_gettime or the
+ * host time() implementation.
+ */
 int gettimeofday(struct timeval *tv, void *tz);
+/*
+ * Populate *tv with CLOCK_REALTIME expressed in seconds and
+ * microseconds. Implemented via SYS_time or SYS_clock_gettime
+ * with a host fallback when unavailable.
+ */
 
 /* sleep helpers */
 unsigned sleep(unsigned seconds);
@@ -109,6 +129,11 @@ int setitimer(int which, const struct itimerval *new,
               struct itimerval *old);
 int getitimer(int which, struct itimerval *curr);
 unsigned int alarm(unsigned int seconds);
+/*
+ * Schedule a SIGALRM after the given number of seconds. Uses
+ * the SYS_alarm syscall or setitimer() when that syscall is
+ * not implemented.
+ */
 
 #ifndef TIMER_ABSTIME
 #define TIMER_ABSTIME 1
@@ -126,12 +151,32 @@ char *strptime(const char *s, const char *format, struct tm *tm);
 
 /* basic time conversion helpers */
 struct tm *gmtime(const time_t *timep);
+/*
+ * Convert a time_t to a UTC broken-down time using a static
+ * buffer. Not thread-safe.
+ */
 struct tm *localtime(const time_t *timep);
+/*
+ * Convert a time_t to local broken-down time using a static
+ * buffer. Currently timezone data is ignored.
+ */
 struct tm *gmtime_r(const time_t *timep, struct tm *result);
+/*
+ * Thread-safe conversion of time_t to UTC broken-down time.
+ * Timezone information is not considered.
+ */
 struct tm *localtime_r(const time_t *timep, struct tm *result);
+/*
+ * Thread-safe conversion of time_t to local broken-down time.
+ * Identical to gmtime_r until timezone support is added.
+ */
 void tzset(void);
+/* Load timezone settings from the TZ environment variable if available. */
 time_t mktime(struct tm *tm);
+/* Convert a broken-down UTC time to seconds since the epoch. */
 time_t timegm(struct tm *tm);
+/* Non-standard alias for mktime(). */
 char *ctime(const time_t *timep);
+/* Format a time value using localtime() into a static string. */
 
 #endif /* TIME_H */

--- a/src/clock_getres.c
+++ b/src/clock_getres.c
@@ -12,6 +12,12 @@
 #include <unistd.h>
 #include "syscall.h"
 
+/*
+ * Return the resolution of the specified clock. When the
+ * SYS_clock_getres syscall exists it is used directly. On
+ * BSD platforms the host clock_getres implementation provides
+ * the value. Otherwise ENOSYS is returned.
+ */
 int clock_getres(int clk_id, struct timespec *res)
 {
 #ifdef SYS_clock_getres

--- a/src/clock_gettime.c
+++ b/src/clock_gettime.c
@@ -12,6 +12,12 @@
 #include <unistd.h>
 #include "syscall.h"
 
+/*
+ * Fetch the current time for the provided clock ID. When
+ * SYS_clock_gettime is present the syscall is invoked. If not
+ * available the function falls back to gettimeofday() which
+ * only supplies CLOCK_REALTIME.
+ */
 int clock_gettime(int clk_id, struct timespec *ts)
 {
 #ifdef SYS_clock_gettime

--- a/src/time.c
+++ b/src/time.c
@@ -25,6 +25,11 @@ extern int host_gettimeofday(struct timeval *tv, void *tz)
 #endif
 #endif
 
+/*
+ * Return seconds since the Unix epoch. Depending on the
+ * platform this uses SYS_time, SYS_clock_gettime with
+ * CLOCK_REALTIME, or falls back to the host time() call.
+ */
 time_t time(time_t *t)
 {
 #ifdef SYS_time
@@ -52,6 +57,11 @@ time_t time(time_t *t)
 #endif
 }
 
+/*
+ * Fill in a timeval structure with the current time of day.
+ * The implementation uses SYS_time or SYS_clock_gettime when
+ * possible and falls back to the host gettimeofday().
+ */
 int gettimeofday(struct timeval *tv, void *tz)
 {
     (void)tz;
@@ -84,6 +94,11 @@ int gettimeofday(struct timeval *tv, void *tz)
 #endif
 }
 
+/*
+ * Schedule delivery of SIGALRM after the given number of
+ * seconds. Uses the SYS_alarm syscall when present and
+ * otherwise emulates it via setitimer().
+ */
 unsigned int alarm(unsigned int seconds)
 {
 #ifdef SYS_alarm

--- a/src/time_conv.c
+++ b/src/time_conv.c
@@ -25,16 +25,28 @@ static const int days_per_month[2][12] = {
 
 static struct tm tm_buf;
 
+/*
+ * Thread-unsafe wrapper around gmtime_r() that uses a static
+ * buffer to hold the result.
+ */
 struct tm *gmtime(const time_t *timep)
 {
     return gmtime_r(timep, &tm_buf);
 }
 
+/*
+ * Thread-unsafe wrapper around localtime_r() using a static
+ * buffer. Timezone handling matches localtime_r.
+ */
 struct tm *localtime(const time_t *timep)
 {
     return localtime_r(timep, &tm_buf);
 }
 
+/*
+ * Convert broken-down UTC time to seconds since the epoch.
+ * Daylight saving time information is ignored.
+ */
 time_t mktime(struct tm *tm)
 {
     if (!tm)
@@ -58,11 +70,16 @@ time_t mktime(struct tm *tm)
     return t;
 }
 
+/* Non-standard conversion from broken-down UTC to time_t. */
 time_t timegm(struct tm *tm)
 {
     return mktime(tm);
 }
 
+/*
+ * Format a time value in a human readable form using localtime().
+ * The result is stored in a static buffer and is not thread-safe.
+ */
 char *ctime(const time_t *timep)
 {
     static char buf[32];

--- a/src/time_r.c
+++ b/src/time_r.c
@@ -64,6 +64,11 @@ static void convert_tm(time_t t, struct tm *out)
     out->tm_isdst = 0;
 }
 
+/*
+ * Convert a time value to UTC broken-down form. The result is
+ * stored in the user supplied structure and timezone handling
+ * is not performed.
+ */
 struct tm *gmtime_r(const time_t *timep, struct tm *result)
 {
     if (!result)
@@ -73,6 +78,11 @@ struct tm *gmtime_r(const time_t *timep, struct tm *result)
     return result;
 }
 
+/*
+ * Convert a time value to local broken-down form. Currently the
+ * conversion is identical to gmtime_r because timezone handling
+ * has not been implemented.
+ */
 struct tm *localtime_r(const time_t *timep, struct tm *result)
 {
     /* no timezone support yet */
@@ -81,6 +91,11 @@ struct tm *localtime_r(const time_t *timep, struct tm *result)
 
 static const char *current_tz;
 
+/*
+ * Update timezone information from the environment. Only the
+ * TZ variable is consulted on BSD platforms; other systems
+ * ignore the request.
+ */
 void tzset(void)
 {
 #ifdef __BSD_VISIBLE


### PR DESCRIPTION
## Summary
- document clock_gettime and clock_getres
- document time(), gettimeofday(), alarm()
- document gmtime_r/localtime_r/tzset
- document gmtime/localtime/mktime/timegm/ctime

## Testing
- `make test` *(fails: missing runtime dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685b45c58060832494d5b76fc9f507db