### PR TITLE
Implement simple hsearch support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ SRC := \
     src/ctype.c \
     $(SELECT_SRC) \
     src/qsort.c \
+    src/search_hash.c \
     src/getopt.c \
     src/dlfcn.c \
     src/getopt_long.c \

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ programs. Key features include:
 - Path expansion helpers with `glob()` and `wordexp()`
 - Text encoding helpers with `vis()`, `nvis()` and `unvis()`
 - Array sorting with `qsort`, `qsort_r` and `bsearch`
+- Simple hash table via `hcreate`, `hdestroy` and `hsearch`
 - Array resizing with `recallocarray()` which zeroes new memory
 - Aligned allocations with `aligned_alloc()`
 - Standard `assert` macro for runtime checks

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -111,3 +111,23 @@ while (*p) {
     }
 }
 ```
+
+## Hash Table Search
+
+`hcreate`, `hdestroy` and `hsearch` implement a very small global hash table.
+Create the table with `hcreate(nel)`, insert elements using `hsearch` with
+`ENTER`, and look them up with `FIND`. `hdestroy` releases the table.
+
+```c
+hcreate(8);
+ENTRY e = {"key", "value"};
+hsearch(e, ENTER);
+ENTRY q = {"key", NULL};
+ENTRY *r = hsearch(q, FIND);
+if (r)
+    printf("%s\n", (char *)r->data);
+hdestroy();
+```
+
+Only one table may exist at a time and collisions are resolved with linear
+probing.

--- a/include/search.h
+++ b/include/search.h
@@ -1,0 +1,22 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Declarations for simple hash table search functions.
+ */
+#ifndef SEARCH_H
+#define SEARCH_H
+
+#include <stddef.h>
+
+typedef struct entry {
+    char *key;
+    void *data;
+} ENTRY;
+
+typedef enum { FIND, ENTER } ACTION;
+
+int hcreate(size_t nel);
+void hdestroy(void);
+ENTRY *hsearch(ENTRY item, ACTION action);
+
+#endif /* SEARCH_H */

--- a/src/search_hash.c
+++ b/src/search_hash.c
@@ -1,0 +1,76 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Implements hcreate, hdestroy and hsearch using
+ * a simple open-addressed hash table.
+ */
+
+#include "search.h"
+#include "stdlib.h"
+#include "string.h"
+
+static ENTRY *table;
+static unsigned char *used;
+static size_t table_size;
+static size_t items;
+
+static unsigned long hash_str(const char *s)
+{
+    unsigned long h = 5381;
+    unsigned char c;
+    while ((c = (unsigned char)*s++))
+        h = ((h << 5) + h) + c;
+    return h;
+}
+
+int hcreate(size_t nel)
+{
+    if (table)
+        return 0;
+    table = calloc(nel, sizeof(ENTRY));
+    if (!table)
+        return 0;
+    used = calloc(nel, 1);
+    if (!used) {
+        free(table);
+        table = NULL;
+        return 0;
+    }
+    table_size = nel;
+    items = 0;
+    return 1;
+}
+
+void hdestroy(void)
+{
+    free(table);
+    free(used);
+    table = NULL;
+    used = NULL;
+    table_size = 0;
+    items = 0;
+}
+
+ENTRY *hsearch(ENTRY item, ACTION action)
+{
+    if (!table || !item.key)
+        return NULL;
+    unsigned long h = hash_str(item.key);
+    for (size_t i = 0; i < table_size; i++) {
+        size_t idx = (h + i) % table_size;
+        if (!used[idx]) {
+            if (action == ENTER) {
+                if (items >= table_size)
+                    return NULL;
+                table[idx] = item;
+                used[idx] = 1;
+                items++;
+                return &table[idx];
+            }
+            return NULL;
+        }
+        if (strcmp(table[idx].key, item.key) == 0)
+            return &table[idx];
+    }
+    return NULL;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -50,6 +50,7 @@
 #include "../include/fts.h"
 #include "../include/wordexp.h"
 #include "../include/vis.h"
+#include "../include/search.h"
 #include "../include/pty.h"
 #include "../include/termios.h"
 #ifndef B9600
@@ -3990,6 +3991,21 @@ static const char *test_qsort_r_desc(void)
     return 0;
 }
 
+static const char *test_hsearch_basic(void)
+{
+    mu_assert("create", hcreate(8) == 1);
+    ENTRY e = {"foo", "bar"};
+    mu_assert("insert foo", hsearch(e, ENTER) != NULL);
+    e.key = "baz";
+    e.data = "qux";
+    mu_assert("insert baz", hsearch(e, ENTER) != NULL);
+    ENTRY q = {"foo", NULL};
+    ENTRY *r = hsearch(q, FIND);
+    mu_assert("lookup foo", r && r->data == (void *)"bar");
+    hdestroy();
+    return 0;
+}
+
 static const char *test_regex_backref_basic(void)
 {
     regex_t re;
@@ -4575,6 +4591,7 @@ static const char *all_tests(void)
     mu_run_test(test_qsort_int);
     mu_run_test(test_qsort_strings);
     mu_run_test(test_qsort_r_desc);
+    mu_run_test(test_hsearch_basic);
     mu_run_test(test_regex_backref_basic);
     mu_run_test(test_regex_backref_fail);
     mu_run_test(test_regex_posix_class);


### PR DESCRIPTION
## Summary
- add `search.h` for ENTRY and hsearch declarations
- implement basic open-addressed hash table
- document the new hash search helpers
- reference hsearch feature in README
- test hcreate/hdestroy/hsearch in unit tests

## Testing
- `make test` *(fails: tests could not be executed)*

------
https://chatgpt.com/codex/tasks/task_e_685d776cf0988324a2f1802c841e0607