### PR TITLE
Add strtoimax/strtoumax wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ programs. Key features include:
 - Extended character checks like `isprint`, `ispunct`, `iscntrl`,
   `isgraph` and `isblank`
 - String-to-number conversions with `strtol`, `strtoul`, `strtoll`,
-  `strtoull`, `strtof`, `strtod` and `strtold`
+  `strtoull`, `strtoimax`, `strtoumax`, `strtof`, `strtod` and `strtold`
 - Integer helpers `abs`, `labs`, `llabs` and division results with `div`,
   `ldiv` and `lldiv`
 - POSIX-style 48-bit random numbers via the `rand48` family

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -34,7 +34,7 @@ The **string** module provides fundamental operations needed by most C programs:
   memory and is not thread-safe. `strtok_r` lets the caller maintain the
   context and is safe for concurrent use.
   - Simple number conversion helpers `atoi`, `strtol`, `strtoul`, `strtoll`,
-    `strtoull`, `strtof`, `strtod`, `strtold`, and `atof`.
+    `strtoull`, `strtoimax`, `strtoumax`, `strtof`, `strtod`, `strtold`, and `atof`.
 
 ### Example
 

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -7,6 +7,7 @@
 #define STDLIB_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 typedef struct { int quot; int rem; } div_t;
 typedef struct { long quot; long rem; } ldiv_t;
@@ -36,6 +37,8 @@ long strtol(const char *nptr, char **endptr, int base);
 unsigned long strtoul(const char *nptr, char **endptr, int base);
 long long strtoll(const char *nptr, char **endptr, int base);
 unsigned long long strtoull(const char *nptr, char **endptr, int base);
+intmax_t strtoimax(const char *nptr, char **endptr, int base);
+uintmax_t strtoumax(const char *nptr, char **endptr, int base);
 int atoi(const char *nptr);
 float strtof(const char *nptr, char **endptr);
 double strtod(const char *nptr, char **endptr);

--- a/src/strto.c
+++ b/src/strto.c
@@ -8,6 +8,7 @@
 
 #include "stdlib.h"
 #include "string.h"
+#include <stdint.h>
 
 static int digit_val(char c)
 {
@@ -408,5 +409,15 @@ long double strtold(const char *nptr, char **endptr)
         val = -val;
 
     return val;
+}
+
+intmax_t strtoimax(const char *nptr, char **endptr, int base)
+{
+    return (intmax_t)strtoll(nptr, endptr, base);
+}
+
+uintmax_t strtoumax(const char *nptr, char **endptr, int base)
+{
+    return (uintmax_t)strtoull(nptr, endptr, base);
 }
 

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -15,6 +15,7 @@
 #include <netinet/in.h>
 #include "../include/arpa/inet.h"
 #include <stdint.h>
+#include <inttypes.h>
 #include "../include/sys/stat.h"
 #include "../include/stdio.h"
 #include "../include/pthread.h"
@@ -1012,6 +1013,17 @@ static const char *test_string_helpers(void)
         ldiff = -ldiff;
     mu_assert("strtold", ldiff < 1e-9L && *end == '\0');
     mu_assert("atof", atof("-3.0") == -3.0);
+
+    char numbuf[64];
+    snprintf(numbuf, sizeof(numbuf), "%jd", (intmax_t)INTMAX_MAX);
+    mu_assert("strtoimax max",
+              strtoimax(numbuf, &end, 10) == INTMAX_MAX && *end == '\0');
+    snprintf(numbuf, sizeof(numbuf), "%jd", (intmax_t)INTMAX_MIN);
+    mu_assert("strtoimax min",
+              strtoimax(numbuf, &end, 10) == INTMAX_MIN && *end == '\0');
+    snprintf(numbuf, sizeof(numbuf), "%ju", (uintmax_t)UINTMAX_MAX);
+    mu_assert("strtoumax max",
+              strtoumax(numbuf, &end, 10) == UINTMAX_MAX && *end == '\0');
 
     mu_assert("strnlen zero", strnlen("abc", 0) == 0);
     mu_assert("strnlen short", strnlen("hello", 3) == 3);


### PR DESCRIPTION
## Summary
- implement `strtoimax` and `strtoumax`
- expose them in `<stdlib.h>`
- document the conversions
- test edge cases for the new functions
- mention the new helpers in the README

## Testing
- `make -j$(nproc) test` *(fails: Makefile build interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685d7aef8640832481048683f6cbd61c