### PR TITLE
Add freopen implementation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ programs. Key features include:
 - Deterministic uniform numbers with `arc4random_uniform()`
 - Descriptor-based printing with `dprintf()`/`vdprintf()`
 - Memory-backed streams with `open_memstream()`, `open_wmemstream()` and `fmemopen()`
+- Replace an open stream with `freopen()`
 - Large-file aware seeks
 - Store and restore file positions with `fgetpos()` and `fsetpos()`
 - Zero-copy file transfers with `sendfile()`

--- a/docs/io.md
+++ b/docs/io.md
@@ -209,6 +209,18 @@ Streams may be given a custom buffer with `setvbuf` or the simpler
 `setbuf`. When buffered, I/O operates on that memory until it is filled
 or explicitly flushed.
 
+`freopen` can replace the file associated with an existing stream so the same
+`FILE` handle refers to a new path. This is handy for redirecting a standard
+stream:
+
+```c
+FILE *f = fopen("swap.txt", "w");
+fputs("hello", f);
+freopen("swap.txt", "r", f);
+char buf[16];
+fgets(buf, sizeof(buf), f);
+```
+
 ```c
 int a;
 unsigned b;

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -71,6 +71,7 @@ int feof(FILE *stream);
 int ferror(FILE *stream);
 void clearerr(FILE *stream);
 int fileno(FILE *stream);
+FILE *freopen(const char *path, const char *mode, FILE *stream);
 FILE *fdopen(int fd, const char *mode);
 
 int printf(const char *format, ...);

--- a/src/stdio.c
+++ b/src/stdio.c
@@ -470,6 +470,28 @@ int fileno(FILE *stream)
     return stream ? stream->fd : -1;
 }
 
+FILE *freopen(const char *path, const char *mode, FILE *stream)
+{
+    if (!path || !mode || !stream)
+        return NULL;
+
+    FILE *tmp = fopen(path, mode);
+    if (!tmp)
+        return NULL;
+
+    flush_buffer(stream);
+    if (!stream->is_mem)
+        close(stream->fd);
+    if (stream->is_mem && stream->mem_bufp)
+        stream->buf_owned = 0;
+    if (stream->buf && stream->buf_owned)
+        free(stream->buf);
+
+    *stream = *tmp;
+    free(tmp);
+    return stream;
+}
+
 FILE *fdopen(int fd, const char *mode)
 {
     (void)mode; /* mode is ignored for now */

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3225,6 +3225,21 @@ static const char *test_temp_files(void)
     return 0;
 }
 
+static const char *test_freopen_basic(void)
+{
+    FILE *f = fopen("tmp_reopen", "w");
+    mu_assert("fopen", f != NULL);
+    mu_assert("write", fwrite("data", 1, 4, f) == 4);
+    f = freopen("tmp_reopen", "r", f);
+    mu_assert("freopen", f != NULL);
+    char buf[5] = {0};
+    mu_assert("read", fread(buf, 1, 4, f) == 4);
+    fclose(f);
+    unlink("tmp_reopen");
+    mu_assert("content", strcmp(buf, "data") == 0);
+    return 0;
+}
+
 static const char *test_abort_fn(void)
 {
     pid_t pid = fork();
@@ -4471,6 +4486,7 @@ static const char *all_tests(void)
     mu_run_test(test_tcdrain_basic);
     mu_run_test(test_tcflush_basic);
     mu_run_test(test_temp_files);
+    mu_run_test(test_freopen_basic);
     mu_run_test(test_abort_fn);
     mu_run_test(test_sigaction_install);
     mu_run_test(test_sigprocmask_block);


### PR DESCRIPTION
## Summary
- implement `freopen` using existing open/close helpers
- document `freopen` usage in the docs and README
- expose the new symbol in `stdio.h`
- test reopening a file stream

## Testing
- `make test` *(fails: build interrupted or environment timed out)*

------
https://chatgpt.com/codex/tasks/task_e_685d6dbae9788324b510dae7c3253db1