### PR TITLE
Add scheduler APIs and tests

### DIFF
--- a/docs/time.md
+++ b/docs/time.md
@@ -114,6 +114,25 @@ int getpriority(int which, int who);
 int setpriority(int which, int who, int prio);
 ```
 
+`sched_getscheduler` queries the current scheduling policy for a
+process. `sched_setscheduler` changes the policy and priority using a
+`struct sched_param`. `sched_getparam` and `sched_setparam` adjust only
+the priority.  `sched_get_priority_max` and `sched_get_priority_min`
+return the valid priority range for a policy and
+`sched_rr_get_interval` reports the time slice for round-robin
+scheduling.  When the corresponding syscalls are unavailable the
+wrappers call the host implementations on BSD systems.
+
+```c
+int sched_getscheduler(pid_t pid);
+int sched_setscheduler(pid_t pid, int policy, const struct sched_param *param);
+int sched_getparam(pid_t pid, struct sched_param *param);
+int sched_setparam(pid_t pid, const struct sched_param *param);
+int sched_get_priority_max(int policy);
+int sched_get_priority_min(int policy);
+int sched_rr_get_interval(pid_t pid, struct timespec *interval);
+```
+
 ## Interval Timers
 
 `setitimer` schedules periodic `SIGALRM` delivery or CPU timers. `getitimer`

--- a/include/sched.h
+++ b/include/sched.h
@@ -6,7 +6,25 @@
 #ifndef SCHED_H
 #define SCHED_H
 
+#include <sys/types.h>
+#include "time.h"
+
 int sched_yield(void);
+
+/* scheduling policies */
+#ifndef SCHED_OTHER
+#define SCHED_OTHER 0
+#endif
+#ifndef SCHED_FIFO
+#define SCHED_FIFO 1
+#endif
+#ifndef SCHED_RR
+#define SCHED_RR   2
+#endif
+
+struct sched_param {
+    int sched_priority;
+};
 
 /* scheduling priority interfaces */
 #ifndef PRIO_PROCESS
@@ -28,5 +46,13 @@ int sched_yield(void);
 int nice(int incr);
 int getpriority(int which, int who);
 int setpriority(int which, int who, int prio);
+
+int sched_getscheduler(pid_t pid);
+int sched_setscheduler(pid_t pid, int policy, const struct sched_param *param);
+int sched_getparam(pid_t pid, struct sched_param *param);
+int sched_setparam(pid_t pid, const struct sched_param *param);
+int sched_get_priority_max(int policy);
+int sched_get_priority_min(int policy);
+int sched_rr_get_interval(pid_t pid, struct timespec *interval);
 
 #endif /* SCHED_H */

--- a/src/sched.c
+++ b/src/sched.c
@@ -84,3 +84,150 @@ int nice(int incr)
         return -1;
     return cur + incr;
 }
+
+int sched_getscheduler(pid_t pid)
+{
+#ifdef SYS_sched_getscheduler
+    long ret = vlibc_syscall(SYS_sched_getscheduler, pid, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_sched_getscheduler(pid_t) __asm("sched_getscheduler");
+    return host_sched_getscheduler(pid);
+#else
+    (void)pid;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+int sched_setscheduler(pid_t pid, int policy, const struct sched_param *param)
+{
+#ifdef SYS_sched_setscheduler
+    long ret = vlibc_syscall(SYS_sched_setscheduler, pid, policy,
+                             (long)param, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_sched_setscheduler(pid_t, int, const struct sched_param *)
+        __asm("sched_setscheduler");
+    return host_sched_setscheduler(pid, policy, param);
+#else
+    (void)pid; (void)policy; (void)param;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+int sched_getparam(pid_t pid, struct sched_param *param)
+{
+#ifdef SYS_sched_getparam
+    long ret = vlibc_syscall(SYS_sched_getparam, pid, (long)param,
+                             0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_sched_getparam(pid_t, struct sched_param *)
+        __asm("sched_getparam");
+    return host_sched_getparam(pid, param);
+#else
+    (void)pid; (void)param;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+int sched_setparam(pid_t pid, const struct sched_param *param)
+{
+#ifdef SYS_sched_setparam
+    long ret = vlibc_syscall(SYS_sched_setparam, pid, (long)param,
+                             0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_sched_setparam(pid_t, const struct sched_param *)
+        __asm("sched_setparam");
+    return host_sched_setparam(pid, param);
+#else
+    (void)pid; (void)param;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+int sched_get_priority_max(int policy)
+{
+#ifdef SYS_sched_get_priority_max
+    long ret = vlibc_syscall(SYS_sched_get_priority_max, policy,
+                             0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_sched_get_priority_max(int) __asm("sched_get_priority_max");
+    return host_sched_get_priority_max(policy);
+#else
+    (void)policy;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+int sched_get_priority_min(int policy)
+{
+#ifdef SYS_sched_get_priority_min
+    long ret = vlibc_syscall(SYS_sched_get_priority_min, policy,
+                             0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_sched_get_priority_min(int) __asm("sched_get_priority_min");
+    return host_sched_get_priority_min(policy);
+#else
+    (void)policy;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+int sched_rr_get_interval(pid_t pid, struct timespec *interval)
+{
+#ifdef SYS_sched_rr_get_interval_time64
+    long ret = vlibc_syscall(SYS_sched_rr_get_interval_time64, pid,
+                             (long)interval, 0, 0, 0, 0);
+#elif defined(SYS_sched_rr_get_interval)
+    long ret = vlibc_syscall(SYS_sched_rr_get_interval, pid,
+                             (long)interval, 0, 0, 0, 0);
+#else
+    (void)pid; (void)interval;
+    long ret = -ENOSYS;
+#endif
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2056,6 +2056,19 @@ static const char *test_priority_wrappers(void)
     return 0;
 }
 
+static const char *test_sched_get_set_scheduler(void)
+{
+    struct sched_param sp;
+    int pol = sched_getscheduler(0);
+    if (pol == -1 && errno == ENOSYS)
+        return 0;
+    mu_assert("sched_getscheduler", pol >= 0);
+    mu_assert("sched_getparam", sched_getparam(0, &sp) == 0);
+    mu_assert("sched_setscheduler", sched_setscheduler(0, pol, &sp) == 0);
+    mu_assert("verify", sched_getscheduler(0) == pol);
+    return 0;
+}
+
 static const char *test_timer_basic(void)
 {
     timer_t t;
@@ -4021,6 +4034,7 @@ static const char *all_tests(void)
     mu_run_test(test_sched_yield_basic);
     mu_run_test(test_sched_yield_loop);
     mu_run_test(test_priority_wrappers);
+    mu_run_test(test_sched_get_set_scheduler);
     mu_run_test(test_timer_basic);
     mu_run_test(test_getrusage_self);
     mu_run_test(test_strftime_basic);


### PR DESCRIPTION
## Summary
- implement the rest of the POSIX scheduler functions
- expose scheduler prototypes in `<sched.h>`
- document the new helpers in `time.md`
- add a test covering sched_getscheduler/setscheduler

## Testing
- `make test` *(fails: interrupted due to environment constraints)*
- `./tests/run_tests` *(fails: interrupted due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_685ca2d0c2f48324b7abff7e202865b8