### PR TITLE
Add wcstok implementation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ sscanf("42 example", "%d %s", &num, word);
 vlibc ships common routines like `strdup`, `strndup`, `strlcpy`, and `strlcat`.
 Search helpers `strstr`, `strrchr`, `memchr`, `memrchr`, and `memmem` locate substrings or
 bytes. Tokenizers `strtok`, `strtok_r`, and the lightweight `strsep` help split
-strings based on delimiters.
+strings based on delimiters. Wide strings can be tokenized with `wcstok`.
 Copy helpers `stpcpy` and `stpncpy` return the end pointer after copying.
 `memccpy` stops when a byte is found while `mempcpy` returns the pointer to the
 end of the copied region.

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -39,6 +39,8 @@ int wcscmp(const wchar_t *s1, const wchar_t *s2);
 int wcsncmp(const wchar_t *s1, const wchar_t *s2, size_t n);
 /* Duplicate a wide-character string */
 wchar_t *wcsdup(const wchar_t *s);
+/* Tokenize a wide-character string */
+wchar_t *wcstok(wchar_t *str, const wchar_t *delim, wchar_t **saveptr);
 /* Display width of a wide character */
 int wcwidth(wchar_t wc);
 /* Display width of at most n wide chars */

--- a/src/wchar.c
+++ b/src/wchar.c
@@ -130,3 +130,52 @@ wchar_t *wcsdup(const wchar_t *s)
     wcscpy(dup, s);
     return dup;
 }
+
+/* Helper to test if a character is in the delimiter set. */
+static int is_wdelim(wchar_t c, const wchar_t *delim)
+{
+    for (const wchar_t *d = delim; *d; ++d) {
+        if (*d == c)
+            return 1;
+    }
+    return 0;
+}
+
+/* Tokenize a wide-character string similar to strtok_r. */
+wchar_t *wcstok(wchar_t *str, const wchar_t *delim, wchar_t **saveptr)
+{
+    wchar_t *s;
+
+    if (str)
+        s = str;
+    else if (saveptr && *saveptr)
+        s = *saveptr;
+    else
+        return NULL;
+
+    /* skip leading delimiters */
+    while (*s && is_wdelim(*s, delim))
+        s++;
+
+    if (*s == L'\0') {
+        if (saveptr)
+            *saveptr = NULL;
+        return NULL;
+    }
+
+    wchar_t *token = s;
+
+    while (*s && !is_wdelim(*s, delim))
+        s++;
+
+    if (*s) {
+        *s = L'\0';
+        s++;
+        if (saveptr)
+            *saveptr = s;
+    } else if (saveptr) {
+        *saveptr = NULL;
+    }
+
+    return token;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1013,6 +1013,21 @@ static const char *test_strsep_basic(void)
     return 0;
 }
 
+static const char *test_wcstok_basic(void)
+{
+    wchar_t buf[] = L"a b c";
+    wchar_t *save = NULL;
+    wchar_t *tok = wcstok(buf, L" ", &save);
+    mu_assert("wcstok1", tok && wcscmp(tok, L"a") == 0);
+    tok = wcstok(NULL, L" ", &save);
+    mu_assert("wcstok2", tok && wcscmp(tok, L"b") == 0);
+    tok = wcstok(NULL, L" ", &save);
+    mu_assert("wcstok3", tok && wcscmp(tok, L"c") == 0);
+    tok = wcstok(NULL, L" ", &save);
+    mu_assert("wcstok end", tok == NULL);
+    return 0;
+}
+
 static const char *test_printf_functions(void)
 {
     char buf[64];
@@ -3355,6 +3370,7 @@ static const char *all_tests(void)
     mu_run_test(test_strtok_basic);
     mu_run_test(test_strtok_r_basic);
     mu_run_test(test_strsep_basic);
+    mu_run_test(test_wcstok_basic);
     mu_run_test(test_printf_functions);
     mu_run_test(test_dprintf_functions);
     mu_run_test(test_scanf_functions);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -386,8 +386,10 @@ of a wide string excluding the terminator.
 
 `wcscpy`, `wcsncpy`, `wcscmp`, `wcsncmp`, and `wcsdup` mirror the
 behaviour of their narrow-string counterparts for copying, comparing and
-duplicating wide strings. The `wmemcpy`, `wmemmove`, `wmemset` and
-`wmemcmp` routines operate on arrays of `wchar_t` analogous to the byte
+duplicating wide strings. The `wcstok` function tokenizes a wide string
+using a caller-supplied save pointer. The `wmemcpy`, `wmemmove`,
+`wmemset` and `wmemcmp` routines operate on arrays of `wchar_t`
+analogous to the byte
 
 ### Example
 
@@ -398,6 +400,15 @@ wmemcpy(dst, src, 3);      // copy three wide characters
 wmemmove(dst + 1, dst, 2); // move with overlap
 wmemset(dst, L'X', 2);     // fill first two entries
 int diff = wmemcmp(dst, src, 3);
+```
+
+Wide strings can be tokenized incrementally:
+
+```c
+wchar_t text[] = L"one two";
+wchar_t *save = NULL;
+wchar_t *t1 = wcstok(text, L" ", &save); // L"one"
+wchar_t *t2 = wcstok(NULL, L" ", &save); // L"two"
 ```
 
 `wcwidth` reports the number of columns needed to display a single wide


### PR DESCRIPTION
## Summary
- add `wcstok` prototype to header
- implement wide tokenization logic in `wchar.c`
- document usage in README and vlibcdoc
- add unit test for `wcstok`

## Testing
- `make test` *(fails: interrupted due to long build time)*

------
https://chatgpt.com/codex/tasks/task_e_685c4dcb032c8324957035aa7c2836c4