### PR TITLE
Add memory locking APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ SRC := \
     $(SYS_SRC) \
     src/mmap.c \
     src/msync.c \
+    src/mlock.c \
     src/shm.c \
     src/mqueue.c \
     src/env.c \

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ programs. Key features include:
 - Store and restore file positions with `fgetpos()` and `fsetpos()`
 - Zero-copy file transfers with `sendfile()`
 - Memory synchronization with `msync()`
+- Lock pages with `mlock()`/`munlock()` and entire address spaces with
+  `mlockall()`/`munlockall()` plus usage hints via `madvise()`
 - POSIX shared memory objects with `shm_open()` and `shm_unlink()`
 - POSIX message queues with `mq_open()`, `mq_send()` and `mq_receive()`
 - Advisory file locking with `flock()`

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -21,6 +21,11 @@ void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
 int munmap(void *addr, size_t length);
 int mprotect(void *addr, size_t length, int prot);
 int msync(void *addr, size_t length, int flags);
+int mlock(const void *addr, size_t length);
+int munlock(const void *addr, size_t length);
+int mlockall(int flags);
+int munlockall(void);
+int madvise(void *addr, size_t length, int advice);
 
 /*
  * Some BSD systems expose MAP_ANON instead of MAP_ANONYMOUS.  Provide
@@ -63,6 +68,29 @@ int msync(void *addr, size_t length, int flags);
 #endif
 #ifndef MS_ASYNC
 #define MS_ASYNC 1
+#endif
+
+#ifndef MCL_CURRENT
+#define MCL_CURRENT 1
+#endif
+#ifndef MCL_FUTURE
+#define MCL_FUTURE 2
+#endif
+
+#ifndef MADV_NORMAL
+#define MADV_NORMAL 0
+#endif
+#ifndef MADV_RANDOM
+#define MADV_RANDOM 1
+#endif
+#ifndef MADV_SEQUENTIAL
+#define MADV_SEQUENTIAL 2
+#endif
+#ifndef MADV_WILLNEED
+#define MADV_WILLNEED 3
+#endif
+#ifndef MADV_DONTNEED
+#define MADV_DONTNEED 4
 #endif
 
 #endif /* MMAN_H */

--- a/src/mlock.c
+++ b/src/mlock.c
@@ -1,0 +1,115 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the copyright
+ * notice and this permission notice appear in all copies. This software is
+ * provided "as is" without warranty.
+ *
+ * Purpose: Implements memory locking helpers for vlibc. Uses vlibc_syscall
+ * when possible and falls back to the host implementations on BSD.
+ */
+
+#include "sys/mman.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int mlock(const void *addr, size_t length)
+{
+#ifdef SYS_mlock
+    long ret = vlibc_syscall(SYS_mlock, (long)addr, length, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_mlock(const void *, size_t) __asm__("mlock");
+    return host_mlock(addr, length);
+#else
+    (void)addr; (void)length;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+int munlock(const void *addr, size_t length)
+{
+#ifdef SYS_munlock
+    long ret = vlibc_syscall(SYS_munlock, (long)addr, length, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_munlock(const void *, size_t) __asm__("munlock");
+    return host_munlock(addr, length);
+#else
+    (void)addr; (void)length;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+int mlockall(int flags)
+{
+#ifdef SYS_mlockall
+    long ret = vlibc_syscall(SYS_mlockall, flags, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_mlockall(int) __asm__("mlockall");
+    return host_mlockall(flags);
+#else
+    (void)flags;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+int munlockall(void)
+{
+#ifdef SYS_munlockall
+    long ret = vlibc_syscall(SYS_munlockall, 0, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_munlockall(void) __asm__("munlockall");
+    return host_munlockall();
+#else
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+int madvise(void *addr, size_t length, int advice)
+{
+#ifdef SYS_madvise
+    long ret = vlibc_syscall(SYS_madvise, (long)addr, length, advice, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_madvise(void *, size_t, int) __asm__("madvise");
+    return host_madvise(addr, length, advice);
+#else
+    (void)addr; (void)length; (void)advice;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2909,6 +2909,14 @@ static const char *test_sigqueue_value(void)
     return 0;
 }
 
+static const char *test_mlock_basic(void)
+{
+    char buf[128];
+    mu_assert("mlock", mlock(buf, sizeof(buf)) == 0);
+    mu_assert("munlock", munlock(buf, sizeof(buf)) == 0);
+    return 0;
+}
+
 static const char *test_mprotect_anon(void)
 {
     size_t len = 4096;
@@ -3845,6 +3853,7 @@ static const char *all_tests(void)
     mu_run_test(test_sigwait_basic);
     mu_run_test(test_sigtimedwait_timeout);
     mu_run_test(test_sigqueue_value);
+    mu_run_test(test_mlock_basic);
     mu_run_test(test_mprotect_anon);
     mu_run_test(test_shm_basic);
     mu_run_test(test_mqueue_basic);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -272,12 +272,20 @@ void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
 int munmap(void *addr, size_t length);
 int mprotect(void *addr, size_t length, int prot);
 int msync(void *addr, size_t length, int flags);
+int mlock(const void *addr, size_t length);
+int munlock(const void *addr, size_t length);
+int mlockall(int flags);
+int munlockall(void);
+int madvise(void *addr, size_t length, int advice);
 ```
 
 `mmap` creates new mappings, `munmap` releases them and `mprotect` changes
 their access protections.  `msync` flushes modified pages back to their
-underlying file.  When the raw syscall is unavailable the BSD wrapper is
-used instead, so some platforms may ignore unsupported flags.
+underlying file.  `mlock` and `munlock` lock or unlock specific regions,
+while `mlockall` and `munlockall` operate on the entire address space.
+`madvise` provides usage hints to the kernel.  When the raw syscall is
+unavailable the BSD wrapper is used instead, so some platforms may ignore
+unsupported flags.
 
 ## Shared Memory
 


### PR DESCRIPTION
## Summary
- expose mlock/munlock/lockall APIs in `<sys/mman.h>`
- implement mlock family with syscall fallbacks in src/mlock.c
- document memory locking features in README and docs
- compile new object and test locking in unit tests

## Testing
- `timeout 60 make test` *(fails: tests hang or exceed time)*

------
https://chatgpt.com/codex/tasks/task_e_685c6fb4c5248324988bbc7d46143b2d