### PR TITLE
Add signal waiting APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ programs. Key features include:
 - Thread-local storage helpers
 - Non-blocking mutex acquisition with `pthread_mutex_trylock()`
 - Timed waits on conditions with `pthread_cond_timedwait()`
+- Wait for specific signals with `sigwait()` and `sigtimedwait()`
 - Set mutex types with `pthread_mutexattr_settype()`
 - Counting semaphores with `sem_init()`/`sem_wait()`/`sem_post()`
 - Thread barriers with `pthread_barrier_init()` and `pthread_barrier_wait()`

--- a/include/signal.h
+++ b/include/signal.h
@@ -7,6 +7,7 @@
 #define SIGNAL_H
 
 #include <sys/types.h>
+#include "time.h"
 
 /* basic signal numbers */
 #define SIGHUP    1
@@ -75,5 +76,20 @@ int sigaddset(sigset_t *set, int signo);
 int sigdelset(sigset_t *set, int signo);
 int sigismember(const sigset_t *set, int signo);
 char *strsignal(int signum);
+
+typedef struct siginfo {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    int _pad[29];
+} siginfo_t;
+
+int pause(void);
+int sigsuspend(const sigset_t *mask);
+int sigpending(sigset_t *set);
+int sigwait(const sigset_t *set, int *sig);
+int sigwaitinfo(const sigset_t *set, siginfo_t *info);
+int sigtimedwait(const sigset_t *set, siginfo_t *info,
+                 const struct timespec *timeout);
 
 #endif /* SIGNAL_H */

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -591,6 +591,12 @@ int setgid(gid_t gid);
 int setegid(gid_t egid);
 int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact);
 int sigprocmask(int how, const sigset_t *set, sigset_t *oldset);
+int sigpending(sigset_t *set);
+int sigsuspend(const sigset_t *mask);
+int sigwait(const sigset_t *set, int *sig);
+int sigwaitinfo(const sigset_t *set, siginfo_t *info);
+int sigtimedwait(const sigset_t *set, siginfo_t *info,
+                 const struct timespec *timeout);
 int system(const char *command);
 int daemon(int nochdir, int noclose);
 int atexit(void (*fn)(void));


### PR DESCRIPTION
## Summary
- add `sigpending`, `sigsuspend`, `sigwait`, `sigwaitinfo`, and `sigtimedwait`
- expose the new routines in `signal.h`
- test waiting for signals and timed waits
- document the new functions in README and docs

## Testing
- `make test` *(fails: took too long and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685b83835fe88324b1acbe54c7829adb