### PR TITLE
Add getsubopt parser and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ SRC := \
     src/dlfcn.c \
     src/getopt_long.c \
     src/getopt_long_only.c \
+    src/getsubopt.c \
     src/locale.c \
     src/locale_extra.c \
     src/wchar.c \

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ waitpid(pid, NULL, 0);
 remap file descriptors or specify a signal mask for the new process.
 
 For detailed documentation, see [docs/index.md](docs/index.md).
+Suboption parsing with `getsubopt` is covered in
+[docs/utilities.md](docs/utilities.md).
 
 ## Thread-Local Storage
 

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -80,3 +80,34 @@ negative infinity, and `isfinite(x)` reports true only for finite values.  When
 the compiler supplies built-ins for these checks the macros map directly to
 them, otherwise simple fallback tests are used.
 
+
+## Suboption Parsing
+
+`getsubopt` breaks down a comma separated list of `name=value` pairs. The
+function compares each name against a provided token array and returns the
+matching index. `*optionp` is updated to point past the parsed element and
+`*valuep` receives the option's value if one was specified.
+
+```c
+char opts[] = "foo=1,bar,baz=2";
+char *p = opts;
+char *val;
+char *tokens[] = {"foo", "bar", "baz", NULL};
+
+while (*p) {
+    switch (getsubopt(&p, tokens, &val)) {
+    case 0:
+        printf("foo=%s\n", val);
+        break;
+    case 1:
+        puts("bar present");
+        break;
+    case 2:
+        printf("baz=%s\n", val);
+        break;
+    default:
+        printf("unknown option\n");
+        break;
+    }
+}
+```

--- a/include/getopt.h
+++ b/include/getopt.h
@@ -29,4 +29,7 @@ int getopt_long(int argc, char * const argv[], const char *optstring,
 int getopt_long_only(int argc, char * const argv[], const char *optstring,
                      const struct option *longopts, int *longindex);
 
+/* parse comma separated suboptions */
+int getsubopt(char **optionp, char * const *tokens, char **valuep);
+
 #endif /* GETOPT_H */

--- a/src/getsubopt.c
+++ b/src/getsubopt.c
@@ -1,0 +1,50 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the copyright notice and
+ * this permission notice appear in all copies. This software is provided "as is" without warranty.
+ *
+ * Purpose: Implements getsubopt for vlibc. Parses comma separated suboptions.
+ */
+
+#include "getopt.h"
+#include "string.h"
+
+int getsubopt(char **optionp, char * const *tokens, char **valuep)
+{
+    if (!optionp || !*optionp || !**optionp) {
+        return -1;
+    }
+
+    char *arg = *optionp;
+    char *end = arg;
+    while (*end && *end != ',' && *end != '=')
+        end++;
+
+    char *val = NULL;
+    if (*end == '=') {
+        *end = '\0';
+        val = end + 1;
+        end = val;
+        while (*end && *end != ',')
+            end++;
+        if (*end)
+            *end = '\0';
+    }
+
+    if (*end == ',') {
+        *end = '\0';
+        *optionp = end + 1;
+    } else {
+        *optionp = end;
+    }
+
+    for (int i = 0; tokens && tokens[i]; i++) {
+        if (strcmp(arg, tokens[i]) == 0) {
+            *valuep = val;
+            return i;
+        }
+    }
+
+    *valuep = val;
+    return -1;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -4029,6 +4029,46 @@ static const char *test_getopt_long_only_basic(void)
     return 0;
 }
 
+static const char *test_getsubopt_basic(void)
+{
+    char opts[] = "foo=1,bar,baz=2";
+    char *p = opts;
+    char *val = NULL;
+    char *tokens[] = {"foo", "bar", "baz", NULL};
+
+    int r = getsubopt(&p, tokens, &val);
+    mu_assert("foo index", r == 0);
+    mu_assert("foo val", val && strcmp(val, "1") == 0);
+
+    r = getsubopt(&p, tokens, &val);
+    mu_assert("bar index", r == 1);
+    mu_assert("bar val", val == NULL);
+
+    r = getsubopt(&p, tokens, &val);
+    mu_assert("baz index", r == 2);
+    mu_assert("baz val", val && strcmp(val, "2") == 0);
+
+    return 0;
+}
+
+static const char *test_getsubopt_unknown(void)
+{
+    char opts[] = "foo=1,unknown";
+    char *p = opts;
+    char *val = NULL;
+    char *tokens[] = {"foo", NULL};
+
+    int r = getsubopt(&p, tokens, &val);
+    mu_assert("known index", r == 0);
+    mu_assert("known val", val && strcmp(val, "1") == 0);
+
+    r = getsubopt(&p, tokens, &val);
+    mu_assert("unknown ret", r == -1);
+    mu_assert("unknown val", val == NULL);
+
+    return 0;
+}
+
 static const char *all_tests(void)
 {
     mu_run_test(test_malloc);
@@ -4220,6 +4260,8 @@ static const char *all_tests(void)
     mu_run_test(test_getopt_long_basic);
     mu_run_test(test_getopt_long_only_missing);
     mu_run_test(test_getopt_long_only_basic);
+    mu_run_test(test_getsubopt_basic);
+    mu_run_test(test_getsubopt_unknown);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- declare `getsubopt` in `getopt.h`
- implement parsing logic in new source
- compile new source
- document `getsubopt` usage
- link new docs from README
- test typical and unknown suboption cases

## Testing
- `make -s test` *(fails: make command interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685caf54133c83249ff0f5b0ef7503a1