### PR TITLE
Add sched_yield wrapper and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ SRC := \
     src/hostname.c \
     src/uname.c \
     src/sleep.c \
+    src/sched.c \
     src/clock_gettime.c \
     src/clock_getres.c \
     src/time.c \
@@ -213,6 +214,8 @@ install: $(LIB)
 	install -m 644 include/assert.h $(DESTDIR)$(PREFIX)/include
 	# ensure iconv.h is installed
 	install -m 644 include/iconv.h $(DESTDIR)$(PREFIX)/include
+	# install sched.h
+	install -m 644 include/sched.h $(DESTDIR)$(PREFIX)/include
 	install -d $(DESTDIR)$(PREFIX)/include/sys
 	# install system headers including wait.h
 	install -m 644 include/sys/*.h $(DESTDIR)$(PREFIX)/include/sys

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ programs. Key features include:
 - Filesystem limits with `pathconf()` and `fpathconf()`
 - Query configuration strings with `confstr()`
 - Simple alarm timers with `alarm()`
+- Yield the processor with `sched_yield()`
 - POSIX interval timers with `timer_create` and `timer_settime()`
 - Resource usage statistics with `getrusage()`
 - Basic character set conversion with `iconv`

--- a/include/sched.h
+++ b/include/sched.h
@@ -1,0 +1,11 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Declarations for basic scheduling helpers.
+ */
+#ifndef SCHED_H
+#define SCHED_H
+
+int sched_yield(void);
+
+#endif /* SCHED_H */

--- a/src/sched.c
+++ b/src/sched.c
@@ -1,0 +1,40 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Implements simple scheduling helpers for vlibc.
+ */
+#include "sched.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int sched_yield(void)
+{
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__) || defined(__APPLE__)
+# ifdef SYS_sched_yield
+    long ret = syscall(SYS_sched_yield, 0, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+# else
+    extern int host_sched_yield(void) __asm__("sched_yield");
+    return host_sched_yield();
+# endif
+#else
+# ifdef SYS_sched_yield
+    long ret = vlibc_syscall(SYS_sched_yield, 0, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+# else
+    extern int host_sched_yield(void) __asm__("sched_yield");
+    return host_sched_yield();
+# endif
+#endif
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -58,6 +58,7 @@
 #include "../include/sys/mman.h"
 #include "../include/sys/shm.h"
 #include "../include/mqueue.h"
+#include "../include/sched.h"
 
 /* use host printf for test output */
 int printf(const char *fmt, ...);
@@ -1767,6 +1768,12 @@ static const char *test_sleep_functions(void)
     return 0;
 }
 
+static const char *test_sched_yield_basic(void)
+{
+    mu_assert("sched_yield", sched_yield() == 0);
+    return 0;
+}
+
 static const char *test_timer_basic(void)
 {
     timer_t t;
@@ -3359,6 +3366,7 @@ static const char *all_tests(void)
     mu_run_test(test_select_pipe);
     mu_run_test(test_poll_pipe);
     mu_run_test(test_sleep_functions);
+    mu_run_test(test_sched_yield_basic);
     mu_run_test(test_timer_basic);
     mu_run_test(test_getrusage_self);
     mu_run_test(test_strftime_basic);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -50,15 +50,16 @@ This document outlines the architecture, planned modules, and API design for **v
 44. [Locale Support](#locale-support)
 45. [Time Retrieval](#time-retrieval)
 46. [Sleep Functions](#sleep-functions)
-47. [Interval Timers](#interval-timers)
-48. [Raw System Calls](#raw-system-calls)
-49. [Non-local Jumps](#non-local-jumps)
-50. [Limitations](#limitations)
-51. [Conclusion](#conclusion)
-52. [Logging](#logging)
-53. [Path Expansion](#path-expansion)
-54. [Filesystem Statistics](#filesystem-statistics)
-55. [Resource Limits](#resource-limits)
+47. [Scheduling](#scheduling)
+48. [Interval Timers](#interval-timers)
+49. [Raw System Calls](#raw-system-calls)
+50. [Non-local Jumps](#non-local-jumps)
+51. [Limitations](#limitations)
+52. [Conclusion](#conclusion)
+53. [Logging](#logging)
+54. [Path Expansion](#path-expansion)
+55. [Filesystem Statistics](#filesystem-statistics)
+56. [Resource Limits](#resource-limits)
 
 ## Overview
 
@@ -1684,6 +1685,16 @@ unsigned sleep(unsigned seconds);
 int usleep(useconds_t usec);
 int nanosleep(const struct timespec *req, struct timespec *rem);
 unsigned int alarm(unsigned int seconds);
+```
+
+## Scheduling
+
+`sched_yield` allows a thread to voluntarily relinquish the CPU, letting
+other runnable threads run. It simply issues the operating system's
+`yield` syscall when available or falls back to the host implementation.
+
+```c
+int sched_yield(void);
 ```
 
 ## Interval Timers


### PR DESCRIPTION
## Summary
- declare `sched_yield` in a new `sched.h`
- implement `sched_yield` using the `yield` syscall and host fallbacks
- install `sched.h`
- document scheduling API and mention in README
- test that `sched_yield` succeeds

## Testing
- `make test` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_685c4a1befbc8324b681893893377522