### PR TITLE
Add inet_aton/inet_ntoa support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ SRC := \
     src/netdb.c \
     src/inet_pton.c \
     src/inet_ntop.c \
+    src/inet_aton.c \
     src/ifaddrs.c \
     src/fd.c \
     src/fcntl.c \

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ programs. Key features include:
 - Human-readable address errors with `gai_strerror()`
 - Interface enumeration via `getifaddrs`
 - Network byte order helpers with `htons`, `ntohs`, `htonl` and `ntohl`
+- IPv4 text conversions with `inet_aton` and `inet_ntoa`
 - Dynamic loading with `dlopen`, `dlsym`, `dlclose` and `dladdr`
 - Environment variable handling
 - Host name queries and changes

--- a/include/arpa/inet.h
+++ b/include/arpa/inet.h
@@ -13,5 +13,7 @@
 
 int inet_pton(int af, const char *src, void *dst);
 const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
+int inet_aton(const char *cp, struct in_addr *inp);
+char *inet_ntoa(struct in_addr in);
 
 #endif /* ARPA_INET_H */

--- a/src/inet_aton.c
+++ b/src/inet_aton.c
@@ -1,0 +1,59 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the copyright notice and this permission notice appear in all copies. This software is provided "as is" without warranty.
+ *
+ * Purpose: Implements the inet_aton and inet_ntoa functions for vlibc. Provides wrappers and helpers used by the standard library.
+ *
+ * Copyright (c) 2025
+ */
+
+#include "arpa/inet.h"
+#include "stdio.h"
+#include <stdint.h>
+#include <string.h>
+
+static int parse_ipv4(const char *s, uint32_t *out)
+{
+    char *end;
+    long a = strtol(s, &end, 10);
+    if (a < 0 || a > 255 || *end != '.')
+        return -1;
+    s = end + 1;
+    long b = strtol(s, &end, 10);
+    if (b < 0 || b > 255 || *end != '.')
+        return -1;
+    s = end + 1;
+    long c = strtol(s, &end, 10);
+    if (c < 0 || c > 255 || *end != '.')
+        return -1;
+    s = end + 1;
+    long d = strtol(s, &end, 10);
+    if (d < 0 || d > 255 || (*end && *end != ' ' && *end != '\t'))
+        return -1;
+    *out = ((uint32_t)a << 24) | ((uint32_t)b << 16) |
+           ((uint32_t)c << 8) | (uint32_t)d;
+    return 0;
+}
+
+int inet_aton(const char *cp, struct in_addr *inp)
+{
+    if (!cp || !inp)
+        return 0;
+    uint32_t ip;
+    if (parse_ipv4(cp, &ip) != 0)
+        return 0;
+    inp->s_addr = htonl(ip);
+    return 1;
+}
+
+char *inet_ntoa(struct in_addr in)
+{
+    static __thread char buf[INET_ADDRSTRLEN];
+    uint32_t addr = ntohl(in.s_addr);
+    unsigned char a = (addr >> 24) & 0xFF;
+    unsigned char b = (addr >> 16) & 0xFF;
+    unsigned char c = (addr >> 8) & 0xFF;
+    unsigned char d = addr & 0xFF;
+    snprintf(buf, sizeof(buf), "%u.%u.%u.%u", a, b, c, d);
+    return buf;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -537,6 +537,19 @@ static const char *test_inet_pton_ntop(void)
     return 0;
 }
 
+static const char *test_inet_aton_ntoa(void)
+{
+    struct in_addr addr;
+    int r = inet_aton("192.0.2.5", &addr);
+    mu_assert("inet_aton", r == 1);
+    char *s = inet_ntoa(addr);
+    mu_assert("inet_ntoa", strcmp(s, "192.0.2.5") == 0);
+    struct in_addr back;
+    r = inet_aton(s, &back);
+    mu_assert("inet_aton round", r == 1 && back.s_addr == addr.s_addr);
+    return 0;
+}
+
 static const char *test_errno_open(void)
 {
     int fd = open("/this/file/does/not/exist", O_RDONLY);
@@ -2768,6 +2781,7 @@ static const char *all_tests(void)
     mu_run_test(test_sendmsg_recvmsg);
     mu_run_test(test_udp_send_recv);
     mu_run_test(test_inet_pton_ntop);
+    mu_run_test(test_inet_aton_ntoa);
     mu_run_test(test_errno_open);
     mu_run_test(test_errno_stat);
     mu_run_test(test_stat_wrappers);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -169,7 +169,8 @@ math.h       - basic math routines
 memory.h     - heap allocation
 assert.h     - runtime assertion checks
 netdb.h      - address resolution helpers
-arpa/inet.h  - IPv4/IPv6 presentation conversion helpers
+arpa/inet.h  - IPv4/IPv6 presentation conversion helpers (`inet_pton`,
+                `inet_ntop`, `inet_aton`, `inet_ntoa`)
 netinet/in.h - network byte order helpers
 ftw.h        - directory tree traversal helpers
 fts.h        - file tree walk helpers
@@ -1076,9 +1077,16 @@ Address resolution is handled
 via `getaddrinfo`, `freeaddrinfo`, and `getnameinfo`.
 
 Utilities `inet_pton` and `inet_ntop` convert between IPv4 or IPv6
-presentation strings and binary network format.
-Use `htons`, `ntohs`, `htonl`, and `ntohl` to convert between host and
-network byte order.
+presentation strings and binary network format. Legacy helpers
+`inet_aton` and `inet_ntoa` perform the same conversion for IPv4
+addresses only. Use `htons`, `ntohs`, `htonl`, and `ntohl` to convert
+between host and network byte order.
+
+```c
+struct in_addr ip;
+if (inet_aton("127.0.0.1", &ip))
+    printf("%s\n", inet_ntoa(ip));
+```
 
 ```c
 struct addrinfo *ai;


### PR DESCRIPTION
## Summary
- implement `inet_aton` and `inet_ntoa`
- expose them in `<arpa/inet.h>`
- document IPv4 conversions in `README.md` and `vlibcdoc.md`
- test round trip conversions

## Testing
- `make test` *(fails: environment build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685b6e41cffc8324b0e4b3315d0a34a0