### PR TITLE
Add tsearch binary search tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ SRC := \
     $(SELECT_SRC) \
     src/qsort.c \
     src/search_hash.c \
+    src/search_tree.c \
     src/getopt.c \
     src/dlfcn.c \
     src/getopt_long.c \

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ programs. Key features include:
 - Text encoding helpers with `vis()`, `nvis()` and `unvis()`
 - Array sorting with `qsort`, `qsort_r` and `bsearch`
 - Simple hash table via `hcreate`, `hdestroy` and `hsearch`
+- Binary search trees with `tsearch`, `tfind`, `tdelete` and `twalk`
 - Array resizing with `recallocarray()` which zeroes new memory
 - Aligned allocations with `aligned_alloc()`
 - Standard `assert` macro for runtime checks

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -131,3 +131,25 @@ hdestroy();
 
 Only one table may exist at a time and collisions are resolved with linear
 probing.
+
+## Binary Search Trees
+
+`tsearch`, `tfind`, `tdelete` and `twalk` build a minimal binary search tree.
+Insert elements with `tsearch`, locate them using `tfind` and remove them with
+`tdelete`. `twalk` visits each node in preorder, postorder and endorder.
+
+```c
+void *root = NULL;
+int values[] = {4, 2, 7, 1, 6};
+for (int i = 0; i < 5; i++)
+    tsearch(&values[i], &root, int_cmp);
+int *p = tfind(&values[2], &root, int_cmp);  // points to 7
+tdelete(&values[1], &root, int_cmp);         // remove 2
+static int sum = 0;
+void collect(const void *node, VISIT v, int l)
+{
+    if (v == postorder || v == leaf)
+        sum += *(const int *)node;
+}
+twalk(root, collect);   // sum == 18
+```

--- a/include/search.h
+++ b/include/search.h
@@ -1,7 +1,7 @@
 /*
  * BSD 2-Clause License
  *
- * Purpose: Declarations for simple hash table search functions.
+ * Purpose: Declarations for hash table and binary search tree helpers.
  */
 #ifndef SEARCH_H
 #define SEARCH_H
@@ -18,5 +18,14 @@ typedef enum { FIND, ENTER } ACTION;
 int hcreate(size_t nel);
 void hdestroy(void);
 ENTRY *hsearch(ENTRY item, ACTION action);
+
+typedef enum { preorder, postorder, endorder, leaf } VISIT;
+void *tsearch(const void *key, void **rootp,
+              int (*compar)(const void *, const void *));
+void *tfind(const void *key, void *const *rootp,
+            int (*compar)(const void *, const void *));
+void *tdelete(const void *key, void **rootp,
+              int (*compar)(const void *, const void *));
+void twalk(const void *root, void (*action)(const void *, VISIT, int));
 
 #endif /* SEARCH_H */

--- a/src/search_tree.c
+++ b/src/search_tree.c
@@ -1,0 +1,112 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Implements simple binary search tree functions tsearch,
+ * tfind, tdelete and twalk used by various utilities.
+ */
+
+#include "search.h"
+#include "stdlib.h"
+
+struct node {
+    const void *key;
+    struct node *left;
+    struct node *right;
+};
+
+static void *node_key(struct node *n)
+{
+    return n ? (void *)&n->key : NULL;
+}
+
+void *tsearch(const void *key, void **rootp,
+              int (*compar)(const void *, const void *))
+{
+    struct node **p = (struct node **)rootp;
+    if (!*p) {
+        *p = malloc(sizeof(struct node));
+        if (!*p)
+            return NULL;
+        (*p)->key = key;
+        (*p)->left = (*p)->right = NULL;
+        return &(*p)->key;
+    }
+    int r = compar(key, (*p)->key);
+    if (r < 0)
+        return tsearch(key, (void **)&(*p)->left, compar);
+    if (r > 0)
+        return tsearch(key, (void **)&(*p)->right, compar);
+    return &(*p)->key;
+}
+
+void *tfind(const void *key, void *const *rootp,
+            int (*compar)(const void *, const void *))
+{
+    struct node * const *p = (struct node * const *)rootp;
+    if (!*p)
+        return NULL;
+    int r = compar(key, (*p)->key);
+    if (r < 0)
+        return tfind(key, (void *const *)&(*p)->left, compar);
+    if (r > 0)
+        return tfind(key, (void *const *)&(*p)->right, compar);
+    return (void *)&(*p)->key;
+}
+
+void *tdelete(const void *key, void **rootp,
+              int (*compar)(const void *, const void *))
+{
+    struct node **p = (struct node **)rootp;
+    if (!*p)
+        return NULL;
+    int r = compar(key, (*p)->key);
+    if (r < 0)
+        return tdelete(key, (void **)&(*p)->left, compar);
+    if (r > 0)
+        return tdelete(key, (void **)&(*p)->right, compar);
+
+    struct node *t = *p;
+    if (!t->left) {
+        *p = t->right;
+        free(t);
+    } else if (!t->right) {
+        *p = t->left;
+        free(t);
+    } else {
+        struct node **minp = &t->right;
+        struct node *min = t->right;
+        while (min->left) {
+            minp = &min->left;
+            min = min->left;
+        }
+        t->key = min->key;
+        struct node *child = min->right;
+        free(min);
+        *minp = child;
+    }
+    return *p;
+}
+
+static void walk(const struct node *n,
+                 void (*action)(const void *, VISIT, int), int level)
+{
+    if (!n)
+        return;
+    if (!n->left && !n->right) {
+        action(&n->key, leaf, level);
+        return;
+    }
+    action(&n->key, preorder, level);
+    if (n->left)
+        walk(n->left, action, level + 1);
+    action(&n->key, postorder, level);
+    if (n->right)
+        walk(n->right, action, level + 1);
+    action(&n->key, endorder, level);
+}
+
+void twalk(const void *root, void (*action)(const void *, VISIT, int))
+{
+    walk((const struct node *)root, action, 0);
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -4045,6 +4045,33 @@ static const char *test_hsearch_basic(void)
     return 0;
 }
 
+static int tree_sum;
+static void sum_action(const void *node, VISIT v, int lvl)
+{
+    (void)lvl;
+    if (v == postorder || v == leaf)
+        tree_sum += *(const int *)node;
+}
+
+static const char *test_tsearch_basic(void)
+{
+    void *root = NULL;
+    int vals[] = {4, 2, 7, 1, 6};
+    for (int i = 0; i < 5; i++)
+        mu_assert("insert", tsearch(&vals[i], &root, int_cmp) != NULL);
+
+    int *p = tfind(&vals[2], &root, int_cmp);
+    mu_assert("find 7", p && *p == 7);
+
+    tdelete(&vals[1], &root, int_cmp);
+    mu_assert("deleted", tfind(&vals[1], &root, int_cmp) == NULL);
+
+    tree_sum = 0;
+    twalk(root, sum_action);
+    mu_assert("walk sum", tree_sum == 18);
+    return 0;
+}
+
 static const char *test_regex_backref_basic(void)
 {
     regex_t re;
@@ -4633,6 +4660,7 @@ static const char *all_tests(void)
     mu_run_test(test_qsort_strings);
     mu_run_test(test_qsort_r_desc);
     mu_run_test(test_hsearch_basic);
+    mu_run_test(test_tsearch_basic);
     mu_run_test(test_regex_backref_basic);
     mu_run_test(test_regex_backref_fail);
     mu_run_test(test_regex_posix_class);


### PR DESCRIPTION
## Summary
- implement binary search tree helpers `tsearch`, `tfind`, `tdelete` and `twalk`
- expose new prototypes in `<search.h>`
- document usage in utilities guide
- add a regression test exercising the API
- mention feature in README

## Testing
- `make -j$(nproc)` *(fails: truncated output due to environment limits but lib built)*
- `make test` *(fails: interrupted in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_685d7afbd8cc8324ad9b0d033a9a6195