### PR TITLE
Add sched_yield implementation with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ programs. Key features include:
 - Filesystem limits with `pathconf()` and `fpathconf()`
 - Query configuration strings with `confstr()`
 - Simple alarm timers with `alarm()`
-- Yield the processor with `sched_yield()`
+- Yield the processor with `sched_yield()` from `<sched.h>`
 - POSIX interval timers with `timer_create` and `timer_settime()`
 - Resource usage statistics with `getrusage()`
 - Basic character set conversion with `iconv`

--- a/src/sched.c
+++ b/src/sched.c
@@ -4,6 +4,7 @@
  * Purpose: Implements simple scheduling helpers for vlibc.
  */
 #include "sched.h"
+#include "time.h"
 #include "errno.h"
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -11,30 +12,15 @@
 
 int sched_yield(void)
 {
-#if defined(__FreeBSD__) || defined(__NetBSD__) || \
-    defined(__OpenBSD__) || defined(__DragonFly__) || defined(__APPLE__)
-# ifdef SYS_sched_yield
-    long ret = syscall(SYS_sched_yield, 0, 0, 0, 0, 0, 0);
-    if (ret < 0) {
-        errno = -ret;
-        return -1;
-    }
-    return 0;
-# else
-    extern int host_sched_yield(void) __asm__("sched_yield");
-    return host_sched_yield();
-# endif
-#else
-# ifdef SYS_sched_yield
+#ifdef SYS_sched_yield
     long ret = vlibc_syscall(SYS_sched_yield, 0, 0, 0, 0, 0, 0);
     if (ret < 0) {
         errno = -ret;
         return -1;
     }
     return 0;
-# else
-    extern int host_sched_yield(void) __asm__("sched_yield");
-    return host_sched_yield();
-# endif
+#else
+    struct timespec ts = {0, 0};
+    return nanosleep(&ts, NULL);
 #endif
 }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1955,6 +1955,13 @@ static const char *test_sched_yield_basic(void)
     return 0;
 }
 
+static const char *test_sched_yield_loop(void)
+{
+    for (int i = 0; i < 10; ++i)
+        mu_assert("sched_yield", sched_yield() == 0);
+    return 0;
+}
+
 static const char *test_timer_basic(void)
 {
     timer_t t;
@@ -3658,6 +3665,7 @@ static const char *all_tests(void)
     mu_run_test(test_poll_pipe);
     mu_run_test(test_sleep_functions);
     mu_run_test(test_sched_yield_basic);
+    mu_run_test(test_sched_yield_loop);
     mu_run_test(test_timer_basic);
     mu_run_test(test_getrusage_self);
     mu_run_test(test_strftime_basic);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -189,6 +189,7 @@ stdlib.h     - basic utilities
 string.h     - string manipulation
 iconv.h      - character set conversion helpers
 regex.h     - simple regular expression matching
+sched.h     - processor yield helper
 termios.h   - terminal attribute helpers
 unistd.h    - POSIX I/O and process helpers
 sys/file.h   - file permission helpers
@@ -1751,8 +1752,11 @@ unsigned int alarm(unsigned int seconds);
 ## Scheduling
 
 `sched_yield` allows a thread to voluntarily relinquish the CPU, letting
-other runnable threads run. It simply issues the operating system's
-`yield` syscall when available or falls back to the host implementation.
+other runnable threads run. When the `SYS_sched_yield` syscall is
+available it is invoked directly. Otherwise the function falls back to
+`nanosleep` with a zero timeout.
+
+Declared in `<sched.h>`.
 
 ```c
 int sched_yield(void);


### PR DESCRIPTION
## Summary
- implement sched_yield using syscall with nanosleep fallback
- extend tests with a sched_yield loop
- document sched.h and sched_yield usage

## Testing
- `make test` *(fails: process timed out)*

------
https://chatgpt.com/codex/tasks/task_e_685c64d0116c8324a2d49ae579a3c8a7