### PR TITLE
Implement arc4random_uniform

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ programs. Key features include:
 - Integer helpers `abs`, `labs`, `llabs` and division results with `div`,
   `ldiv` and `lldiv`
 - POSIX-style 48-bit random numbers via the `rand48` family
+- Deterministic uniform numbers with `arc4random_uniform()`
 - Descriptor-based printing with `dprintf()`/`vdprintf()`
 - Memory-backed streams with `open_memstream()` and `fmemopen()`
 - Large-file aware seeks

--- a/docs/random.md
+++ b/docs/random.md
@@ -10,6 +10,7 @@ int rand(void);
 void srand(unsigned seed);
 unsigned int arc4random(void);
 void arc4random_buf(void *buf, size_t len);
+unsigned int arc4random_uniform(unsigned int upper_bound);
 int rand_r(unsigned *state);
 ```
 
@@ -19,8 +20,11 @@ produces the identical sequence of numbers, each in the range `0` to
 
 `arc4random()` returns a 32-bit value sourced from the operating system's
 random generator. `arc4random_buf()` fills an arbitrary buffer with secure
-random bytes. The `rand_r()` variant operates like `rand()` but stores its
-state in a user-provided variable so it can be used in threaded code.
+random bytes. `arc4random_uniform()` converts this 32-bit output into a
+value in the range `[0, upper_bound)` using rejection sampling so each
+result occurs with equal probability. The `rand_r()` variant operates like
+`rand()` but stores its state in a user-provided variable so it can be used
+in threaded code.
 
 ## rand48 API
 

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -64,6 +64,7 @@ int rand(void);
 void srand(unsigned seed);
 unsigned int arc4random(void);
 void arc4random_buf(void *buf, size_t len);
+unsigned int arc4random_uniform(unsigned int upper_bound);
 int rand_r(unsigned *state);
 double drand48(void);
 double erand48(unsigned short xseed[3]);

--- a/src/arc4random.c
+++ b/src/arc4random.c
@@ -46,6 +46,22 @@ unsigned int arc4random(void)
     return v;
 }
 
+unsigned int arc4random_uniform(unsigned int upper_bound)
+{
+    unsigned int r, min;
+
+    if (upper_bound < 2)
+        return 0;
+
+    min = -upper_bound % upper_bound;
+    for (;;) {
+        r = arc4random();
+        if (r >= min)
+            break;
+    }
+    return r % upper_bound;
+}
+
 int rand_r(unsigned *state)
 {
     *state = *state * 1103515245 + 12345;

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2969,6 +2969,26 @@ static const char *test_rand48_fn(void)
     return 0;
 }
 
+static const char *test_arc4random_uniform_basic(void)
+{
+    enum { BOUND = 5, ITER = 10000 };
+    unsigned counts[BOUND];
+    memset(counts, 0, sizeof(counts));
+
+    for (unsigned i = 0; i < ITER; i++) {
+        unsigned v = arc4random_uniform(BOUND);
+        mu_assert("in range", v < BOUND);
+        counts[v]++;
+    }
+
+    unsigned expected = ITER / BOUND;
+    for (unsigned i = 0; i < BOUND; i++)
+        mu_assert("rough uniform",
+                  counts[i] > expected - 400 && counts[i] < expected + 400);
+
+    return 0;
+}
+
 static const char *test_forkpty_echo(void)
 {
     int mfd;
@@ -4165,6 +4185,7 @@ static const char *all_tests(void)
     mu_run_test(test_popen_fn);
     mu_run_test(test_rand_fn);
     mu_run_test(test_rand48_fn);
+    mu_run_test(test_arc4random_uniform_basic);
     mu_run_test(test_forkpty_echo);
     mu_run_test(test_tcdrain_basic);
     mu_run_test(test_tcflush_basic);


### PR DESCRIPTION
## Summary
- add `arc4random_uniform` declaration
- implement uniform random number generation
- document deterministic uniform API
- note uniform generation in README
- test arc4random_uniform over small ranges

## Testing
- `make test` *(fails: no output)*
- `./tests/run_tests` *(fails: program produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_685caf6114348324a53799c4ca10be43