### PR TITLE
Implement clock_settime wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ SRC := \
     src/sched.c \
     src/clock_gettime.c \
     src/clock_getres.c \
+    src/clock_settime.c \
     src/time.c \
     src/time_conv.c \
     src/time_r.c \

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ clock_gettime(CLOCK_MONOTONIC, &ts);
 ```
 
 `CLOCK_REALTIME` returns the wall-clock time.
+`clock_settime` adjusts it when privileges allow.
 `clock_getres` queries the resolution of a given clock.
 Use `difftime` to compute the difference between two `time_t` values.
 

--- a/docs/time.md
+++ b/docs/time.md
@@ -76,6 +76,19 @@ Thread-safe variants `gmtime_r` and `localtime_r` fill a user-provided
 timezone from the `TZ` environment variable or `/etc/localtime` so
 `localtime`, `mktime` and `ctime` honour the configured offset.
 
+## Clock Adjustment
+
+`clock_settime` updates the value of a particular clock. When the
+`SYS_clock_settime` syscall is present it is invoked directly. On the BSD
+family the wrapper falls back to `settimeofday` when adjusting
+`CLOCK_REALTIME`. Modifying clocks typically requires superuser
+privileges.
+
+```c
+struct timespec ts = { .tv_sec = 1700000000, .tv_nsec = 0 };
+clock_settime(CLOCK_REALTIME, &ts);
+```
+
 ## Sleep Functions
 
 Delay helpers are available in `time.h`:

--- a/include/time.h
+++ b/include/time.h
@@ -111,6 +111,13 @@ int clock_getres(int clk_id, struct timespec *res);
  * systems the host clock_getres implementation is called if
  * no direct syscall is present.
  */
+int clock_settime(int clk_id, const struct timespec *ts);
+/*
+ * Set the specified clock. When SYS_clock_settime exists it is
+ * invoked directly. BSD builds fall back to settimeofday() for
+ * CLOCK_REALTIME.
+ */
+
 
 time_t time(time_t *t);
 /*

--- a/src/clock_settime.c
+++ b/src/clock_settime.c
@@ -1,0 +1,38 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms, with or without modification, are permitted provided that the copyright notice and this permission notice appear in all copies. This software is provided "as is" without warranty.
+ *
+ * Purpose: Implements the clock_settime function for vlibc. Provides wrappers and helpers used by the standard library.
+ */
+
+#include "time.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int clock_settime(int clk_id, const struct timespec *ts)
+{
+#ifdef SYS_clock_settime
+    long ret = vlibc_syscall(SYS_clock_settime, clk_id, (long)ts, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || \
+      defined(__OpenBSD__) || defined(__DragonFly__)
+    if (clk_id != CLOCK_REALTIME || !ts) {
+        errno = EINVAL;
+        return -1;
+    }
+    struct timeval tv;
+    tv.tv_sec = ts->tv_sec;
+    tv.tv_usec = ts->tv_nsec / 1000;
+    extern int host_settimeofday(const struct timeval *, const void *) __asm__("settimeofday");
+    return host_settimeofday(&tv, NULL);
+#else
+    (void)clk_id; (void)ts;
+    errno = ENOSYS;
+    return -1;
+#endif
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2281,6 +2281,23 @@ static const char *test_timer_basic(void)
     return 0;
 }
 
+static const char *test_clock_settime_priv(void)
+{
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
+        return "gettime";
+    int r = clock_settime(CLOCK_MONOTONIC, &ts);
+    if (r != 0) {
+        if (errno == EPERM || errno == ENOSYS || errno == EINVAL)
+            return 0; /* skip when not permitted */
+        return "clock_settime";
+    }
+    struct timespec check;
+    mu_assert("verify", clock_gettime(CLOCK_MONOTONIC, &check) == 0);
+    mu_assert("compare", check.tv_sec >= ts.tv_sec);
+    return 0;
+}
+
 static const char *test_getrusage_self(void)
 {
     struct rusage r;
@@ -4424,6 +4441,7 @@ static const char *all_tests(void)
     mu_run_test(test_priority_wrappers);
     mu_run_test(test_sched_get_set_scheduler);
     mu_run_test(test_timer_basic);
+    mu_run_test(test_clock_settime_priv);
     mu_run_test(test_getrusage_self);
     mu_run_test(test_times_self);
     mu_run_test(test_strftime_basic);


### PR DESCRIPTION
## Summary
- add `clock_settime` implementation with BSD fallback
- declare `clock_settime` in header
- document clock adjustment functionality
- mention `clock_settime` in README summary
- compile it in the build and test via a new unit test

## Testing
- `make test` *(fails: command interrupted due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_685d6dcd90dc8324b4272ef3729a2257