### PR TITLE
Fix fflush fsync handling

### DIFF
--- a/src/stdio.c
+++ b/src/stdio.c
@@ -388,20 +388,18 @@ int fflush(FILE *stream)
         return 0;
     if (flush_buffer(stream) < 0)
         return -1;
-#if defined(__linux__) && defined(SYS_fsync)
     if (!stream->is_mem) {
+#ifdef SYS_fsync
         long ret = vlibc_syscall(SYS_fsync, stream->fd, 0, 0, 0, 0, 0);
         if (ret < 0) {
             errno = -ret;
             return -1;
         }
-    }
 #else
-#    ifndef __linux__
-    if (!stream->is_mem && fsync(stream->fd) < 0)
-        return -1;
-#    endif
+        if (fsync(stream->fd) < 0)
+            return -1;
 #endif
+    }
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- remove `__linux__` conditional and fallback
- rely on the fsync wrapper or SYS_fsync when present

## Testing
- `make test` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685c742308b48324805f89e00eaa1dea