### PR TITLE
Add floating-point classification helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ programs. Key features include:
 - Array sorting with `qsort`, `qsort_r` and `bsearch`
 - Standard `assert` macro for runtime checks
 - Extended math helpers
+- Floating-point classification with `isnan()`, `isinf()` and `isfinite()`
 - String-to-number conversions with `strtol`, `strtoul`, `strtoll`,
   `strtoull`, `strtof`, `strtod` and `strtold`
 - Descriptor-based printing with `dprintf()`/`vdprintf()`

--- a/include/math.h
+++ b/include/math.h
@@ -30,4 +30,33 @@ double fmin(double a, double b);
 double fmax(double a, double b);
 double copysign(double x, double y);
 
+/* Floating-point classification */
+#if defined(__has_builtin)
+#  if !defined(isnan) && __has_builtin(__builtin_isnan)
+#    define isnan(x) __builtin_isnan(x)
+#  endif
+#  if !defined(isinf)
+#    if __has_builtin(__builtin_isinf_sign)
+#      define isinf(x) __builtin_isinf_sign(x)
+#    elif __has_builtin(__builtin_isinf)
+#      define isinf(x) __builtin_isinf(x)
+#    endif
+#  endif
+#  if !defined(isfinite) && __has_builtin(__builtin_isfinite)
+#    define isfinite(x) __builtin_isfinite(x)
+#  endif
+#endif
+
+#ifndef isnan
+#define isnan(x) ((x) != (x))
+#endif
+
+#ifndef isinf
+#define isinf(x) ((x) == (1.0/0.0) || (x) == (-1.0/0.0))
+#endif
+
+#ifndef isfinite
+#define isfinite(x) (!isnan(x) && !isinf(x))
+#endif
+
 #endif /* MATH_H */

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2725,6 +2725,25 @@ static const char *test_math_functions(void)
     return 0;
 }
 
+static const char *test_fp_checks(void)
+{
+    volatile double zero = 0.0;
+    double inf = 1.0 / zero;
+    double ninf = -1.0 / zero;
+    double nanv = zero / zero;
+
+    mu_assert("isinf pos", isinf(inf));
+    mu_assert("isinf neg", isinf(ninf));
+    mu_assert("!isinf", !isinf(1.5));
+    mu_assert("isnan", isnan(nanv));
+    mu_assert("!isnan", !isnan(inf));
+    mu_assert("isfinite", isfinite(2.0));
+    mu_assert("isfinite zero", isfinite(0.0));
+    mu_assert("!isfinite nan", !isfinite(nanv));
+    mu_assert("!isfinite inf", !isfinite(inf));
+    return 0;
+}
+
 static const char *test_getopt_basic(void)
 {
     char *argv[] = {"prog", "-f", "-a", "val", "rest", NULL};
@@ -3016,6 +3035,7 @@ static const char *all_tests(void)
     mu_run_test(test_regex_backref_basic);
     mu_run_test(test_regex_backref_fail);
     mu_run_test(test_math_functions);
+    mu_run_test(test_fp_checks);
     mu_run_test(test_getopt_basic);
     mu_run_test(test_getopt_missing);
     mu_run_test(test_dlopen_basic);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -539,6 +539,12 @@ regfree(&r);
 series approximations
 and are suitable for basic calculations but may lack high precision.
 
+`math.h` also defines macros to classify floating-point values. `isnan(x)`
+returns non-zero when `x` is not a number, `isinf(x)` detects positive or
+negative infinity, and `isfinite(x)` reports true only for finite values.  When
+the compiler supplies built-ins for these checks the macros map directly to
+them, otherwise simple fallback tests are used.
+
 ## Process Control
 
 Process-related functionality resides in the **process** module. It provides


### PR DESCRIPTION
## Summary
- support `isnan`, `isinf` and `isfinite` using built-ins when present
- document the new macros and mention them in README
- test floating point classification macros

## Testing
- `make test` *(fails: process timed out)*

------
https://chatgpt.com/codex/tasks/task_e_685b83480e108324ab4ff21241a70a25