### PR TITLE
Implement fchdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ programs. Key features include:
 - Syslog-style logging
 - Simplified `err`/`warn` helpers for fatal and nonfatal messages
 - Change root directories with `chroot()` when supported
+- Change directories by descriptor with `fchdir()`
 - Directory scanning helpers
 - File tree traversal with `fts`
 - Path expansion helpers with `glob()` and `wordexp()`

--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -143,6 +143,20 @@ while ((e = fts_read(f)))
 fts_close(f);
 ```
 
+## Changing Directories
+
+`fchdir` updates the current working directory using an open directory
+file descriptor. This avoids constructing a path again when returning
+to a previously opened location.
+
+```c
+char tmpl[] = "/tmp/dirXXXXXX";
+char *dir = mkdtemp(tmpl);
+int fd = open(dir, O_RDONLY | O_DIRECTORY);
+fchdir(fd);
+close(fd);
+```
+
 ## Path Canonicalization
 
 `realpath` converts a pathname into an absolute canonical form. It

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -38,6 +38,8 @@ size_t confstr(int name, char *buf, size_t len);
 long pathconf(const char *path, int name);
 long fpathconf(int fd, int name);
 
+int fchdir(int fd);
+
 char *getlogin(void);
 char *getpass(const char *prompt);
 char *crypt(const char *key, const char *salt);

--- a/src/io.c
+++ b/src/io.c
@@ -435,3 +435,31 @@ int symlinkat(const char *target, int dirfd, const char *linkpath)
 #endif
 #endif
 }
+
+/*
+ * Change the current working directory using a descriptor. When the
+ * dedicated SYS_fchdir syscall is unavailable, fall back to the
+ * F_CHDIR fcntl command if provided by the host system.
+ */
+int fchdir(int fd)
+{
+#ifdef SYS_fchdir
+    long ret = vlibc_syscall(SYS_fchdir, fd, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (int)ret;
+#else
+#ifdef F_CHDIR
+    int ret = fcntl(fd, F_CHDIR);
+    if (ret < 0)
+        return -1;
+    return ret;
+#else
+    (void)fd;
+    errno = ENOSYS;
+    return -1;
+#endif
+#endif
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3520,6 +3520,29 @@ static const char *test_getcwd_chdir(void)
     return 0;
 }
 
+static const char *test_fchdir_basic(void)
+{
+    char orig[256];
+    mu_assert("orig cwd", getcwd(orig, sizeof(orig)) != NULL);
+
+    char tmpl[] = "/tmp/fcdXXXXXX";
+    char *dir = mkdtemp(tmpl);
+    mu_assert("mkdtemp", dir != NULL);
+
+    int fd = open(dir, O_RDONLY);
+    mu_assert("open dir", fd >= 0);
+
+    mu_assert("fchdir", fchdir(fd) == 0);
+    char buf[256];
+    mu_assert("cwd dir", getcwd(buf, sizeof(buf)) != NULL);
+    mu_assert("dir path", strcmp(buf, dir) == 0);
+
+    mu_assert("restore", chdir(orig) == 0);
+    close(fd);
+    rmdir(dir);
+    return 0;
+}
+
 static const char *test_realpath_basic(void)
 {
     char cwd[256];
@@ -4465,6 +4488,7 @@ static const char *all_tests(void)
     mu_run_test(test_atexit_handler);
     mu_run_test(test_quick_exit_handler);
     mu_run_test(test_getcwd_chdir);
+    mu_run_test(test_fchdir_basic);
     mu_run_test(test_realpath_basic);
     mu_run_test(test_pathconf_basic);
     mu_run_test(test_passwd_lookup);


### PR DESCRIPTION
## Summary
- add `fchdir` implementation with syscall/fcntl fallback
- declare `fchdir` in `<unistd.h>`
- document usage in filesystem docs
- note feature in README
- test `fchdir` functionality

## Testing
- `make test` *(fails: command timed out in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_685d6b15700c8324a333d7c08f478daa