### PR TITLE
Add wide-character memory functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ SRC := \
     src/wchar_conv.c \
     src/wchar_io.c \
     src/wctype.c \
+    src/wmem.c \
     src/memstream.c \
     src/tempfile.c \
     src/confstr.c \

--- a/README.md
+++ b/README.md
@@ -267,7 +267,8 @@ int w = wcswidth(L"hello", 5);       // 5
 
 Common helpers like `wcslen`, `wcscpy`, `wcsncpy`, `wcscmp`, `wcsncmp`, and
 `wcsdup` mirror their narrow-string counterparts for manipulating wide
-character strings.
+character strings. Memory routines `wmemcpy`, `wmemmove`, `wmemset` and
+`wmemcmp` perform the same operations on arrays of `wchar_t`.
 
 ## Wide-Character I/O
 

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -79,9 +79,15 @@ size_t wcsftime(wchar_t *s, size_t max, const wchar_t *format,
                 const struct tm *tm);
 
 /* Wide-character byte I/O */
-wint_t fgetwc(FILE *stream);
-wint_t fputwc(wchar_t wc, FILE *stream);
+    wint_t fgetwc(FILE *stream);
+    wint_t fputwc(wchar_t wc, FILE *stream);
 #define getwc(stream) fgetwc(stream)
 #define putwc(wc, stream) fputwc(wc, stream)
+
+/* Wide-character memory operations */
+wchar_t *wmemcpy(wchar_t *dest, const wchar_t *src, size_t n);
+wchar_t *wmemmove(wchar_t *dest, const wchar_t *src, size_t n);
+wchar_t *wmemset(wchar_t *s, wchar_t c, size_t n);
+int wmemcmp(const wchar_t *s1, const wchar_t *s2, size_t n);
 
 #endif /* WCHAR_H */

--- a/src/wmem.c
+++ b/src/wmem.c
@@ -1,0 +1,52 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms, with or without modification, are permitted provided that the copyright notice and this permission notice appear in all copies. This software is provided "as is" without warranty.
+ *
+ * Purpose: Implements wide memory routines for vlibc.
+ */
+
+#include "wchar.h"
+
+wchar_t *wmemset(wchar_t *s, wchar_t c, size_t n)
+{
+    wchar_t *p = s;
+    while (n--)
+        *p++ = c;
+    return s;
+}
+
+wchar_t *wmemcpy(wchar_t *dest, const wchar_t *src, size_t n)
+{
+    wchar_t *d = dest;
+    const wchar_t *s2 = src;
+    while (n--)
+        *d++ = *s2++;
+    return dest;
+}
+
+wchar_t *wmemmove(wchar_t *dest, const wchar_t *src, size_t n)
+{
+    wchar_t *d = dest;
+    const wchar_t *s2 = src;
+    if (d == s2 || n == 0)
+        return dest;
+    if (d < s2) {
+        while (n--)
+            *d++ = *s2++;
+    } else {
+        d += n;
+        s2 += n;
+        while (n--)
+            *--d = *--s2;
+    }
+    return dest;
+}
+
+int wmemcmp(const wchar_t *s1, const wchar_t *s2, size_t n)
+{
+    while (n--) {
+        if (*s1 != *s2)
+            return (int)(*s1 - *s2);
+        s1++; s2++;
+    }
+    return 0;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -899,6 +899,27 @@ static const char *test_wctype_checks(void)
     return 0;
 }
 
+static const char *test_wmem_ops(void)
+{
+    wchar_t buf[8];
+    wmemset(buf, L'x', 8);
+    for (size_t i = 0; i < 8; i++)
+        mu_assert("wmemset", buf[i] == L'x');
+
+    wchar_t src[8] = { L'a', L'b', L'c', L'd', L'e', L'f', L'g', L'h' };
+    wmemcpy(buf, src, 8);
+    mu_assert("wmemcpy", wmemcmp(buf, src, 8) == 0);
+
+    wmemmove(buf + 1, buf, 7);
+    mu_assert("wmemmove", buf[1] == L'a' && buf[2] == L'b');
+
+    wchar_t a[] = { L'a', L'b', L'c' };
+    wchar_t b[] = { L'a', L'b', L'd' };
+    mu_assert("wmemcmp diff", wmemcmp(a, b, 3) < 0);
+
+    return 0;
+}
+
 static const char *test_iconv_ascii_roundtrip(void)
 {
     iconv_t cd = iconv_open("UTF-8", "ASCII");
@@ -3294,6 +3315,7 @@ static const char *all_tests(void)
     mu_run_test(test_widechar_conv);
     mu_run_test(test_widechar_width);
     mu_run_test(test_wctype_checks);
+    mu_run_test(test_wmem_ops);
     mu_run_test(test_iconv_ascii_roundtrip);
     mu_run_test(test_iconv_invalid_byte);
     mu_run_test(test_strtok_basic);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -382,7 +382,19 @@ of a wide string excluding the terminator.
 
 `wcscpy`, `wcsncpy`, `wcscmp`, `wcsncmp`, and `wcsdup` mirror the
 behaviour of their narrow-string counterparts for copying, comparing and
-duplicating wide strings.
+duplicating wide strings. The `wmemcpy`, `wmemmove`, `wmemset` and
+`wmemcmp` routines operate on arrays of `wchar_t` analogous to the byte
+
+### Example
+
+```c
+wchar_t src[] = { L'a', L'b', L'c' };
+wchar_t dst[3];
+wmemcpy(dst, src, 3);      // copy three wide characters
+wmemmove(dst + 1, dst, 2); // move with overlap
+wmemset(dst, L'X', 2);     // fill first two entries
+int diff = wmemcmp(dst, src, 3);
+```
 
 `wcwidth` reports the number of columns needed to display a single wide
 character while `wcswidth` sums the widths of up to `n` characters. ASCII


### PR DESCRIPTION
## Summary
- declare wmemcpy/wmemmove/wmemset/wmemcmp in `<wchar.h>`
- implement new wide memory helpers
- document new routines with examples
- note availability in README
- compile new file and add unit tests for the helpers

## Testing
- `make test` *(fails: command interrupted due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685c4751301c8324bbbfb4d4302190d1