### PR TITLE
Add memccpy/mempcpy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Search helpers `strstr`, `strrchr`, `memchr`, `memrchr`, and `memmem` locate sub
 bytes. Tokenizers `strtok`, `strtok_r`, and the lightweight `strsep` help split
 strings based on delimiters.
 Copy helpers `stpcpy` and `stpncpy` return the end pointer after copying.
+`memccpy` stops when a byte is found while `mempcpy` returns the pointer to the
+end of the copied region.
 
 Launching a program in a new process with `posix_spawn` is similarly easy:
 

--- a/include/string.h
+++ b/include/string.h
@@ -57,6 +57,10 @@ int vmemcmp(const void *s1, const void *s2, size_t n);
 void *memcpy(void *dest, const void *src, size_t n);
 /* Memory move allowing overlap */
 void *memmove(void *dest, const void *src, size_t n);
+/* Copy until byte found */
+void *memccpy(void *dest, const void *src, int c, size_t n);
+/* Copy returning pointer past end */
+void *mempcpy(void *dest, const void *src, size_t n);
 /* Fill region of memory */
 void *memset(void *s, int c, size_t n);
 /* Compare two memory regions */

--- a/src/string_extra.c
+++ b/src/string_extra.c
@@ -269,3 +269,23 @@ char *stpncpy(char *dest, const char *src, size_t n)
     return d;
 }
 
+void *memccpy(void *dest, const void *src, int c, size_t n)
+{
+    unsigned char *d = dest;
+    const unsigned char *s = src;
+    unsigned char ch = (unsigned char)c;
+    while (n--) {
+        unsigned char byte = *s++;
+        *d++ = byte;
+        if (byte == ch)
+            return d;
+    }
+    return NULL;
+}
+
+void *mempcpy(void *dest, const void *src, size_t n)
+{
+    vmemcpy(dest, src, n);
+    return (unsigned char *)dest + n;
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -792,6 +792,26 @@ static const char *test_stpcpy_functions(void)
     return 0;
 }
 
+static const char *test_memccpy_mempcpy(void)
+{
+    char src[] = "abcde";
+    char buf[6] = {0};
+    char *p = memccpy(buf, src, 'c', sizeof(src));
+    mu_assert("memccpy ptr", p == buf + 3);
+    mu_assert("memccpy copy", buf[0] == 'a' && buf[1] == 'b' && buf[2] == 'c');
+
+    char dst[5];
+    char *end = mempcpy(dst, "wxyz", 4);
+    mu_assert("mempcpy end", end == dst + 4);
+    mu_assert("mempcpy copy", memcmp(dst, "wxyz", 4) == 0);
+
+    char other[4] = {0};
+    p = memccpy(other, src, 'z', 4);
+    mu_assert("memccpy not found", p == NULL && memcmp(other, "abcd", 4) == 0);
+
+    return 0;
+}
+
 static const char *test_strndup_basic(void)
 {
     char *p = strndup("hello", 10);
@@ -3101,6 +3121,7 @@ static const char *all_tests(void)
     mu_run_test(test_string_casecmp);
     mu_run_test(test_strlcpy_cat);
     mu_run_test(test_stpcpy_functions);
+    mu_run_test(test_memccpy_mempcpy);
     mu_run_test(test_strndup_basic);
     mu_run_test(test_strcoll_xfrm);
     mu_run_test(test_widechar_basic);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -323,6 +323,8 @@ The **string** module provides fundamental operations needed by most C programs:
   not `"C"` or `"POSIX"`.
 - Conventional memory routines (`memcpy`, `memmove`, `memset`, `memcmp`) map to
   the internal `v` implementations.
+- `memccpy` stops copying when a byte value is found and returns a pointer past
+  it. `mempcpy` copies `n` bytes and returns the destination end pointer.
 - The low-level memory helpers `vmemcpy`, `vmemmove`, `vmemset`, and `vmemcmp` operate on raw byte buffers. `vmemcpy` copies bytes from a source to a destination, `vmemmove` handles overlaps safely, `vmemset` fills a region with a byte value, and `vmemcmp` compares two buffers. The standard `memcpy`, `memmove`, `memset`, and `memcmp` functions simply call these implementations.
 - Basic locale handling reads the `LC_ALL` and `LANG` environment variables.
   `setlocale` defaults to those values and, on BSD systems, falls back to the
@@ -348,6 +350,9 @@ const char *text = "hello world";
 size_t first_word = strcspn(text, " ");
 char *vowel = strpbrk(text, "aeiou");
 size_t prefix = strspn("abc123", "abc");
+char dest[8];
+char *end = memccpy(dest, "stop!", '!', 5);
+end = mempcpy(dest, "end", 3);
 ```
 
 Basic time formatting is available via `strftime` and the matching


### PR DESCRIPTION
## Summary
- implement `memccpy` and `mempcpy`
- expose prototypes in `string.h`
- test new routines in unit tests
- document usage in `vlibcdoc.md` and mention them in README

## Testing
- `make test` *(fails: timeout or other issue)*

------
https://chatgpt.com/codex/tasks/task_e_685c1660bf8883248bbcb7ded6975e0a