### PR TITLE
Implement aligned_alloc wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ programs. Key features include:
 - Text encoding helpers with `vis()`, `nvis()` and `unvis()`
 - Array sorting with `qsort`, `qsort_r` and `bsearch`
 - Array resizing with `recallocarray()` which zeroes new memory
+- Aligned allocations with `aligned_alloc()`
 - Standard `assert` macro for runtime checks
 - Extended math helpers including `hypot`, `round` and `trunc`
 - Simple complex math with `cabs`, `carg`, `cexp`, `ccos` and `csin`

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -21,6 +21,7 @@ void *realloc(void *ptr, size_t size);
 void *reallocarray(void *ptr, size_t nmemb, size_t size);
 void *recallocarray(void *ptr, size_t nmemb, size_t size);
 int posix_memalign(void **memptr, size_t alignment, size_t size);
+void *aligned_alloc(size_t alignment, size_t size);
 ```
 
 ### Behavior and Caveats
@@ -41,12 +42,19 @@ int posix_memalign(void **memptr, size_t alignment, size_t size);
   alignment. It returns `0` on success, `EINVAL` if the alignment is not a power
   of two or not a multiple of `sizeof(void *)`, or `ENOMEM` when the allocation
   fails.
+- `aligned_alloc` wraps `posix_memalign` and returns `NULL` on failure.
 
 ```c
 void *p;
 if (posix_memalign(&p, 64, 128) == 0) {
     /* use memory */
     free(p);
+}
+
+void *q = aligned_alloc(64, 128);
+if (q) {
+    /* use memory */
+    free(q);
 }
 ```
 

--- a/include/memory.h
+++ b/include/memory.h
@@ -22,5 +22,7 @@ void *reallocarray(void *ptr, size_t nmemb, size_t size);
 void *recallocarray(void *ptr, size_t nmemb, size_t size);
 /* Allocate aligned memory and record the original pointer. */
 int posix_memalign(void **memptr, size_t alignment, size_t size);
+/* Allocate memory with a given alignment. Returns NULL on failure. */
+void *aligned_alloc(size_t alignment, size_t size);
 
 #endif /* MEMORY_H */

--- a/src/memory.c
+++ b/src/memory.c
@@ -226,6 +226,18 @@ int posix_memalign(void **memptr, size_t alignment, size_t size)
 }
 
 /*
+ * Allocates a block with the requested alignment using posix_memalign.
+ * Returns NULL on failure like standard aligned_alloc.
+ */
+void *aligned_alloc(size_t alignment, size_t size)
+{
+    void *ptr = NULL;
+    if (posix_memalign(&ptr, alignment, size) != 0)
+        return NULL;
+    return ptr;
+}
+
+/*
  * Resizes an array with overflow checking.
  * Verifies nmemb * size won't overflow and delegates to realloc.
  */

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -188,6 +188,18 @@ static const char *test_posix_memalign(void)
     return 0;
 }
 
+static const char *test_aligned_alloc(void)
+{
+    void *p = aligned_alloc(32, 64);
+    mu_assert("aligned_alloc ptr", p != NULL);
+    mu_assert("ptr aligned", ((uintptr_t)p % 32) == 0);
+    char *c = p;
+    for (int i = 0; i < 64; i++)
+        c[i] = (char)i;
+    free(p);
+    return 0;
+}
+
 static const char *test_reallocarray_overflow(void)
 {
     size_t big = (size_t)-1 / 2 + 1;
@@ -3937,6 +3949,7 @@ static const char *all_tests(void)
     mu_run_test(test_malloc_reuse);
     mu_run_test(test_posix_memalign_basic);
     mu_run_test(test_posix_memalign);
+    mu_run_test(test_aligned_alloc);
     mu_run_test(test_reallocarray_overflow);
     mu_run_test(test_reallocarray_basic);
     mu_run_test(test_recallocarray_grow);


### PR DESCRIPTION
## Summary
- implement `aligned_alloc` using `posix_memalign`
- expose the new prototype in `memory.h`
- document aligned allocation usage
- note the new function in the README feature list
- test allocation and freeing of an aligned block

## Testing
- `make test` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_685ca2b2715483249150271938c82a8f