### PR TITLE
Add fsync/fdatasync wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ SRC := \
     src/file.c \
     src/file_perm.c \
     src/flock.c \
+    src/fsync.c \
     src/truncate.c \
     src/posix_fallocate.c \
     src/dir.c \

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ programs. Key features include:
 - FIFO creation with `mkfifo()` and `mkfifoat()`
 - Device node creation with `mknod()` and `mknodat()`
 - File space reservation with `posix_fallocate()`
+- Force file updates to disk with `fsync()` and `fdatasync()`
 - Generic descriptor control with `ioctl()`
 - Terminal attribute helpers `tcgetattr()`, `tcsetattr()`, `tcdrain()`,
   `tcflow()`, `tcflush()` and `tcsendbreak()`

--- a/include/io.h
+++ b/include/io.h
@@ -50,5 +50,9 @@ int rmdir(const char *pathname);
 int chdir(const char *path);
 int access(const char *pathname, int mode);
 int faccessat(int dirfd, const char *pathname, int mode, int flags);
+/* Flush all pending writes for a descriptor using SYS_fsync or host fsync. */
+int fsync(int fd);
+/* Synchronize file data only via SYS_fdatasync or host fdatasync. */
+int fdatasync(int fd);
 
 #endif /* IO_H */

--- a/src/fsync.c
+++ b/src/fsync.c
@@ -1,0 +1,71 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the copyright
+ * notice and this permission notice appear in all copies. This software is
+ * provided "as is" without warranty.
+ *
+ * Purpose: Implements fsync and fdatasync for vlibc. Uses vlibc_syscall
+ * when possible and falls back to the host implementations on BSD.
+ */
+
+#include "io.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+#ifndef SYS_fsync
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+extern int host_fsync(int) __asm__("fsync");
+#endif
+#endif
+
+#ifndef SYS_fdatasync
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+extern int host_fdatasync(int) __asm__("fdatasync");
+#endif
+#endif
+
+int fsync(int fd)
+{
+#ifdef SYS_fsync
+    long ret = vlibc_syscall(SYS_fsync, fd, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#else
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    return host_fsync(fd);
+#else
+    (void)fd;
+    errno = ENOSYS;
+    return -1;
+#endif
+#endif
+}
+
+int fdatasync(int fd)
+{
+#ifdef SYS_fdatasync
+    long ret = vlibc_syscall(SYS_fdatasync, fd, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#else
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    return host_fdatasync(fd);
+#else
+    (void)fd;
+    errno = ENOSYS;
+    return -1;
+#endif
+#endif
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -773,6 +773,32 @@ static const char *test_at_wrappers_basic(void)
     return 0;
 }
 
+static const char *test_fsync_basic(void)
+{
+    const char *fname = "tmp_fsync_file";
+    int fd = open(fname, O_CREAT | O_RDWR, 0644);
+    mu_assert("open", fd >= 0);
+    mu_assert("write", write(fd, "x", 1) == 1);
+    int r = fsync(fd);
+    close(fd);
+    unlink(fname);
+    mu_assert("fsync", r == 0);
+    return 0;
+}
+
+static const char *test_fdatasync_basic(void)
+{
+    const char *fname = "tmp_fdatasync_file";
+    int fd = open(fname, O_CREAT | O_RDWR, 0644);
+    mu_assert("open", fd >= 0);
+    mu_assert("write", write(fd, "y", 1) == 1);
+    int r = fdatasync(fd);
+    close(fd);
+    unlink(fname);
+    mu_assert("fdatasync", r == 0);
+    return 0;
+}
+
 static const char *test_string_helpers(void)
 {
     mu_assert("strcmp equal", strcmp("abc", "abc") == 0);
@@ -3634,6 +3660,8 @@ static const char *all_tests(void)
     mu_run_test(test_posix_fallocate_basic);
     mu_run_test(test_link_readlink);
     mu_run_test(test_at_wrappers_basic);
+    mu_run_test(test_fsync_basic);
+    mu_run_test(test_fdatasync_basic);
     mu_run_test(test_string_helpers);
     mu_run_test(test_string_casecmp);
     mu_run_test(test_strlcpy_cat);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -1166,6 +1166,9 @@ int pipefd[2];
 pipe(pipefd);
 ```
 
+Flush pending writes with `fsync(fd)` or the data-only variant
+`fdatasync(fd)`. Both return 0 on success.
+
 Use `isatty(fd)` to query whether a descriptor refers to a terminal.
 
 ## File Control


### PR DESCRIPTION
## Summary
- add fsync and fdatasync implementations
- export prototypes in io.h
- compile new source
- document usage in docs and README
- test the new wrappers

## Testing
- `make test` *(fails: make took too long and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685c67da9b48832487bef74680726944