### PR TITLE
Implement wide char IO wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ SRC := \
     src/locale.c \
     src/wchar.c \
     src/wchar_conv.c \
+    src/wchar_io.c \
     src/wctype.c \
     src/memstream.c \
     src/tempfile.c \

--- a/README.md
+++ b/README.md
@@ -258,6 +258,18 @@ Basic wide-character formatting and scanning are available through
 `wprintf` and `wscanf`. Only the subset of conversion specifiers handled
 by the regular `printf` implementation is currently recognized.
 
+Individual wide characters can also be read and written using `fgetwc`
+and `fputwc`:
+
+```c
+FILE *f = tmpfile();
+fputwc(L'A', f);
+rewind(f);
+wchar_t wc = fgetwc(f);
+// wc == L'A'
+fclose(f);
+```
+
 ## Platform Support
 
 The library currently targets Linux but aims to run on other POSIX systems as

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -15,6 +15,11 @@ typedef int wchar_t;
 #define __wchar_t_defined
 #endif
 
+#ifndef __wint_t_defined
+typedef int wint_t;
+#define __wint_t_defined
+#endif
+
 /* Opaque multibyte conversion state */
 typedef struct { int __dummy; } mbstate_t;
 
@@ -72,5 +77,11 @@ int vswscanf(const wchar_t *str, const wchar_t *format, va_list ap);
 /* Format time information using wide characters */
 size_t wcsftime(wchar_t *s, size_t max, const wchar_t *format,
                 const struct tm *tm);
+
+/* Wide-character byte I/O */
+wint_t fgetwc(FILE *stream);
+wint_t fputwc(wchar_t wc, FILE *stream);
+#define getwc(stream) fgetwc(stream)
+#define putwc(wc, stream) fputwc(wc, stream)
 
 #endif /* WCHAR_H */

--- a/src/wchar_io.c
+++ b/src/wchar_io.c
@@ -1,0 +1,35 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms, with or without modification, are permitted provided that the copyright notice and this permission notice appear in all copies. This software is provided "as is" without warranty.
+ *
+ * Purpose: Implements basic wide character I/O helpers for vlibc.
+ */
+
+#include "wchar.h"
+#include "stdio.h"
+
+wint_t fgetwc(FILE *stream)
+{
+    if (!stream)
+        return -1;
+    int c = fgetc(stream);
+    if (c == -1)
+        return -1;
+    wchar_t wc = 0;
+    if (mbrtowc(&wc, (char[]){(char)c, '\0'}, 1, NULL) == (size_t)-1)
+        return -1;
+    return (wint_t)wc;
+}
+
+wint_t fputwc(wchar_t wc, FILE *stream)
+{
+    if (!stream)
+        return -1;
+    char buf[8];
+    size_t len = wcrtomb(buf, wc, NULL);
+    if (len == (size_t)-1)
+        return -1;
+    if (fwrite(buf, 1, len, stream) != len)
+        return -1;
+    return (wint_t)wc;
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1252,6 +1252,32 @@ static const char *test_fgets_fputs(void)
     return 0;
 }
 
+static const char *test_fgetwc_fputwc(void)
+{
+    FILE *f = fopen("tmp_wcs", "w+");
+    mu_assert("fopen wcs", f != NULL);
+    mu_assert("fputwc ret", fputwc(L'Z', f) == L'Z');
+    rewind(f);
+    wint_t wc = fgetwc(f);
+    mu_assert("fgetwc val", wc == L'Z');
+    fclose(f);
+    unlink("tmp_wcs");
+    return 0;
+}
+
+static const char *test_getwc_putwc(void)
+{
+    FILE *f = fopen("tmp_wcs2", "w+");
+    mu_assert("fopen wcs2", f != NULL);
+    mu_assert("putwc ret", putwc(L'A', f) == L'A');
+    rewind(f);
+    wint_t wc = getwc(f);
+    mu_assert("getwc val", wc == L'A');
+    fclose(f);
+    unlink("tmp_wcs2");
+    return 0;
+}
+
 static const char *test_getline_various(void)
 {
     FILE *f = fopen("tmp_getline", "w+");
@@ -2849,6 +2875,8 @@ static const char *all_tests(void)
     mu_run_test(test_fseek_rewind);
     mu_run_test(test_fgetc_fputc);
     mu_run_test(test_fgets_fputs);
+    mu_run_test(test_fgetwc_fputwc);
+    mu_run_test(test_getwc_putwc);
     mu_run_test(test_getline_various);
     mu_run_test(test_getdelim_various);
     mu_run_test(test_fflush);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -389,6 +389,21 @@ int c = wcwidth(L'A');               // 1
 int w = wcswidth(L"hello", 5);      // 5
 ```
 
+### Wide-Character I/O
+
+`fgetwc` and `fputwc` mirror `fgetc` and `fputc` but operate on wide
+characters. The `getwc` and `putwc` wrappers simply call these
+functions.
+
+```c
+FILE *fp = tmpfile();
+fputwc(L'Z', fp);
+rewind(fp);
+wchar_t ch = fgetwc(fp);
+// ch == L'Z'
+fclose(fp);
+```
+
 ### Character Set Conversion
 
 `iconv_open` returns a descriptor for translating between character


### PR DESCRIPTION
## Summary
- implement `fgetwc`, `fputwc`, `getwc`, and `putwc`
- expose new prototypes in `<wchar.h>`
- document reading/writing wide characters in README and docs
- test the new wide character I/O helpers
- include new source file in build

## Testing
- `make test` *(fails: build interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685b75d3b1848324b82566bcd9e89303