### PR TITLE
Add priority management APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ programs. Key features include:
 - Query configuration strings with `confstr()`
 - Simple alarm timers with `alarm()`
 - Yield the processor with `sched_yield()` from `<sched.h>`
+- Adjust and query nice values with `nice()`, `getpriority()` and
+  `setpriority()` from `<sched.h>`
 - POSIX interval timers with `timer_create` and `timer_settime()`.
   On NetBSD the native timer syscalls are used when present, with a
   kqueue fallback otherwise.

--- a/include/sched.h
+++ b/include/sched.h
@@ -8,4 +8,25 @@
 
 int sched_yield(void);
 
+/* scheduling priority interfaces */
+#ifndef PRIO_PROCESS
+#define PRIO_PROCESS 0
+#endif
+#ifndef PRIO_PGRP
+#define PRIO_PGRP    1
+#endif
+#ifndef PRIO_USER
+#define PRIO_USER    2
+#endif
+#ifndef PRIO_MIN
+#define PRIO_MIN    -20
+#endif
+#ifndef PRIO_MAX
+#define PRIO_MAX     20
+#endif
+
+int nice(int incr);
+int getpriority(int which, int who);
+int setpriority(int which, int who, int prio);
+
 #endif /* SCHED_H */

--- a/src/sched.c
+++ b/src/sched.c
@@ -24,3 +24,63 @@ int sched_yield(void)
     return nanosleep(&ts, NULL);
 #endif
 }
+
+/*
+ * Retrieve the current scheduling priority for the given target.
+ */
+int getpriority(int which, int who)
+{
+#ifdef SYS_getpriority
+    long ret = vlibc_syscall(SYS_getpriority, which, who, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_getpriority(int, int) __asm("getpriority");
+    return host_getpriority(which, who);
+#else
+    (void)which; (void)who;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+/*
+ * Set the scheduling priority for the specified process, process
+ * group or user.
+ */
+int setpriority(int which, int who, int prio)
+{
+#ifdef SYS_setpriority
+    long ret = vlibc_syscall(SYS_setpriority, which, who, prio, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_setpriority(int, int, int) __asm("setpriority");
+    return host_setpriority(which, who, prio);
+#else
+    (void)which; (void)who; (void)prio;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+/*
+ * Increase the calling process' nice value by incr and return the new value.
+ */
+int nice(int incr)
+{
+    int cur = getpriority(PRIO_PROCESS, 0);
+    if (cur == -1 && errno)
+        return -1;
+    if (setpriority(PRIO_PROCESS, 0, cur + incr) < 0)
+        return -1;
+    return cur + incr;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2042,6 +2042,17 @@ static const char *test_sched_yield_loop(void)
     return 0;
 }
 
+static const char *test_priority_wrappers(void)
+{
+    int orig = getpriority(PRIO_PROCESS, 0);
+    mu_assert("getpriority", orig != -1 || errno == 0);
+    mu_assert("setpriority", setpriority(PRIO_PROCESS, 0, orig + 1) == 0);
+    mu_assert("verify", getpriority(PRIO_PROCESS, 0) == orig + 1);
+    mu_assert("nice", nice(-1) == orig);
+    mu_assert("restore", getpriority(PRIO_PROCESS, 0) == orig);
+    return 0;
+}
+
 static const char *test_timer_basic(void)
 {
     timer_t t;
@@ -3851,6 +3862,7 @@ static const char *all_tests(void)
     mu_run_test(test_sleep_functions);
     mu_run_test(test_sched_yield_basic);
     mu_run_test(test_sched_yield_loop);
+    mu_run_test(test_priority_wrappers);
     mu_run_test(test_timer_basic);
     mu_run_test(test_getrusage_self);
     mu_run_test(test_strftime_basic);

--- a/vlibcdoc.md
+++ b/vlibcdoc.md
@@ -1800,6 +1800,20 @@ Declared in `<sched.h>`.
 int sched_yield(void);
 ```
 
+`getpriority` returns the current scheduling priority for a process,
+process group or user as selected by the `PRIO_*` constants.
+`setpriority` updates the value and `nice` adjusts the calling
+process' nice level relative to its current priority.  The wrappers
+map directly to the `setpriority(2)` and `getpriority(2)` syscalls on
+NetBSD and Linux, falling back to host implementations on the other
+BSDs.
+
+```c
+int nice(int incr);
+int getpriority(int which, int who);
+int setpriority(int which, int who, int prio);
+```
+
 ## Interval Timers
 
 `setitimer` schedules periodic `SIGALRM` delivery or CPU timers. `getitimer`


### PR DESCRIPTION
## Summary
- extend `<sched.h>` with nice, getpriority and setpriority
- implement wrappers around SYS_{get,set}priority
- document scheduling priority helpers
- cover the new APIs in unit tests

## Testing
- `make clean` (success)
- `timeout 120 make test` *(failed: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_685c802e16288324bd1e09ea27c3038d