### PR TITLE
Add err/warn helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ endif
 SRC := \
     src/errno.c \
     src/error.c \
+    src/err.c \
     src/init.c \
     src/io.c \
     src/stdio.c \

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ programs. Key features include:
 - Secure password input with `getpass()`
 - Password hashing with `crypt()`
 - Syslog-style logging
+- Simplified `err`/`warn` helpers for fatal and nonfatal messages
 - Change root directories with `chroot()` when supported
 - Directory scanning helpers
 - File tree traversal with `fts`

--- a/include/err.h
+++ b/include/err.h
@@ -1,0 +1,27 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Declarations for simple error reporting helpers.
+ */
+#ifndef ERR_H
+#define ERR_H
+
+#include <stdarg.h>
+
+/* Warn with the current errno message appended */
+void warn(const char *fmt, ...);
+void vwarn(const char *fmt, va_list ap);
+
+/* Warn without errno */
+void warnx(const char *fmt, ...);
+void vwarnx(const char *fmt, va_list ap);
+
+/* Print warning and exit */
+void err(int status, const char *fmt, ...) __attribute__((noreturn));
+void verr(int status, const char *fmt, va_list ap) __attribute__((noreturn));
+
+/* Print message without errno and exit */
+void errx(int status, const char *fmt, ...) __attribute__((noreturn));
+void verrx(int status, const char *fmt, va_list ap) __attribute__((noreturn));
+
+#endif /* ERR_H */

--- a/src/err.c
+++ b/src/err.c
@@ -1,0 +1,85 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the copyright
+ * notice and this permission notice appear in all copies. This software is
+ * provided "as is" without warranty.
+ *
+ * Purpose: Implements the err/warn helpers for vlibc.
+ */
+
+#include "err.h"
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+#include "errno.h"
+
+static void vwarn_internal(const char *fmt, va_list ap, int use_errno)
+{
+    if (fmt && *fmt)
+        vfprintf(stderr, fmt, ap);
+    if (use_errno) {
+        if (fmt && *fmt)
+            fprintf(stderr, ": %s", strerror(errno));
+        else
+            fprintf(stderr, "%s", strerror(errno));
+    }
+    fprintf(stderr, "\n");
+}
+
+void vwarn(const char *fmt, va_list ap)
+{
+    vwarn_internal(fmt, ap, 1);
+}
+
+void warn(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    vwarn(fmt, ap);
+    va_end(ap);
+}
+
+void vwarnx(const char *fmt, va_list ap)
+{
+    vwarn_internal(fmt, ap, 0);
+}
+
+void warnx(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    vwarnx(fmt, ap);
+    va_end(ap);
+}
+
+static void verr_internal(int status, const char *fmt, va_list ap, int use_errno)
+{
+    vwarn_internal(fmt, ap, use_errno);
+    exit(status);
+}
+
+void verr(int status, const char *fmt, va_list ap)
+{
+    verr_internal(status, fmt, ap, 1);
+}
+
+void err(int status, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    verr(status, fmt, ap);
+    va_end(ap);
+}
+
+void verrx(int status, const char *fmt, va_list ap)
+{
+    verr_internal(status, fmt, ap, 0);
+}
+
+void errx(int status, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    verrx(status, fmt, ap);
+    va_end(ap);
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -51,6 +51,7 @@
 #include "../include/termios.h"
 #include <unistd.h>
 #include <stdio.h>
+#include "../include/err.h"
 #include <errno.h>
 #include <sys/wait.h>
 #include <signal.h>
@@ -2452,6 +2453,102 @@ static const char *test_error_reporting(void)
     return 0;
 }
 
+static int call_vwarn(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    vwarn(fmt, ap);
+    va_end(ap);
+    return 0;
+}
+
+static const char *test_warn_functions(void)
+{
+    int p[2];
+    mu_assert("pipe", pipe(p) == 0);
+    int old = dup(2);
+    mu_assert("dup", old >= 0);
+    dup2(p[1], 2);
+    close(p[1]);
+    errno = ENOENT;
+    warn("missing %s", "file");
+    dup2(old, 2);
+    close(old);
+    char buf[80] = {0};
+    ssize_t n = read(p[0], buf, sizeof(buf) - 1);
+    close(p[0]);
+    mu_assert("warn output", n > 0 && strcmp(buf, "missing file: No such file or directory\n") == 0);
+
+    mu_assert("pipe", pipe(p) == 0);
+    old = dup(2);
+    mu_assert("dup", old >= 0);
+    dup2(p[1], 2);
+    close(p[1]);
+    warnx("fatal %d", 5);
+    dup2(old, 2);
+    close(old);
+    memset(buf, 0, sizeof(buf));
+    n = read(p[0], buf, sizeof(buf) - 1);
+    close(p[0]);
+    mu_assert("warnx output", n > 0 && strcmp(buf, "fatal 5\n") == 0);
+
+    mu_assert("pipe", pipe(p) == 0);
+    old = dup(2);
+    dup2(p[1], 2);
+    close(p[1]);
+    errno = ENOENT;
+    call_vwarn("try %s", "again");
+    dup2(old, 2);
+    close(old);
+    memset(buf, 0, sizeof(buf));
+    n = read(p[0], buf, sizeof(buf) - 1);
+    close(p[0]);
+    mu_assert("vwarn output", n > 0 && strcmp(buf, "try again: No such file or directory\n") == 0);
+
+    return 0;
+}
+
+static const char *test_err_functions(void)
+{
+    int p[2];
+    mu_assert("pipe", pipe(p) == 0);
+    pid_t pid = fork();
+    mu_assert("fork", pid >= 0);
+    if (pid == 0) {
+        dup2(p[1], 2);
+        close(p[0]);
+        errno = ENOENT;
+        err(7, "open %s", "file");
+    }
+    close(p[1]);
+    char buf[80] = {0};
+    ssize_t n = read(p[0], buf, sizeof(buf) - 1);
+    close(p[0]);
+    int status = 0;
+    waitpid(pid, &status, 0);
+    mu_assert("err exit", WIFEXITED(status) && WEXITSTATUS(status) == 7);
+    mu_assert("err output", n > 0 && strcmp(buf, "open file: No such file or directory\n") == 0);
+
+    mu_assert("pipe", pipe(p) == 0);
+    pid = fork();
+    mu_assert("fork", pid >= 0);
+    if (pid == 0) {
+        dup2(p[1], 2);
+        close(p[0]);
+        errx(3, "fatal %s", "bug");
+    }
+    close(p[1]);
+    memset(buf, 0, sizeof(buf));
+    n = read(p[0], buf, sizeof(buf) - 1);
+    close(p[0]);
+    status = 0;
+    waitpid(pid, &status, 0);
+    mu_assert("errx exit", WIFEXITED(status) && WEXITSTATUS(status) == 3);
+    mu_assert("errx output", n > 0 && strcmp(buf, "fatal bug\n") == 0);
+
+    return 0;
+}
+
 static const char *test_strsignal_names(void)
 {
     mu_assert("SIGHUP", strcmp(strsignal(SIGHUP), "Hangup") == 0);
@@ -3874,6 +3971,8 @@ static const char *all_tests(void)
     mu_run_test(test_uname_fn);
     mu_run_test(test_confstr_path);
     mu_run_test(test_error_reporting);
+    mu_run_test(test_warn_functions);
+    mu_run_test(test_err_functions);
     mu_run_test(test_strsignal_names);
     mu_run_test(test_system_fn);
     mu_run_test(test_execv_fn);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -167,6 +167,7 @@ dirent.h     - directory iteration
 dlfcn.h      - runtime loading of shared libraries
 env.h        - environment variable access
 errno.h      - standard error codes
+err.h        - err/warn convenience helpers
 getopt.h     - option parsing
 io.h         - unbuffered I/O primitives
 locale.h     - locale helpers
@@ -813,6 +814,20 @@ int strerror_r(int errnum, char *buf, size_t buflen);
 void perror(const char *s);
 const char *strsignal(int signum);
 ```
+
+Additional helpers mirror the traditional BSD `err.h` API:
+
+```c
+void warn(const char *fmt, ...);
+void warnx(const char *fmt, ...);
+void err(int status, const char *fmt, ...) __attribute__((noreturn));
+void errx(int status, const char *fmt, ...) __attribute__((noreturn));
+```
+
+`warn` prints the formatted message followed by the text for the current
+`errno`. The `err` variants behave similarly but terminate the process with
+the provided exit status. The `warnx`/`errx` forms omit the `errno`
+description.
 
 
 `strerror()` returns a string describing `errnum` or "Unknown error" for


### PR DESCRIPTION
## Summary
- add `<err.h>` header for err/warn APIs
- implement err and warn helpers using vfprintf and exit
- document the new APIs
- test err/warn output formatting

## Testing
- `make test` *(fails: no output captured)*

------
https://chatgpt.com/codex/tasks/task_e_685c80485ea48324afc884fde52333bb