### PR TITLE
Add preadv/pwritev support

### DIFF
--- a/docs/io.md
+++ b/docs/io.md
@@ -10,7 +10,9 @@ corresponding syscalls or suitable fallbacks.
 `access` and `faccessat` query permissions on files without opening
 them.
 Vector I/O through `readv` and `writev` is available to gather or scatter
-multiple buffers in a single call. Zero-copy transfers are possible with
+multiple buffers in a single call.  The offset aware variants `preadv`
+and `pwritev` operate on multiple buffers at a specific file position.
+Zero-copy transfers are possible with
 `sendfile`, which uses the BSD system call when available and otherwise
 falls back to copying via `read` and `write`.
 
@@ -75,6 +77,9 @@ reading or writing at a specific offset, or duplicating handles.
 off_t pos = lseek(fd, 0, SEEK_SET);
 ssize_t n = pread(fd, buf, 16, 4);
 pwrite(fd, buf, n, 32);
+struct iovec v[2] = { {buf, 4}, {buf + 4, 4} };
+preadv(fd, v, 2, 0);
+pwritev(fd, v, 2, 8);
 int duped = dup(fd);
 int pipefd[2];
 pipe(pipefd);

--- a/include/io.h
+++ b/include/io.h
@@ -7,6 +7,7 @@
 #define IO_H
 
 #include <sys/types.h>
+#include "sys/uio.h"
 
 /* Open a file using vlibc_syscall with SYS_open or SYS_openat. */
 int open(const char *path, int flags, ...);
@@ -20,6 +21,10 @@ ssize_t write(int fd, const void *buf, size_t count);
 ssize_t pread(int fd, void *buf, size_t count, off_t offset);
 /* Positional write with SYS_pwrite/SYS_pwrite64 or host pwrite. */
 ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
+/* Vector positional read using SYS_preadv/preadv2 or a loop fallback. */
+ssize_t preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset);
+/* Vector positional write using SYS_pwritev/pwritev2 or a loop fallback. */
+ssize_t pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset);
 /* Close a descriptor using SYS_close. */
 int close(int fd);
 off_t lseek(int fd, off_t offset, int whence);


### PR DESCRIPTION
## Summary
- add preadv/pwritev declarations to io.h
- implement preadv/pwritev in src/io.c with syscall or loop fallbacks
- document new helpers in docs/io.md
- test preadv/pwritev in test suite

## Testing
- `make test` *(fails: command timed out in CI)*

------
https://chatgpt.com/codex/tasks/task_e_685caa71d65483249515e64ecbb102b3