### PR TITLE
Add fgetpos/fsetpos support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ programs. Key features include:
 - Descriptor-based printing with `dprintf()`/`vdprintf()`
 - Memory-backed streams with `open_memstream()` and `fmemopen()`
 - Large-file aware seeks
+- Store and restore file positions with `fgetpos()` and `fsetpos()`
 - Zero-copy file transfers with `sendfile()`
 - Memory synchronization with `msync()`
 - POSIX shared memory objects with `shm_open()` and `shm_unlink()`

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -26,6 +26,8 @@ typedef struct {
     size_t *mem_sizep;           /* pointer to size for mem streams */
 } FILE;
 
+typedef off_t fpos_t;
+
 /*
  * A FILE may maintain an internal buffer for efficiency. Data written with
  * fwrite() accumulates in the buffer until it is full or fflush() is called.
@@ -53,6 +55,8 @@ int fseek(FILE *stream, long offset, int whence);
 long ftell(FILE *stream);
 int fseeko(FILE *stream, off_t offset, int whence);
 off_t ftello(FILE *stream);
+int fgetpos(FILE *stream, fpos_t *pos);
+int fsetpos(FILE *stream, const fpos_t *pos);
 void rewind(FILE *stream);
 int fgetc(FILE *stream);
 int fputc(int c, FILE *stream);

--- a/src/stdio.c
+++ b/src/stdio.c
@@ -285,6 +285,24 @@ off_t ftello(FILE *stream)
     return (off_t)ftell(stream);
 }
 
+int fgetpos(FILE *stream, fpos_t *pos)
+{
+    if (!stream || !pos)
+        return -1;
+    off_t off = ftello(stream);
+    if (off == (off_t)-1)
+        return -1;
+    *pos = (fpos_t)off;
+    return 0;
+}
+
+int fsetpos(FILE *stream, const fpos_t *pos)
+{
+    if (!stream || !pos)
+        return -1;
+    return fseeko(stream, (off_t)*pos, SEEK_SET);
+}
+
 void rewind(FILE *stream)
 {
     if (!stream)

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1250,6 +1250,39 @@ static const char *test_fseek_rewind(void)
     return 0;
 }
 
+static const char *test_fgetpos_fsetpos(void)
+{
+    FILE *f = fopen("tmp_fpos", "w+");
+    mu_assert("fopen fpos", f != NULL);
+
+    const char *msg = "abcdef";
+    size_t w = fwrite(msg, 1, strlen(msg), f);
+    mu_assert("fwrite fpos", w == strlen(msg));
+
+    rewind(f);
+    char buf[4] = {0};
+    size_t r = fread(buf, 1, 3, f);
+    mu_assert("fread first", r == 3);
+    mu_assert("content first", strncmp(buf, "abc", 3) == 0);
+
+    fpos_t pos;
+    mu_assert("fgetpos ret", fgetpos(f, &pos) == 0);
+
+    r = fread(buf, 1, 3, f);
+    mu_assert("fread second", r == 3);
+    mu_assert("content second", strncmp(buf, "def", 3) == 0);
+
+    mu_assert("fsetpos ret", fsetpos(f, &pos) == 0);
+    memset(buf, 0, sizeof(buf));
+    r = fread(buf, 1, 3, f);
+    mu_assert("fread restore", r == 3);
+    mu_assert("content restore", strncmp(buf, "def", 3) == 0);
+
+    fclose(f);
+    unlink("tmp_fpos");
+    return 0;
+}
+
 static const char *test_fgetc_fputc(void)
 {
     FILE *f = fopen("tmp_char", "w+");
@@ -3028,6 +3061,7 @@ static const char *all_tests(void)
     mu_run_test(test_scanf_functions);
     mu_run_test(test_vscanf_variants);
     mu_run_test(test_fseek_rewind);
+    mu_run_test(test_fgetpos_fsetpos);
     mu_run_test(test_fgetc_fputc);
     mu_run_test(test_fgets_fputs);
     mu_run_test(test_fgetwc_fputwc);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -1127,7 +1127,7 @@ across all targets.
 
 `stdin`, `stdout`, and `stderr` are lightweight streams wrapping file
 descriptors 0, 1 and 2. They can be used with the provided `fread`,
-`fwrite`, `fseek`, `ftell`, `fseeko`, `ftello`, `rewind`, `fgetc`, `fputc`, `ungetc`, `fgets`,
+`fwrite`, `fseek`, `ftell`, `fseeko`, `ftello`, `fgetpos`, `fsetpos`, `rewind`, `fgetc`, `fputc`, `ungetc`, `fgets`,
 `fputs`, `sprintf`, `snprintf`, `asprintf`, `vasprintf`, `vsprintf`,
 `vsnprintf`, `fprintf`, `vfprintf`, `dprintf`, `vdprintf`, `printf`, `vprintf`, `vsscanf`, `vfscanf`, `vscanf`,
 `sscanf`, `fscanf`, `scanf`, `getline`, and `getdelim` helpers.  Query


### PR DESCRIPTION
## Summary
- add `fgetpos` and `fsetpos` declarations
- implement the functions using `ftello` and `fseeko`
- document new file positioning helpers
- add tests covering `fgetpos`/`fsetpos`

## Testing
- `make test` *(fails: compilation timed out in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_685b8ef72e588324903afed4fd5afc79