### PR TITLE
Add POSIX rand48 functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ SRC := \
     src/strerror_r.c \
     src/strto.c \
     src/rand.c \
+    src/rand48.c \
     src/abs.c \
     src/arc4random.c \
     src/socket.c \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ programs. Key features include:
   `strtoull`, `strtof`, `strtod` and `strtold`
 - Integer helpers `abs`, `labs`, `llabs` and division results with `div`,
   `ldiv` and `lldiv`
+- POSIX-style 48-bit random numbers via the `rand48` family
 - Descriptor-based printing with `dprintf()`/`vdprintf()`
 - Memory-backed streams with `open_memstream()` and `fmemopen()`
 - Large-file aware seeks

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -64,6 +64,13 @@ void srand(unsigned seed);
 unsigned int arc4random(void);
 void arc4random_buf(void *buf, size_t len);
 int rand_r(unsigned *state);
+double drand48(void);
+double erand48(unsigned short xseed[3]);
+long lrand48(void);
+long nrand48(unsigned short xseed[3]);
+void srand48(long seedval);
+unsigned short *seed48(unsigned short seed16v[3]);
+void lcong48(unsigned short param[7]);
 
 /* Register a function to run at normal process exit */
 int atexit(void (*fn)(void));

--- a/src/rand48.c
+++ b/src/rand48.c
@@ -1,0 +1,82 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the copyright notice and
+ * this permission notice appear in all copies. This software is provided "as is" without warranty.
+ *
+ * Purpose: Implements the rand48 functions for vlibc. Provides wrappers and helpers used by the standard library.
+ */
+
+#include "stdlib.h"
+#include <stdint.h>
+
+/* 48-bit linear congruential generator */
+static uint64_t rand48_state = 0x1234abcd330eULL;
+static uint64_t rand48_mult  = 0x5deece66dULL;
+static uint64_t rand48_add   = 0xbULL;
+#define RAND48_MASK ((1ULL << 48) - 1)
+
+static uint64_t rand48_step(void)
+{
+    rand48_state = (rand48_state * rand48_mult + rand48_add) & RAND48_MASK;
+    return rand48_state;
+}
+
+static uint64_t arr_to_u64(const unsigned short x[3])
+{
+    return ((uint64_t)x[2] << 32) | ((uint64_t)x[1] << 16) | (uint64_t)x[0];
+}
+
+static void u64_to_arr(uint64_t v, unsigned short x[3])
+{
+    x[0] = (unsigned short)(v & 0xffff);
+    x[1] = (unsigned short)((v >> 16) & 0xffff);
+    x[2] = (unsigned short)((v >> 32) & 0xffff);
+}
+
+double drand48(void)
+{
+    return rand48_step() / (double)(1ULL << 48);
+}
+
+double erand48(unsigned short x[3])
+{
+    uint64_t v = arr_to_u64(x);
+    v = (v * rand48_mult + rand48_add) & RAND48_MASK;
+    u64_to_arr(v, x);
+    return v / (double)(1ULL << 48);
+}
+
+long lrand48(void)
+{
+    return (long)(rand48_step() >> 17);
+}
+
+long nrand48(unsigned short x[3])
+{
+    uint64_t v = arr_to_u64(x);
+    v = (v * rand48_mult + rand48_add) & RAND48_MASK;
+    u64_to_arr(v, x);
+    return (long)(v >> 17);
+}
+
+void srand48(long seedval)
+{
+    rand48_state = ((uint64_t)seedval << 16) | 0x330eULL;
+    rand48_mult  = 0x5deece66dULL;
+    rand48_add   = 0xbULL;
+}
+
+unsigned short *seed48(unsigned short seed16v[3])
+{
+    static unsigned short old[3];
+    u64_to_arr(rand48_state, old);
+    rand48_state = arr_to_u64(seed16v);
+    return old;
+}
+
+void lcong48(unsigned short param[7])
+{
+    rand48_state = arr_to_u64(param);
+    rand48_mult  = arr_to_u64(param + 3);
+    rand48_add   = param[6];
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2245,6 +2245,30 @@ static const char *test_rand_fn(void)
     return 0;
 }
 
+static const char *test_rand48_fn(void)
+{
+    srand48(1L);
+    mu_assert("lrand48 1", lrand48() == 89400484);
+    mu_assert("lrand48 2", lrand48() == 976015093);
+    mu_assert("lrand48 3", lrand48() == 1792756325);
+    srand48(1L);
+    double d = drand48();
+    mu_assert("drand48 1", fabs(d - 0.041630344771878214) < 1e-12);
+    d = drand48();
+    mu_assert("drand48 2", fabs(d - 0.45449244472862915) < 1e-12);
+    unsigned short seed[3] = {0x330e, 0xabcd, 0x1234};
+    mu_assert("nrand48 1", nrand48(seed) == 851401618);
+    mu_assert("nrand48 2", nrand48(seed) == 1804928587);
+    mu_assert("nrand48 3", nrand48(seed) == 758783491);
+    unsigned short newseed[3] = {1,2,3};
+    unsigned short *old = seed48(newseed);
+    mu_assert("seed48 old0", old[0] == 0x330e);
+    mu_assert("seed48 old1", old[1] == 0x1);
+    mu_assert("seed48 old2", old[2] == 0x0);
+    srand48(1L);
+    return 0;
+}
+
 static const char *test_forkpty_echo(void)
 {
     int mfd;
@@ -3187,6 +3211,7 @@ static const char *all_tests(void)
     mu_run_test(test_posix_spawn_sigmask);
     mu_run_test(test_popen_fn);
     mu_run_test(test_rand_fn);
+    mu_run_test(test_rand48_fn);
     mu_run_test(test_forkpty_echo);
     mu_run_test(test_tcdrain_basic);
     mu_run_test(test_tcflush_basic);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -15,49 +15,50 @@ This document outlines the architecture, planned modules, and API design for **v
 9. [Character Classification](#character-classification)
 10. [Option Parsing](#option-parsing)
 11. [Random Numbers](#random-numbers)
-12. [Sorting Helpers](#sorting-helpers)
-13. [Utilities](#utilities)
-14. [Regular Expressions](#regular-expressions)
-15. [Math Functions](#math-functions)
-16. [Process Control](#process-control)
-17. [Error Reporting](#error-reporting)
-18. [Errno Access](#errno-access)
-19. [Threading](#threading)
-20. [Dynamic Loading](#dynamic-loading)
-21. [Environment Variables](#environment-variables)
-22. [System Information](#system-information)
-23. [Basic File I/O](#basic-file-io)
-24. [File Descriptor Helpers](#file-descriptor-helpers)
-25. [File Control](#file-control)
-26. [File Locking](#file-locking)
-27. [Terminal Attributes](#terminal-attributes)
-28. [Pseudo-terminals](#pseudo-terminals)
-29. [Secure Password Input](#secure-password-input)
-30. [Standard Streams](#standard-streams)
-31. [Temporary Files](#temporary-files)
-32. [Networking](#networking)
-33. [I/O Multiplexing](#io-multiplexing)
-34. [File Permissions](#file-permissions)
-35. [Filesystem *at Wrappers](#filesystem-at-wrappers)
-36. [File Status](#file-status)
-37. [Directory Iteration](#directory-iteration)
-38. [Path Canonicalization](#path-canonicalization)
-39. [Path Utilities](#path-utilities)
-40. [User Database](#user-database)
-41. [Group Database](#group-database)
-42. [Time Formatting](#time-formatting)
-43. [Locale Support](#locale-support)
-44. [Time Retrieval](#time-retrieval)
-45. [Sleep Functions](#sleep-functions)
-46. [Interval Timers](#interval-timers)
-47. [Raw System Calls](#raw-system-calls)
-48. [Non-local Jumps](#non-local-jumps)
-49. [Limitations](#limitations)
-50. [Conclusion](#conclusion)
-51. [Logging](#logging)
-52. [Path Expansion](#path-expansion)
-53. [Filesystem Statistics](#filesystem-statistics)
-54. [Resource Limits](#resource-limits)
+12. [rand48 API](#rand48-api)
+13. [Sorting Helpers](#sorting-helpers)
+14. [Utilities](#utilities)
+15. [Regular Expressions](#regular-expressions)
+16. [Math Functions](#math-functions)
+17. [Process Control](#process-control)
+18. [Error Reporting](#error-reporting)
+19. [Errno Access](#errno-access)
+20. [Threading](#threading)
+21. [Dynamic Loading](#dynamic-loading)
+22. [Environment Variables](#environment-variables)
+23. [System Information](#system-information)
+24. [Basic File I/O](#basic-file-io)
+25. [File Descriptor Helpers](#file-descriptor-helpers)
+26. [File Control](#file-control)
+27. [File Locking](#file-locking)
+28. [Terminal Attributes](#terminal-attributes)
+29. [Pseudo-terminals](#pseudo-terminals)
+30. [Secure Password Input](#secure-password-input)
+31. [Standard Streams](#standard-streams)
+32. [Temporary Files](#temporary-files)
+33. [Networking](#networking)
+34. [I/O Multiplexing](#io-multiplexing)
+35. [File Permissions](#file-permissions)
+36. [Filesystem *at Wrappers](#filesystem-at-wrappers)
+37. [File Status](#file-status)
+38. [Directory Iteration](#directory-iteration)
+39. [Path Canonicalization](#path-canonicalization)
+40. [Path Utilities](#path-utilities)
+41. [User Database](#user-database)
+42. [Group Database](#group-database)
+43. [Time Formatting](#time-formatting)
+44. [Locale Support](#locale-support)
+45. [Time Retrieval](#time-retrieval)
+46. [Sleep Functions](#sleep-functions)
+47. [Interval Timers](#interval-timers)
+48. [Raw System Calls](#raw-system-calls)
+49. [Non-local Jumps](#non-local-jumps)
+50. [Limitations](#limitations)
+51. [Conclusion](#conclusion)
+52. [Logging](#logging)
+53. [Path Expansion](#path-expansion)
+54. [Filesystem Statistics](#filesystem-statistics)
+55. [Resource Limits](#resource-limits)
 
 ## Overview
 
@@ -472,6 +473,28 @@ produces the identical sequence of numbers, each in the range `0` to
 random generator. `arc4random_buf()` fills an arbitrary buffer with secure
 random bytes. The `rand_r()` variant operates like `rand()` but stores its
 state in a user-provided variable so it can be used in threaded code.
+
+## rand48 API
+
+The `rand48` functions implement a 48-bit linear congruential generator
+compatible with POSIX.  They share a global state initialized with
+`srand48()`:
+
+```c
+double drand48(void);
+double erand48(unsigned short state[3]);
+long lrand48(void);
+long nrand48(unsigned short state[3]);
+void srand48(long seedval);
+unsigned short *seed48(unsigned short state[3]);
+void lcong48(unsigned short param[7]);
+```
+
+`drand48()` returns a floating-point value in the range `[0.0,1.0)`.
+`lrand48()` produces a non-negative long integer.  The `erand48()` and
+`nrand48()` variants operate on a caller supplied state array instead of
+the global seed.  Calling `seed48()` swaps the generator state and
+`lcong48()` allows customizing the multiplier and additive constants.
 
 ## Sorting Helpers
 


### PR DESCRIPTION
## Summary
- implement drand48, lrand48 and related helpers
- expose rand48 declarations in stdlib.h
- test deterministic rand48 sequences
- document the rand48 API and mention it in README

## Testing
- `make test` *(fails: process interrupted due to long build time)*

------
https://chatgpt.com/codex/tasks/task_e_685c1a4d85f483249e71b3aeb9ea0f1f