### PR TITLE
Add wide-character collation helpers

### DIFF
--- a/docs/strings.md
+++ b/docs/strings.md
@@ -12,7 +12,7 @@ The **string** module provides fundamental operations needed by most C programs:
 - Case-insensitive substring search with `strcasestr`.
 - Basic collation helpers `strcoll` and `strxfrm` act on ASCII strings. On
   BSD systems they defer to the host implementations when the active locale is
-  not `"C"` or `"POSIX"`.
+  not `"C"` or `"POSIX"`. The wide-character versions `wcscoll` and `wcsxfrm` behave the same way.
 - Conventional memory routines (`memcpy`, `memmove`, `memset`, `memcmp`) map to
   the internal `v` implementations.
 - `memccpy` stops copying when a byte value is found and returns a pointer past
@@ -73,10 +73,12 @@ of a wide string excluding the terminator.
 
 `wcscpy`, `wcsncpy`, `wcscmp`, `wcsncmp`, and `wcsdup` mirror the
 behaviour of their narrow-string counterparts for copying, comparing and
-duplicating wide strings. The `wcstok` function tokenizes a wide string
-using a caller-supplied save pointer. The `wmemcpy`, `wmemmove`,
-`wmemset` and `wmemcmp` routines operate on arrays of `wchar_t`
-analogous to the byte
+duplicating wide strings. Collation helpers `wcscoll` and `wcsxfrm` use
+simple lexicographic ordering in the `C` locale and delegate to the host
+implementation on BSD when other locales are active. The `wcstok`
+function tokenizes a wide string using a caller-supplied save pointer.
+The `wmemcpy`, `wmemmove`, `wmemset` and `wmemcmp` routines operate on
+arrays of `wchar_t` analogous to the byte-oriented routines.
 
 ### Example
 

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -39,6 +39,10 @@ int wcscmp(const wchar_t *s1, const wchar_t *s2);
 int wcsncmp(const wchar_t *s1, const wchar_t *s2, size_t n);
 /* Duplicate a wide-character string */
 wchar_t *wcsdup(const wchar_t *s);
+/* Collate wide-character strings */
+int wcscoll(const wchar_t *s1, const wchar_t *s2);
+/* Transform wide-character string for collation */
+size_t wcsxfrm(wchar_t *dest, const wchar_t *src, size_t n);
 /* Tokenize a wide-character string */
 wchar_t *wcstok(wchar_t *str, const wchar_t *delim, wchar_t **saveptr);
 /* Display width of a wide character */

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1030,6 +1030,17 @@ static const char *test_strcoll_xfrm(void)
     return 0;
 }
 
+static const char *test_wcscoll_xfrm(void)
+{
+    mu_assert("wcscoll eq", wcscoll(L"abc", L"abc") == 0);
+    mu_assert("wcscoll lt", wcscoll(L"abc", L"abd") < 0);
+    wchar_t buf[8];
+    size_t n = wcsxfrm(buf, L"abc", sizeof(buf) / sizeof(wchar_t));
+    mu_assert("wcsxfrm len", n == 3);
+    mu_assert("wcsxfrm copy", wcsncmp(buf, L"abc", 4) == 0);
+    return 0;
+}
+
 static const char *test_ctype_extra(void)
 {
     mu_assert("isprint", isprint('A'));
@@ -3977,6 +3988,7 @@ static const char *all_tests(void)
     mu_run_test(test_memccpy_zero);
     mu_run_test(test_strndup_basic);
     mu_run_test(test_strcoll_xfrm);
+    mu_run_test(test_wcscoll_xfrm);
     mu_run_test(test_ctype_extra);
     mu_run_test(test_widechar_basic);
     mu_run_test(test_widechar_conv);


### PR DESCRIPTION
## Summary
- implement `wcscoll` and `wcsxfrm`
- expose them in the public header
- document wide-character collation behaviour
- test `wcscoll`/`wcsxfrm` sorting

## Testing
- `make test` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685ca2e14864832491b07afad0cee825