### PR TITLE
Add named semaphore wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ SRC := \
     src/pthread_spin.c \
     src/pthread_barrier.c \
     src/semaphore.c \
+    src/semaphore_named.c \
     src/dirent.c \
     src/default_shell.c \
     src/popen.c \

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ programs. Key features include:
 - Wait for specific signals with `sigwait()` and `sigtimedwait()`
 - Set mutex types with `pthread_mutexattr_settype()`
 - Counting semaphores with `sem_init()`/`sem_wait()`/`sem_post()`
+- Named semaphores with `sem_open()`/`sem_close()`/`sem_unlink()`
 - Thread barriers with `pthread_barrier_init()` and `pthread_barrier_wait()`
 - Lightweight spin locks with `pthread_spin_lock()` and
   `pthread_spin_unlock()`

--- a/include/semaphore.h
+++ b/include/semaphore.h
@@ -13,6 +13,10 @@ typedef struct {
     atomic_int count;
 } sem_t;
 
+#ifndef SEM_FAILED
+#define SEM_FAILED ((sem_t *)-1)
+#endif
+
 int sem_init(sem_t *sem, int pshared, unsigned value);
 /* Initialize a counting semaphore with the given starting value. */
 int sem_destroy(sem_t *sem);
@@ -23,5 +27,16 @@ int sem_trywait(sem_t *sem);
 /* Try to decrement the semaphore without blocking. */
 int sem_post(sem_t *sem);
 /* Increment the semaphore count and wake any waiting threads. */
+
+sem_t *sem_open(const char *name, int oflag, ...);
+/* Open or create a named semaphore object. */
+int sem_close(sem_t *sem);
+/* Close a named semaphore object. */
+int sem_unlink(const char *name);
+/* Remove a named semaphore. */
+int sem_getvalue(sem_t *sem, int *value);
+/* Retrieve the current semaphore count. */
+int sem_timedwait(sem_t *sem, const struct timespec *abstime);
+/* Wait with an absolute timeout. */
 
 #endif /* SEMAPHORE_H */

--- a/src/semaphore_named.c
+++ b/src/semaphore_named.c
@@ -1,0 +1,122 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the copyright
+ * notice and this permission notice appear in all copies. This software is
+ * provided "as is" without warranty.
+ *
+ * Purpose: Implements named semaphore wrappers for vlibc.
+ */
+
+#include "semaphore.h"
+#include "errno.h"
+#include "time.h"
+#include <stdarg.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+
+extern sem_t *host_sem_open(const char *, int, ...) __asm("sem_open");
+extern int host_sem_close(sem_t *) __asm("sem_close");
+extern int host_sem_unlink(const char *) __asm("sem_unlink");
+extern int host_sem_getvalue(sem_t *, int *) __asm("sem_getvalue");
+extern int host_sem_timedwait(sem_t *, const struct timespec *) __asm("sem_timedwait");
+
+sem_t *sem_open(const char *name, int oflag, ...)
+{
+    mode_t mode = 0;
+    unsigned value = 0;
+    if (oflag & O_CREAT) {
+        va_list ap;
+        va_start(ap, oflag);
+        mode = va_arg(ap, mode_t);
+        value = va_arg(ap, unsigned);
+        va_end(ap);
+    }
+    return host_sem_open(name, oflag, mode, value);
+}
+
+int sem_close(sem_t *sem)
+{
+    return host_sem_close(sem);
+}
+
+int sem_unlink(const char *name)
+{
+    return host_sem_unlink(name);
+}
+
+int sem_getvalue(sem_t *sem, int *value)
+{
+    return host_sem_getvalue(sem, value);
+}
+
+int sem_timedwait(sem_t *sem, const struct timespec *abstime)
+{
+    return host_sem_timedwait(sem, abstime);
+}
+
+#else /* generic minimal fallback */
+
+sem_t *sem_open(const char *name, int oflag, ...)
+{
+    (void)name; (void)oflag;
+    unsigned value = 0;
+    if (oflag & O_CREAT) {
+        va_list ap;
+        va_start(ap, oflag);
+        (void)va_arg(ap, mode_t);
+        value = va_arg(ap, unsigned);
+        va_end(ap);
+    }
+    sem_t *sem = malloc(sizeof(*sem));
+    if (!sem) {
+        errno = ENOMEM;
+        return SEM_FAILED;
+    }
+    sem_init(sem, 0, value);
+    return sem;
+}
+
+int sem_close(sem_t *sem)
+{
+    if (!sem)
+        return -1;
+    sem_destroy(sem);
+    free(sem);
+    return 0;
+}
+
+int sem_unlink(const char *name)
+{
+    (void)name;
+    return 0;
+}
+
+int sem_getvalue(sem_t *sem, int *value)
+{
+    if (!sem || !value)
+        return EINVAL;
+    *value = atomic_load_explicit(&sem->count, memory_order_relaxed);
+    return 0;
+}
+
+int sem_timedwait(sem_t *sem, const struct timespec *abstime)
+{
+    if (!sem || !abstime)
+        return EINVAL;
+    for (;;) {
+        if (sem_trywait(sem) == 0)
+            return 0;
+        struct timespec now;
+        clock_gettime(CLOCK_REALTIME, &now);
+        if (now.tv_sec > abstime->tv_sec ||
+            (now.tv_sec == abstime->tv_sec && now.tv_nsec >= abstime->tv_nsec))
+            return ETIMEDOUT;
+        struct timespec ts = {0, 1000000};
+        nanosleep(&ts, NULL);
+    }
+}
+
+#endif

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2733,6 +2733,16 @@ static const char *test_mqueue_basic(void)
     return 0;
 }
 
+static const char *test_named_semaphore_create(void)
+{
+    const char *name = "/vlibc_test_sem";
+    sem_t *s = sem_open(name, O_CREAT | O_EXCL, 0600, 1);
+    mu_assert("sem_open", s != SEM_FAILED);
+    mu_assert("sem_close", sem_close(s) == 0);
+    mu_assert("sem_unlink", sem_unlink(name) == 0);
+    return 0;
+}
+
 static const char *test_atexit_handler(void)
 {
     mu_assert("pipe", pipe(exit_pipe) == 0);
@@ -3528,6 +3538,7 @@ static const char *all_tests(void)
     mu_run_test(test_mprotect_anon);
     mu_run_test(test_shm_basic);
     mu_run_test(test_mqueue_basic);
+    mu_run_test(test_named_semaphore_create);
     mu_run_test(test_atexit_handler);
     mu_run_test(test_quick_exit_handler);
     mu_run_test(test_getcwd_chdir);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -864,6 +864,11 @@ int sem_destroy(sem_t *sem);
 int sem_wait(sem_t *sem);
 int sem_trywait(sem_t *sem);
 int sem_post(sem_t *sem);
+sem_t *sem_open(const char *name, int oflag, ...);
+int sem_close(sem_t *sem);
+int sem_unlink(const char *name);
+int sem_getvalue(sem_t *sem, int *value);
+int sem_timedwait(sem_t *sem, const struct timespec *abstime);
 
 int pthread_barrier_init(pthread_barrier_t *barrier, void *attr,
                          unsigned count);
@@ -920,6 +925,10 @@ pattern as mutexes.
 Semaphores provide a simple counting mechanism for coordinating threads. They
 use an atomic counter and block with `nanosleep` when no resources are
 available.
+Named semaphores can be opened with `sem_open`. On BSD systems the native
+interfaces are used while other platforms allocate an in-process semaphore and
+ignore the name. Such fallbacks are not shared between processes and
+`sem_unlink` simply succeeds.
 
 Barriers synchronize a fixed number of threads at predetermined points. After
 calling `pthread_barrier_init()` with the participant count, each thread invokes
@@ -1830,10 +1839,12 @@ state.
  - The `system()` helper spawns `/bin/sh -c` and lacks detailed status
    codes.
  - `perror` and `strerror` support the full set of standard errno values.
- - Thread support is limited to basic mutexes, condition variables,
-   semaphores, barriers and join/detach.
- - Locale handling falls back to the host implementation for values other
-   than `"C"` or `"POSIX"`.
+- Thread support is limited to basic mutexes, condition variables,
+  semaphores, barriers and join/detach.
+- Named semaphores fall back to process-local objects on non-BSD systems and are
+  not shareable across processes.
+- Locale handling falls back to the host implementation for values other
+  than `"C"` or `"POSIX"`.
 - `setjmp`/`longjmp` rely on the host C library when available.
   Only an x86_64 fallback implementation is provided.
 - Regular expressions cover only a subset of POSIX syntax. Capture


### PR DESCRIPTION
## Summary
- expose more semaphore APIs
- implement named semaphore functions
- test named semaphore creation and removal
- document usage and limits for named semaphores

## Testing
- `make -j2 test` *(fails: interrupted due to long build)*

------
https://chatgpt.com/codex/tasks/task_e_685c56333f8c832490474999089f71f2