### PR TITLE
Update README platform section

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ programs. Key features include:
   `quick_exit()`
 
 **Note**: vlibc provides only a small subset of the standard C library. Some
-functions depend on system calls that are currently implemented for Linux. BSD
-variants are now partially supported and the memory mapping routines fall back
-to `MAP_ANON` when `MAP_ANONYMOUS` is unavailable. A few features may still
-rely on platform-specific interfaces.
+functions depend on system calls tailored for Linux, though FreeBSD, OpenBSD
+and NetBSD are all supported. Memory mapping routines fall back to
+`MAP_ANON` when `MAP_ANONYMOUS` is unavailable. A few features may still rely
+on platform-specific interfaces.
 
 Build the static library with:
 
@@ -311,13 +311,13 @@ fclose(f);
 
 ## Platform Support
 
-The library currently targets Linux but aims to run on other POSIX systems as
-well. BSD compatibility has been tested on FreeBSD, though some modules still
-rely on Linux-only system calls. Portable helpers like `sysconf()` and
-`getpagesize()` ease porting, but non-Linux builds may still require additional
-work.
-The `chroot()` wrapper is one such case and returns `ENOSYS` when the
-underlying kernel lacks the system call.
+vlibc builds on Linux, FreeBSD, OpenBSD and NetBSD. NetBSD is now fully
+supported alongside the other BSDs. Most functionality is portable across these
+systems, though a few modules continue to rely on Linux-specific system calls.
+Portable helpers like `sysconf()` and `getpagesize()` ease porting, but
+non-Linux builds may require additional work. The `chroot()` wrapper is one
+such case and returns `ENOSYS` when the underlying kernel lacks the system
+call.
 
 ## Running Tests
 

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -74,8 +74,8 @@ predictability. The project is distributed under the terms of the BSD 2-Clause
 - Offer consistent behavior for statically linked or embedded programs.
 
 ### Target Platforms
-- Linux (x86_64, aarch64, armv7) is currently the primary platform.
- - *BSD variants are partially supported and patches are welcome.
+- Linux (x86_64, aarch64, armv7) and the major BSD variants (FreeBSD,
+  OpenBSD, NetBSD) are supported.
 - Other POSIX systems should work with minimal porting effort.
 - Lightweight containers or small research kernels implementing POSIX system
   calls.


### PR DESCRIPTION
## Summary
- clarify NetBSD support status in the Platform Support section
- remove Linux-specific emphasis from docs

## Testing
- `make test` *(fails: make interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685c73e86180832493a0273c2828bd96