### PR TITLE
Add times wrapper and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ SRC := \
     src/time.c \
     src/time_conv.c \
     src/time_r.c \
+    src/times.c \
     src/itimer.c \
     src/timer.c \
     src/strftime.c \

--- a/docs/time.md
+++ b/docs/time.md
@@ -183,3 +183,14 @@ printf("user: %ld.%06ld sys: %ld.%06ld\n",
        (long)ru.ru_stime.tv_sec, (long)ru.ru_stime.tv_usec);
 ```
 
+`times` provides similar information measured in clock ticks. It fills a
+`struct tms` with user and system times for the process and its exited
+children and returns the elapsed real time:
+
+```c
+struct tms t;
+clock_t r = times(&t);
+printf("ticks: %ld user: %ld sys: %ld\n",
+       (long)r, (long)t.tms_utime, (long)t.tms_stime);
+```
+

--- a/include/sys/times.h
+++ b/include/sys/times.h
@@ -1,0 +1,22 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Process CPU time reporting helpers.
+ */
+#ifndef SYS_TIMES_H
+#define SYS_TIMES_H
+
+#include <sys/types.h>
+#include "../time.h"
+#include <time.h>
+
+struct tms {
+    clock_t tms_utime;   /* user CPU time */
+    clock_t tms_stime;   /* system CPU time */
+    clock_t tms_cutime;  /* user CPU time of children */
+    clock_t tms_cstime;  /* system CPU time of children */
+};
+
+clock_t times(struct tms *buf);
+
+#endif /* SYS_TIMES_H */

--- a/include/time.h
+++ b/include/time.h
@@ -61,6 +61,11 @@ struct tm {
 int tm_isdst; /* daylight savings time flag */
 };
 
+#ifndef __clock_t_defined
+#define __clock_t_defined 1
+typedef long clock_t;
+#endif
+
 #ifndef __clockid_t_defined
 #define __clockid_t_defined 1
 typedef int clockid_t;

--- a/src/times.c
+++ b/src/times.c
@@ -1,0 +1,31 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms, with or without modification, are permitted provided that the copyright notice and this permission notice appear in all copies. This software is provided "as is" without warranty.
+ *
+ * Purpose: Implements the times wrapper for vlibc. Provides process CPU time information.
+ */
+
+#include "sys/times.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+clock_t times(struct tms *buf)
+{
+#ifdef SYS_times
+    long ret = vlibc_syscall(SYS_times, (long)buf, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return (clock_t)-1;
+    }
+    return (clock_t)ret;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    extern clock_t host_times(struct tms *) __asm("times");
+    return host_times(buf);
+#else
+    (void)buf;
+    errno = ENOSYS;
+    return (clock_t)-1;
+#endif
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -59,6 +59,7 @@
 #include <signal.h>
 #include "../include/time.h"
 #include "../include/sys/resource.h"
+#include "../include/sys/times.h"
 #include "../include/sys/mman.h"
 #include "../include/sys/shm.h"
 #include "../include/sys/sem.h"
@@ -2220,6 +2221,19 @@ static const char *test_getrusage_self(void)
     return 0;
 }
 
+static const char *test_times_self(void)
+{
+    struct tms t;
+    volatile long sink = 0;
+    for (long i = 0; i < 1000000; ++i)
+        sink += i;
+    (void)sink;
+    clock_t c = times(&t);
+    mu_assert("times", c != (clock_t)-1);
+    mu_assert("have ticks", t.tms_utime > 0 || t.tms_stime > 0);
+    return 0;
+}
+
 static const char *test_strftime_basic(void)
 {
     struct tm tm = {
@@ -4297,6 +4311,7 @@ static const char *all_tests(void)
     mu_run_test(test_sched_get_set_scheduler);
     mu_run_test(test_timer_basic);
     mu_run_test(test_getrusage_self);
+    mu_run_test(test_times_self);
     mu_run_test(test_strftime_basic);
     mu_run_test(test_strftime_extended);
     mu_run_test(test_wcsftime_basic);


### PR DESCRIPTION
## Summary
- implement `times()` wrapper calling SYS_times or host libc on BSD
- add `struct tms` declaration and prototype in `sys/times.h`
- document CPU time retrieval via `times`
- test process CPU time retrieval

## Testing
- `make test` *(fails: command interrupted or environment issue)*

------
https://chatgpt.com/codex/tasks/task_e_685d5ea954108324bb14599dbbd77456