### PR TITLE
Add wide-character search functions

### DIFF
--- a/docs/strings.md
+++ b/docs/strings.md
@@ -7,6 +7,7 @@ The **string** module provides fundamental operations needed by most C programs:
 - `vstrlen`, `vstrcpy`, `vstrncmp`, `strnlen`, `strcat`, `strncat`, `strlcpy`, `strlcat`, `stpcpy` and `stpncpy` equivalents.
 - `strdup` and `strndup` helpers allocate new copies of strings.
 - Search helpers `strstr`, `strrchr`, `memchr`, `memrchr`, and `memmem` for locating substrings or bytes.
+- Wide-character search helpers `wcschr`, `wcsrchr`, `wcsstr` and `wmemchr` mirror those operations for `wchar_t` data.
 - Prefix scanners `strspn` and `strcspn` along with `strpbrk` for finding any character from a set.
 - Case-insensitive comparisons `strcasecmp` and `strncasecmp`.
 - Case-insensitive substring search with `strcasestr`.
@@ -79,6 +80,8 @@ implementation on BSD when other locales are active. The `wcstok`
 function tokenizes a wide string using a caller-supplied save pointer.
 The `wmemcpy`, `wmemmove`, `wmemset` and `wmemcmp` routines operate on
 arrays of `wchar_t` analogous to the byte-oriented routines.
+Search helpers `wcschr`, `wcsrchr`, `wcsstr` and `wmemchr` provide character
+and substring lookup for wide strings.
 
 ### Example
 

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -39,6 +39,12 @@ int wcscmp(const wchar_t *s1, const wchar_t *s2);
 int wcsncmp(const wchar_t *s1, const wchar_t *s2, size_t n);
 /* Duplicate a wide-character string */
 wchar_t *wcsdup(const wchar_t *s);
+/* Search a wide-character string for a character */
+wchar_t *wcschr(const wchar_t *s, wchar_t c);
+/* Search a wide-character string from the end */
+wchar_t *wcsrchr(const wchar_t *s, wchar_t c);
+/* Locate a substring in a wide-character string */
+wchar_t *wcsstr(const wchar_t *haystack, const wchar_t *needle);
 /* Collate wide-character strings */
 int wcscoll(const wchar_t *s1, const wchar_t *s2);
 /* Transform wide-character string for collation */
@@ -95,5 +101,6 @@ wchar_t *wmemcpy(wchar_t *dest, const wchar_t *src, size_t n);
 wchar_t *wmemmove(wchar_t *dest, const wchar_t *src, size_t n);
 wchar_t *wmemset(wchar_t *s, wchar_t c, size_t n);
 int wmemcmp(const wchar_t *s1, const wchar_t *s2, size_t n);
+wchar_t *wmemchr(const wchar_t *s, wchar_t c, size_t n);
 
 #endif /* WCHAR_H */

--- a/src/wchar.c
+++ b/src/wchar.c
@@ -217,3 +217,53 @@ wchar_t *wcstok(wchar_t *str, const wchar_t *delim, wchar_t **saveptr)
 
     return token;
 }
+
+/* Locate first occurrence of c in wide string s. */
+wchar_t *wcschr(const wchar_t *s, wchar_t c)
+{
+    while (*s) {
+        if (*s == c)
+            return (wchar_t *)s;
+        s++;
+    }
+    if (c == L'\0')
+        return (wchar_t *)s;
+    return NULL;
+}
+
+/* Locate last occurrence of c in wide string s. */
+wchar_t *wcsrchr(const wchar_t *s, wchar_t c)
+{
+    const wchar_t *ret = NULL;
+    do {
+        if (*s == c)
+            ret = s;
+    } while (*s++);
+    return (wchar_t *)ret;
+}
+
+/* Find substring needle in haystack. */
+wchar_t *wcsstr(const wchar_t *haystack, const wchar_t *needle)
+{
+    if (!*needle)
+        return (wchar_t *)haystack;
+    size_t nlen = wcslen(needle);
+    while (*haystack) {
+        if (*haystack == *needle && wcsncmp(haystack, needle, nlen) == 0)
+            return (wchar_t *)haystack;
+        haystack++;
+    }
+    return NULL;
+}
+
+/* Search first n wide characters of s for c. */
+wchar_t *wmemchr(const wchar_t *s, wchar_t c, size_t n)
+{
+    const wchar_t *p = s;
+    while (n--) {
+        if (*p == c)
+            return (wchar_t *)p;
+        p++;
+    }
+    return NULL;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1243,6 +1243,26 @@ static const char *test_wmem_ops(void)
     return 0;
 }
 
+static const char *test_wchar_search(void)
+{
+    const wchar_t *p = wcschr(L"hello", L'e');
+    mu_assert("wcschr", p && p - L"hello" == 1);
+
+    const wchar_t *r = wcsrchr(L"abca", L'a');
+    mu_assert("wcsrchr", r && r - L"abca" == 3);
+
+    const wchar_t *h = L"abcabc";
+    const wchar_t *s = wcsstr(h, L"cab");
+    mu_assert("wcsstr", s && s - h == 2);
+
+    wchar_t buf[4] = { L'x', L'y', L'z', L'y' };
+    wchar_t *m = wmemchr(buf, L'z', 4);
+    mu_assert("wmemchr", m == &buf[2]);
+    mu_assert("wmemchr none", wmemchr(buf, L'a', 4) == NULL);
+
+    return 0;
+}
+
 static const char *test_wmemstream_basic(void)
 {
     wchar_t *out = NULL;
@@ -4271,6 +4291,7 @@ static const char *all_tests(void)
     mu_run_test(test_widechar_width);
     mu_run_test(test_wctype_checks);
     mu_run_test(test_wmem_ops);
+    mu_run_test(test_wchar_search);
     mu_run_test(test_wmemstream_basic);
     mu_run_test(test_iconv_ascii_roundtrip);
     mu_run_test(test_iconv_invalid_byte);


### PR DESCRIPTION
## Summary
- implement `wcschr`, `wcsrchr`, `wcsstr` and `wmemchr`
- expose the new functions in `wchar.h`
- document wide-character search helpers
- test the new routines

## Testing
- `make test` *(fails: process terminated due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685d600d378c8324aa8012a6babd2791