### PR TITLE
Add getloadavg support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,7 @@ SRC := \
     src/sysconf.c \
     src/syslog.c \
     src/getline.c \
+    src/getloadavg.c \
     src/getpass.c \
     src/crypt.c \
     src/getlogin.c \

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ programs. Key features include:
   On NetBSD the native timer syscalls are used when present, with a
   kqueue fallback otherwise.
 - Resource usage statistics with `getrusage()`
+- Retrieve system load averages with `getloadavg()`
 - Basic character set conversion with `iconv`
 - Register quick-exit handlers with `at_quick_exit()` and trigger them via
   `quick_exit()`

--- a/docs/process.md
+++ b/docs/process.md
@@ -485,3 +485,10 @@ if (n > 0 && n < sizeof(path))
     printf("search path: %s\n", path);
 ```
 
+## Load Average
+
+`getloadavg()` fills an array with the 1, 5 and 15 minute system load
+averages. The function writes up to three values and returns the count
+stored or `-1` on error. BSD systems retrieve the numbers via a `sysctl`
+query while Linux parses `/proc/loadavg`.
+

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -77,6 +77,9 @@ void srand48(long seedval);
 unsigned short *seed48(unsigned short seed16v[3]);
 void lcong48(unsigned short param[7]);
 
+/* System load averages */
+int getloadavg(double loadavg[], int nelem);
+
 /* Register a function to run at normal process exit */
 int atexit(void (*fn)(void));
 

--- a/src/getloadavg.c
+++ b/src/getloadavg.c
@@ -1,0 +1,46 @@
+#include "stdlib.h"
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__) || defined(__APPLE__)
+#include <sys/sysctl.h>
+#include <sys/param.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+int getloadavg(double loadavg[], int nelem)
+{
+    if (!loadavg || nelem <= 0)
+        return 0;
+    struct loadavg load;
+    size_t len = sizeof(load);
+    int mib[2] = { CTL_VM, VM_LOADAVG };
+    if (sysctl(mib, 2, &load, &len, NULL, 0) == -1)
+        return -1;
+    int n = nelem > 3 ? 3 : nelem;
+    for (int i = 0; i < n; i++)
+        loadavg[i] = (double)load.ldavg[i] / load.fscale;
+    return n;
+}
+
+#else /* Linux and others */
+#include "stdio.h"
+
+int getloadavg(double loadavg[], int nelem)
+{
+    if (!loadavg || nelem <= 0)
+        return 0;
+    FILE *f = fopen("/proc/loadavg", "r");
+    if (!f)
+        return -1;
+    double a = 0.0, b = 0.0, c = 0.0;
+    int r = fscanf(f, "%lf %lf %lf", &a, &b, &c);
+    fclose(f);
+    if (r < 3)
+        return -1;
+    int n = nelem > 3 ? 3 : nelem;
+    if (n >= 1) loadavg[0] = a;
+    if (n >= 2) loadavg[1] = b;
+    if (n >= 3) loadavg[2] = c;
+    return n;
+}
+#endif

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2381,6 +2381,16 @@ static const char *test_times_self(void)
     return 0;
 }
 
+static const char *test_getloadavg_basic(void)
+{
+    double l[3];
+    int n = getloadavg(l, 3);
+    mu_assert("getloadavg", n >= 1);
+    for (int i = 0; i < n; ++i)
+        mu_assert("nonnegative", l[i] >= 0.0);
+    return 0;
+}
+
 static const char *test_strftime_basic(void)
 {
     struct tm tm = {
@@ -4561,6 +4571,7 @@ static const char *all_tests(void)
     mu_run_test(test_clock_settime_priv);
     mu_run_test(test_getrusage_self);
     mu_run_test(test_times_self);
+    mu_run_test(test_getloadavg_basic);
     mu_run_test(test_strftime_basic);
     mu_run_test(test_strftime_extended);
     mu_run_test(test_wcsftime_basic);


### PR DESCRIPTION
## Summary
- implement `getloadavg` using BSD `sysctl` or Linux `/proc/loadavg`
- expose `getloadavg` in `<stdlib.h>`
- document the function in process docs
- test that returned load averages are nonnegative
- mention load average retrieval in README
- include new source in build

## Testing
- `make test` *(fails: command timed out or exceeded resource limits)*

------
https://chatgpt.com/codex/tasks/task_e_685d7d0014c883248f7517fbe9a86f4b