### PR TITLE
Add progname helper functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,8 @@ SRC := \
     src/wordexp.c \
     src/vis.c \
     src/wprintf.c \
-    src/wscanf.c
+    src/wscanf.c \
+    src/progname.c
 
 ARCH_SRC := $(wildcard src/arch/$(ARCH)/*.c)
 SRC += $(if $(ARCH_SRC),$(ARCH_SRC),src/setjmp.c)

--- a/include/util.h
+++ b/include/util.h
@@ -1,0 +1,14 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Declarations for program name helpers.
+ */
+#ifndef UTIL_H
+#define UTIL_H
+
+/* Retrieve the stored program name */
+const char *getprogname(void);
+/* Store the program name, typically called from main */
+void setprogname(const char *name);
+
+#endif /* UTIL_H */

--- a/src/progname.c
+++ b/src/progname.c
@@ -1,0 +1,28 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the copyright
+ * notice and this permission notice appear in all copies. This software is
+ * provided "as is" without warranty.
+ *
+ * Purpose: Implements program name helpers for vlibc.
+ */
+
+#include "string.h"
+#include "util.h"
+
+static const char *progname = "";
+
+const char *getprogname(void)
+{
+    return progname;
+}
+
+void setprogname(const char *name)
+{
+    if (!name) {
+        progname = "";
+        return;
+    }
+    const char *base = strrchr(name, '/');
+    progname = base ? base + 1 : name;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -18,6 +18,7 @@
 #include "../include/sys/stat.h"
 #include "../include/stdio.h"
 #include "../include/pthread.h"
+#include "../include/util.h"
 #include "../include/semaphore.h"
 #include "../include/sys/select.h"
 #include "../include/poll.h"
@@ -2416,6 +2417,19 @@ static const char *test_confstr_path(void)
     return 0;
 }
 
+static const char *test_progname_setget(void)
+{
+    setprogname("prog");
+    const char *p = getprogname();
+    mu_assert("initial name", p && strcmp(p, "prog") == 0);
+
+    setprogname("/usr/bin/testprog");
+    p = getprogname();
+    mu_assert("basename", p && strcmp(p, "testprog") == 0);
+
+    return 0;
+}
+
 static const char *test_error_reporting(void)
 {
     errno = ENOENT;
@@ -4029,6 +4043,7 @@ static const char *all_tests(void)
     mu_run_test(test_gethostname_fn);
     mu_run_test(test_uname_fn);
     mu_run_test(test_confstr_path);
+    mu_run_test(test_progname_setget);
     mu_run_test(test_error_reporting);
     mu_run_test(test_warn_functions);
     mu_run_test(test_err_functions);


### PR DESCRIPTION
## Summary
- implement `getprogname` and `setprogname`
- expose new helpers via `util.h`
- compile new source
- test program name handling

## Testing
- `make test` *(fails: tests hang or exceed environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685c83706f888324b9b3d62112ae0ed9