### PR TITLE
Add hypot, round, trunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ programs. Key features include:
 - Path expansion helpers with `glob()` and `wordexp()`
 - Array sorting with `qsort`, `qsort_r` and `bsearch`
 - Standard `assert` macro for runtime checks
-- Extended math helpers
+- Extended math helpers including `hypot`, `round` and `trunc`
 - Floating-point classification with `isnan()`, `isinf()` and `isfinite()`
 - String-to-number conversions with `strtol`, `strtoul`, `strtoll`,
   `strtoull`, `strtof`, `strtod` and `strtold`

--- a/include/math.h
+++ b/include/math.h
@@ -22,6 +22,10 @@ double sinh(double x);
 double cosh(double x);
 double tanh(double x);
 
+double hypot(double x, double y);
+double round(double x);
+double trunc(double x);
+
 double fmod(double x, double y);
 float fabsf(float x);
 double ldexp(double x, int exp);

--- a/src/math_extra.c
+++ b/src/math_extra.c
@@ -91,6 +91,9 @@ extern double host_log2(double) __asm("log2");
 extern double host_fmin(double, double) __asm("fmin");
 extern double host_fmax(double, double) __asm("fmax");
 extern double host_copysign(double, double) __asm("copysign");
+extern double host_hypot(double, double) __asm("hypot");
+extern double host_round(double) __asm("round");
+extern double host_trunc(double) __asm("trunc");
 #endif
 
 double fmod(double x, double y)
@@ -176,5 +179,44 @@ double copysign(double x, double y)
     if ((y < 0 && x > 0) || (y >= 0 && x < 0))
         x = -x;
     return x;
+#endif
+}
+
+double hypot(double x, double y)
+{
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    return host_hypot(x, y);
+#else
+    return sqrt(x * x + y * y);
+#endif
+}
+
+double round(double x)
+{
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    return host_round(x);
+#else
+    double i = floor(x);
+    double frac = x - i;
+    if (x >= 0.0) {
+        if (frac >= 0.5)
+            i += 1.0;
+    } else {
+        if (frac <= -0.5)
+            i -= 1.0;
+    }
+    return i;
+#endif
+}
+
+double trunc(double x)
+{
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    return host_trunc(x);
+#else
+    return (x >= 0.0) ? floor(x) : ceil(x);
 #endif
 }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2783,6 +2783,12 @@ static const char *test_math_functions(void)
     double l = log(5.0);
     mu_assert("exp/log", fabs(exp(l) - 5.0) < 1e-6);
     mu_assert("log/exp", fabs(log(exp(1.0)) - 1.0) < 1e-6);
+    mu_assert("hypot", fabs(hypot(3.0, 4.0) - 5.0) < 1e-6);
+    mu_assert("round", round(2.3) == 2.0);
+    mu_assert("round half", round(2.5) == 3.0);
+    mu_assert("round neg", round(-1.6) == -2.0);
+    mu_assert("trunc", trunc(2.9) == 2.0);
+    mu_assert("trunc neg", trunc(-2.9) == -2.0);
     return 0;
 }
 

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -534,10 +534,10 @@ regfree(&r);
 ## Math Functions
 
 `sin`, `cos`, `tan`, `sqrt`, `pow`, `log`, `log2`, `log10`, `exp`, `ldexp`,
-`floor`, `ceil`, `fmod`, `fabs`, `fabsf`, `fmin`, `fmax`, `copysign`,
-`atan2`, `sinh`, `cosh`, and `tanh` are provided in `math.h`. These use simple
-series approximations
-and are suitable for basic calculations but may lack high precision.
+`floor`, `ceil`, `round`, `trunc`, `hypot`, `fmod`, `fabs`, `fabsf`, `fmin`,
+`fmax`, `copysign`, `atan2`, `sinh`, `cosh`, and `tanh` are provided in
+`math.h`. These use simple series approximations and are suitable for basic
+calculations but may lack high precision.
 
 `math.h` also defines macros to classify floating-point values. `isnan(x)`
 returns non-zero when `x` is not a number, `isinf(x)` detects positive or


### PR DESCRIPTION
## Summary
- expose `hypot`, `round`, and `trunc` in `math.h`
- implement approximations and BSD fallbacks in `math_extra.c`
- document the new math helpers in README and vlibcdoc
- test the new functions in the unit suite

## Testing
- `make test` *(fails: Command interrupted due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685b899b92148324b5d616355b11315f