### PR TITLE
Add difftime implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ clock_gettime(CLOCK_MONOTONIC, &ts);
 
 `CLOCK_REALTIME` returns the wall-clock time.
 `clock_getres` queries the resolution of a given clock.
+Use `difftime` to compute the difference between two `time_t` values.
 
 ## Time Formatting
 

--- a/include/time.h
+++ b/include/time.h
@@ -177,6 +177,8 @@ time_t mktime(struct tm *tm);
 /* Convert a broken-down UTC time to seconds since the epoch. */
 time_t timegm(struct tm *tm);
 /* Non-standard alias for mktime(). */
+double difftime(time_t end, time_t start);
+/* Difference between two times in seconds. */
 char *ctime(const time_t *timep);
 /* Format a time value using localtime() into a static string. */
 

--- a/src/time_conv.c
+++ b/src/time_conv.c
@@ -106,3 +106,12 @@ char *ctime(const time_t *timep)
              tm->tm_year + 1900);
     return buf;
 }
+
+/*
+ * Return the difference between two time values in seconds as a
+ * double precision floating point number.
+ */
+double difftime(time_t end, time_t start)
+{
+    return (double)end - (double)start;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1899,6 +1899,17 @@ static const char *test_time_r_conversions(void)
     return 0;
 }
 
+static const char *test_difftime_basic(void)
+{
+    time_t a = 10;
+    time_t b = 42;
+    double d = difftime(b, a);
+    mu_assert("difftime pos", fabs(d - 32.0) < 1e-9);
+    d = difftime(a, b);
+    mu_assert("difftime neg", fabs(d + 32.0) < 1e-9);
+    return 0;
+}
+
 static const char *test_tz_positive(void)
 {
     setenv("TZ", "UTC+2", 1);
@@ -3335,6 +3346,7 @@ static const char *all_tests(void)
     mu_run_test(test_strptime_basic);
     mu_run_test(test_time_conversions);
     mu_run_test(test_time_r_conversions);
+    mu_run_test(test_difftime_basic);
     mu_run_test(test_tz_positive);
     mu_run_test(test_tz_negative);
     mu_run_test(test_tz_mktime_roundtrip);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -1655,6 +1655,9 @@ struct timespec res;
 clock_getres(CLOCK_MONOTONIC, &res);
 ```
 
+`difftime` subtracts two `time_t` values and returns the elapsed seconds as
+a `double`.
+
 Thread-safe variants `gmtime_r` and `localtime_r` fill a user-provided
 `struct tm` using the same conversion logic.  `tzset` reloads the active
 timezone from the `TZ` environment variable or `/etc/localtime` so


### PR DESCRIPTION
## Summary
- declare and implement `difftime`
- document usage in README and vlibcdoc
- test positive and negative time differences

## Testing
- `timeout 60 make test` *(fails: terminated after 60s)*

------
https://chatgpt.com/codex/tasks/task_e_685c475877708324b41a5c991726f6ea