### PR TITLE
Add sigaltstack support

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -77,6 +77,8 @@ Convenience wrappers `getpgrp()` and `setpgrp()` map to `getpgid(0)` and
 `setpgid(0, 0)` for portability.
 `sigqueue` delivers a queued signal with a small data payload when the
 platform exposes `rt_sigqueueinfo` or falls back to the native implementation.
+`sigaltstack` configures an alternate stack for signal handlers using the
+`sigaltstack` system call when available or delegating to the host on BSD.
 
 `posix_spawn` accepts an attribute object controlling the signal mask and
 process group of the new process. File actions can be supplied to open, close

--- a/include/signal.h
+++ b/include/signal.h
@@ -77,6 +77,19 @@ int sigdelset(sigset_t *set, int signo);
 int sigismember(const sigset_t *set, int signo);
 char *strsignal(int signum);
 
+typedef struct {
+    void  *ss_sp;
+    size_t ss_size;
+    int    ss_flags;
+} stack_t;
+
+#define SS_ONSTACK  1
+#define SS_DISABLE  2
+#define MINSIGSTKSZ 2048
+#define SIGSTKSZ    8192
+
+int sigaltstack(const stack_t *ss, stack_t *old);
+
 typedef struct siginfo {
     int si_signo;
     int si_errno;

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3254,6 +3254,21 @@ static const char *test_sigqueue_value(void)
     return 0;
 }
 
+static const char *test_sigaltstack_basic(void)
+{
+    stack_t old;
+    stack_t ss;
+    char buf[SIGSTKSZ];
+    ss.ss_sp = buf;
+    ss.ss_size = sizeof(buf);
+    ss.ss_flags = 0;
+    mu_assert("set altstack", sigaltstack(&ss, &old) == 0);
+    ss.ss_flags = SS_DISABLE;
+    mu_assert("disable altstack", sigaltstack(&ss, NULL) == 0);
+    (void)old;
+    return 0;
+}
+
 static const char *test_mlock_basic(void)
 {
     char buf[128];
@@ -4333,6 +4348,7 @@ static const char *all_tests(void)
     mu_run_test(test_sigwait_basic);
     mu_run_test(test_sigtimedwait_timeout);
     mu_run_test(test_sigqueue_value);
+    mu_run_test(test_sigaltstack_basic);
     mu_run_test(test_mlock_basic);
     mu_run_test(test_mprotect_anon);
     mu_run_test(test_shm_basic);


### PR DESCRIPTION
## Summary
- implement sigaltstack using SYS_sigaltstack or host delegate
- expose stack_t API in signal.h
- document alt stack usage in signal handling docs
- test alternate stack installation

## Testing
- `make test` *(fails: command interrupted due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685d5ae9f020832491df3f594e96b1ad