### PR TITLE
Add clock_nanosleep wrapper and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ programs. Key features include:
 - Filesystem limits with `pathconf()` and `fpathconf()`
 - Query configuration strings with `confstr()`
 - Simple alarm timers with `alarm()`
+- High resolution delays with `clock_nanosleep()` for relative or
+  absolute sleeps
 - Yield the processor with `sched_yield()` from `<sched.h>`
 - Adjust and query nice values with `nice()`, `getpriority()` and
   `setpriority()` from `<sched.h>`

--- a/docs/time.md
+++ b/docs/time.md
@@ -100,6 +100,10 @@ int nanosleep(const struct timespec *req, struct timespec *rem);
 unsigned int alarm(unsigned int seconds);
 ```
 
+`clock_nanosleep` accepts a clock ID and optional `TIMER_ABSTIME` flag to
+sleep until an absolute time. When the kernel lacks the dedicated syscall the
+wrapper falls back to `nanosleep` and `clock_gettime`.
+
 ## Scheduling
 
 `sched_yield` allows a thread to voluntarily relinquish the CPU, letting

--- a/include/time.h
+++ b/include/time.h
@@ -136,6 +136,13 @@ int gettimeofday(struct timeval *tv, void *tz);
 unsigned sleep(unsigned seconds);
 int usleep(useconds_t usec);
 int nanosleep(const struct timespec *req, struct timespec *rem);
+int clock_nanosleep(clockid_t clk_id, int flags,
+                    const struct timespec *req, struct timespec *rem);
+/*
+ * Sleep based on the specified clock. When the SYS_clock_nanosleep
+ * syscall is unavailable the wrapper falls back to nanosleep for
+ * relative delays and uses clock_gettime for TIMER_ABSTIME waits.
+ */
 
 int setitimer(int which, const struct itimerval *new,
               struct itimerval *old);

--- a/src/clock_nanosleep.c
+++ b/src/clock_nanosleep.c
@@ -1,0 +1,51 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Implements clock_nanosleep for vlibc. When the kernel
+ * lacks a direct syscall the function falls back to nanosleep for
+ * relative delays and emulates absolute sleeps using clock_gettime.
+ */
+
+#include "time.h"
+#include "errno.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include "syscall.h"
+
+int clock_nanosleep(clockid_t clk_id, int flags,
+                    const struct timespec *req, struct timespec *rem)
+{
+#ifdef SYS_clock_nanosleep
+    long ret = vlibc_syscall(SYS_clock_nanosleep, clk_id, flags,
+                             (long)req, (long)rem, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return 0;
+#else
+    if (!(flags & TIMER_ABSTIME)) {
+        (void)clk_id;
+        return nanosleep(req, rem);
+    }
+
+    struct timespec now;
+    while (1) {
+        if (clock_gettime(clk_id, &now) < 0)
+            return -1;
+        long sec = req->tv_sec - now.tv_sec;
+        long nsec = req->tv_nsec - now.tv_nsec;
+        if (nsec < 0) {
+            nsec += 1000000000L;
+            --sec;
+        }
+        if (sec < 0 || (sec == 0 && nsec <= 0))
+            return 0;
+        struct timespec rel = {sec, nsec};
+        if (nanosleep(&rel, NULL) == 0)
+            return 0;
+        if (errno != EINTR)
+            return -1;
+    }
+#endif
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2235,6 +2235,31 @@ static const char *test_sleep_functions(void)
     return 0;
 }
 
+static const char *test_clock_nanosleep_basic(void)
+{
+    struct timespec ts, start, end;
+
+    ts.tv_sec = 1;
+    ts.tv_nsec = 0;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    mu_assert("clock_nanosleep rel",
+             clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL) == 0);
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    mu_assert("rel delay", end.tv_sec - start.tv_sec >= 1 &&
+                             end.tv_sec - start.tv_sec <= 3);
+
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    ts = start;
+    ts.tv_sec += 1;
+    mu_assert("clock_nanosleep abs",
+             clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, NULL) == 0);
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    mu_assert("abs delay", end.tv_sec - start.tv_sec >= 1 &&
+                            end.tv_sec - start.tv_sec <= 3);
+
+    return 0;
+}
+
 static const char *test_sched_yield_basic(void)
 {
     mu_assert("sched_yield", sched_yield() == 0);
@@ -4484,6 +4509,7 @@ static const char *all_tests(void)
     mu_run_test(test_select_pipe);
     mu_run_test(test_poll_pipe);
     mu_run_test(test_sleep_functions);
+    mu_run_test(test_clock_nanosleep_basic);
     mu_run_test(test_sched_yield_basic);
     mu_run_test(test_sched_yield_loop);
     mu_run_test(test_priority_wrappers);


### PR DESCRIPTION
## Summary
- implement `clock_nanosleep` with a fallback to `nanosleep`
- expose the function in `<time.h>`
- document usage in `docs/time.md`
- add tests for relative and absolute `clock_nanosleep`
- mention the feature in the README

## Testing
- `make test` *(fails: strace not found; tests hang)*

------
https://chatgpt.com/codex/tasks/task_e_685d77a3e8d083248fcd9d5194f9d8e1