### PR TITLE
Add asctime implementations and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ programs. Key features include:
 - Dynamic loading with `dlopen`, `dlsym`, `dlclose` and `dladdr`
 - Environment variable handling
 - Basic timezone handling with `tzset()`
+- Format broken-down times with `asctime()` and thread-safe `asctime_r()`
 - Host name queries and changes
 - Login name retrieval with `getlogin()`
 - Thread-safe user and group lookups with `getpwuid_r`, `getpwnam_r`,

--- a/include/time.h
+++ b/include/time.h
@@ -181,5 +181,9 @@ double difftime(time_t end, time_t start);
 /* Difference between two times in seconds. */
 char *ctime(const time_t *timep);
 /* Format a time value using localtime() into a static string. */
+char *asctime(const struct tm *tm);
+/* Format a broken-down time into a static string. */
+char *asctime_r(const struct tm *tm, char *buf);
+/* Reentrant version of asctime() writing to user supplied buffer. */
 
 #endif /* TIME_H */

--- a/src/time_conv.c
+++ b/src/time_conv.c
@@ -108,6 +108,42 @@ char *ctime(const time_t *timep)
 }
 
 /*
+ * Reentrant conversion of a broken-down time structure to the
+ * standard ASCII representation. The caller supplies the buffer
+ * which must hold at least 26 characters.
+ */
+char *asctime_r(const struct tm *tm, char *buf)
+{
+    static const char *wd[7] = {"Sun","Mon","Tue","Wed","Thu","Fri","Sat"};
+    static const char *mn[12] = {"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug",
+                                 "Sep","Oct","Nov","Dec"};
+    if (!tm || !buf)
+        return NULL;
+    char dd[3] = {0}, hh[3] = {0}, mm[3] = {0}, ss[3] = {0};
+    dd[0] = '0' + (tm->tm_mday / 10);
+    dd[1] = '0' + (tm->tm_mday % 10);
+    hh[0] = '0' + (tm->tm_hour / 10);
+    hh[1] = '0' + (tm->tm_hour % 10);
+    mm[0] = '0' + (tm->tm_min / 10);
+    mm[1] = '0' + (tm->tm_min % 10);
+    ss[0] = '0' + (tm->tm_sec / 10);
+    ss[1] = '0' + (tm->tm_sec % 10);
+    snprintf(buf, 26, "%s %s %s %s:%s:%s %d\n",
+             wd[tm->tm_wday], mn[tm->tm_mon], dd, hh, mm, ss,
+             tm->tm_year + 1900);
+    return buf;
+}
+
+/*
+ * Thread-unsafe wrapper around asctime_r() using a static buffer.
+ */
+char *asctime(const struct tm *tm)
+{
+    static char buf[32];
+    return asctime_r(tm, buf);
+}
+
+/*
  * Return the difference between two time values in seconds as a
  * double precision floating point number.
  */

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -112,6 +112,20 @@ static void *strerror_r_worker(void *arg)
     return (void *)(strcmp(buf, expect) != 0);
 }
 
+struct asctime_arg {
+    struct tm tm;
+    const char *expect;
+};
+
+static void *asctime_r_worker(void *arg)
+{
+    struct asctime_arg *a = arg;
+    char buf[32];
+    if (!asctime_r(&a->tm, buf))
+        return (void *)1;
+    return (void *)(strcmp(buf, a->expect) != 0);
+}
+
 static const char *test_malloc(void)
 {
     void *p = malloc(16);
@@ -2093,6 +2107,11 @@ static const char *test_time_conversions(void)
 
     char *s = ctime(&t);
     mu_assert("ctime", strcmp(s, "Tue Nov 14 22:13:20 2023\n") == 0);
+    char *a = asctime(gm);
+    mu_assert("asctime", strcmp(a, "Tue Nov 14 22:13:20 2023\n") == 0);
+    char buf[32];
+    mu_assert("asctime_r",
+              strcmp(asctime_r(gm, buf), "Tue Nov 14 22:13:20 2023\n") == 0);
     return 0;
 }
 
@@ -2168,6 +2187,27 @@ static const char *test_tz_ctime(void)
     unsetenv("TZ");
     tzset();
     mu_assert("ctime offset", strstr(s, "23:13:20") != NULL);
+    return 0;
+}
+
+static const char *test_asctime_r_threadsafe(void)
+{
+    time_t t1 = 1700000000;
+    time_t t2 = t1 + 86400;
+    struct tm tm1, tm2;
+    gmtime_r(&t1, &tm1);
+    gmtime_r(&t2, &tm2);
+    struct asctime_arg a1 = { tm1, "Tue Nov 14 22:13:20 2023\n" };
+    struct asctime_arg a2 = { tm2, "Wed Nov 15 22:13:20 2023\n" };
+    pthread_t th1, th2;
+    pthread_create(&th1, NULL, asctime_r_worker, &a1);
+    pthread_create(&th2, NULL, asctime_r_worker, &a2);
+    void *r1 = (void *)1;
+    void *r2 = (void *)1;
+    pthread_join(th1, &r1);
+    pthread_join(th2, &r2);
+    mu_assert("asctime_r thread1", r1 == NULL);
+    mu_assert("asctime_r thread2", r2 == NULL);
     return 0;
 }
 
@@ -3685,6 +3725,7 @@ static const char *all_tests(void)
     mu_run_test(test_strptime_basic);
     mu_run_test(test_time_conversions);
     mu_run_test(test_time_r_conversions);
+    mu_run_test(test_asctime_r_threadsafe);
     mu_run_test(test_difftime_basic);
     mu_run_test(test_tz_positive);
     mu_run_test(test_tz_negative);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -1705,6 +1705,20 @@ strftime(buf, sizeof(buf), "%a %b %d %Y %H:%M:%S %Z %z", &tm);
 `wcsftime` performs the same conversion but writes to a wide-character buffer.
 `timegm` converts a `struct tm` in UTC back to `time_t` using the same logic as `mktime` but without timezone adjustments.
 
+### asctime and asctime_r
+
+`asctime` converts a `struct tm` to the classic 26 byte string used by `ctime`.
+`asctime_r` is the reentrant variant that writes into a caller provided buffer.
+
+```c
+time_t t = 1700000000;
+struct tm tm;
+gmtime_r(&t, &tm);
+char buf[26];
+printf("%s", asctime_r(&tm, buf));
+// "Tue Nov 14 22:13:20 2023\n"
+```
+
 ## Locale Support
 
 `setlocale` reads `LC_ALL` and `LANG` and sets the active locale


### PR DESCRIPTION
## Summary
- implement `asctime` and thread-safe `asctime_r`
- expose prototypes in `<time.h>`
- document new APIs in vlibcdoc and README
- extend unit tests for formatting and thread safety

## Testing
- `make test` *(fails: process terminated due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_685c66506e9c83249535b70e9ff096ba