### PR TITLE
Add locale object APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ SRC := \
     src/getopt_long.c \
     src/getopt_long_only.c \
     src/locale.c \
+    src/locale_extra.c \
     src/wchar.c \
     src/wchar_conv.c \
     src/wchar_io.c \

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ programs. Key features include:
 - Dynamic loading with `dlopen`, `dlsym`, `dlclose` and `dladdr`
 - Environment variable handling
 - Basic timezone handling with `tzset()`
+- Minimal locale objects with `newlocale()` and `uselocale()`
 - Format broken-down times with `asctime()` and thread-safe `asctime_r()`
 - Host name queries and changes
 - Login name retrieval with `getlogin()`

--- a/include/locale.h
+++ b/include/locale.h
@@ -38,4 +38,15 @@ struct lconv {
 char *setlocale(int category, const char *locale);
 struct lconv *localeconv(void);
 
+typedef struct __vlibc_locale *locale_t;
+
+#ifndef LC_GLOBAL_LOCALE
+#define LC_GLOBAL_LOCALE ((locale_t)-1)
+#endif
+
+locale_t newlocale(int category_mask, const char *locale, locale_t base);
+locale_t duplocale(locale_t loc);
+void freelocale(locale_t loc);
+locale_t uselocale(locale_t newloc);
+
 #endif /* LOCALE_H */

--- a/src/locale_extra.c
+++ b/src/locale_extra.c
@@ -1,0 +1,94 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Implements locale object helpers for vlibc. When running on
+ * BSD systems these wrap the host implementations. Otherwise only the
+ * "C" locale is supported.
+ */
+#include "locale.h"
+#include "string.h"
+#include "errno.h"
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+
+#define newlocale  host_newlocale
+#define duplocale  host_duplocale
+#define freelocale host_freelocale
+#define uselocale  host_uselocale
+#include_next <locale.h>
+#undef newlocale
+#undef duplocale
+#undef freelocale
+#undef uselocale
+
+extern locale_t host_newlocale(int, const char *, locale_t) __asm("newlocale");
+extern locale_t host_duplocale(locale_t) __asm("duplocale");
+extern void     host_freelocale(locale_t) __asm("freelocale");
+extern locale_t host_uselocale(locale_t) __asm("uselocale");
+
+locale_t newlocale(int mask, const char *loc, locale_t base)
+{
+    return host_newlocale(mask, loc, base);
+}
+
+locale_t duplocale(locale_t loc)
+{
+    return host_duplocale(loc);
+}
+
+void freelocale(locale_t loc)
+{
+    host_freelocale(loc);
+}
+
+locale_t uselocale(locale_t loc)
+{
+    return host_uselocale(loc);
+}
+
+#else /* !BSD */
+
+struct __vlibc_locale {
+    int dummy;
+};
+
+static struct __vlibc_locale c_locale = {0};
+static locale_t current_locale_obj = &c_locale;
+
+locale_t newlocale(int mask, const char *locale, locale_t base)
+{
+    (void)mask;
+    (void)base;
+    if (!locale || strcmp(locale, "C") == 0 || strcmp(locale, "POSIX") == 0)
+        return &c_locale;
+    errno = EINVAL;
+    return NULL;
+}
+
+locale_t duplocale(locale_t loc)
+{
+    if (loc == &c_locale)
+        return &c_locale;
+    errno = EINVAL;
+    return NULL;
+}
+
+void freelocale(locale_t loc)
+{
+    (void)loc;
+}
+
+locale_t uselocale(locale_t loc)
+{
+    locale_t old = current_locale_obj;
+    if (loc != (locale_t)0) {
+        if (loc == LC_GLOBAL_LOCALE)
+            current_locale_obj = &c_locale;
+        else
+            current_locale_obj = loc;
+    }
+    return old;
+}
+
+#endif /* BSD */

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2322,6 +2322,19 @@ static const char *test_locale_from_env(void)
     return 0;
 }
 
+static const char *test_locale_objects(void)
+{
+    locale_t loc = newlocale(LC_ALL, "C", NULL);
+    mu_assert("newlocale", loc != NULL);
+    locale_t old = uselocale(loc);
+    struct lconv *lc = localeconv();
+    mu_assert("decimal_point", strcmp(lc->decimal_point, ".") == 0);
+    mu_assert("thousands_sep", strcmp(lc->thousands_sep, "") == 0);
+    uselocale(old);
+    freelocale(loc);
+    return 0;
+}
+
 static const char *test_gethostname_fn(void)
 {
     char buf[256];
@@ -3816,6 +3829,7 @@ static const char *all_tests(void)
     mu_run_test(test_environment);
     mu_run_test(test_clearenv_fn);
     mu_run_test(test_locale_from_env);
+    mu_run_test(test_locale_objects);
     mu_run_test(test_gethostname_fn);
     mu_run_test(test_uname_fn);
     mu_run_test(test_confstr_path);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -1738,6 +1738,11 @@ accordingly. For non-`"C"` locales the function defers to the host
 formatting information. `gmtime`, `localtime`, `mktime`, and `ctime`
 convert between `time_t` and `struct tm` or human readable strings.
 
+Locale objects provide per-thread settings. Use `newlocale` to create a
+locale, `duplocale` to clone one, `freelocale` to free it and
+`uselocale` to activate it. vlibc only implements the built-in `"C"`
+locale on non-BSD systems while BSD builds wrap the native routines.
+
 ## Time Retrieval
 
 Use `time`, `gettimeofday`, or `clock_gettime` to obtain the current time of day.


### PR DESCRIPTION
## Summary
- extend `<locale.h>` with `locale_t` and locale object APIs
- implement minimal locale object handling in new `locale_extra.c`
- document locale objects in vlibcdoc
- mention locale objects in README
- test creating and using locale objects

## Testing
- `make test` *(fails: process terminated due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685c6fc366d083248c718c38077a08ec