### PR TITLE
Add group membership utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ programs. Key features include:
 - Thread-safe user and group lookups with `getpwuid_r`, `getpwnam_r`,
   `getgrgid_r`, and `getgrnam_r`
 - Enumerate all users or groups with `getpwent()` and `getgrent()`
+- Query supplementary groups with `getgrouplist()` and initialize them
+  with `initgroups()`
 - Secure password input with `getpass()`
 - Password hashing with `crypt()`
 - Syslog-style logging

--- a/docs/users_groups.md
+++ b/docs/users_groups.md
@@ -73,3 +73,21 @@ thread-safe.
 order.  As with the passwd enumeration, BSD platforms use the host
 libc while other systems parse `/etc/group` directly.
 
+## Group Membership
+
+Applications can inspect or modify a user's supplementary groups.
+
+```c
+int getgrouplist(const char *user, gid_t basegid,
+                 gid_t *groups, int *ngroups);
+int initgroups(const char *user, gid_t basegid);
+```
+
+`getgrouplist` fills `groups` with the IDs for `user`, starting with
+`basegid`.  `*ngroups` specifies the array capacity and on return holds
+the number of groups found.  If the buffer is too small the function
+returns `-1` and updates `*ngroups` with the required size.
+
+`initgroups` calls `setgroups()` to apply the list retrieved by
+`getgrouplist`.  It typically requires appropriate privileges.
+

--- a/include/grp.h
+++ b/include/grp.h
@@ -25,5 +25,7 @@ int getgrnam_r(const char *name, struct group *grp, char *buf, size_t buflen,
 void setgrent(void);
 struct group *getgrent(void);
 void endgrent(void);
+int getgrouplist(const char *user, gid_t group, gid_t *groups, int *ngroups);
+int initgroups(const char *user, gid_t group);
 
 #endif /* GRP_H */


### PR DESCRIPTION
## Summary
- implement `getgrouplist` and `initgroups`
- expose prototypes in `grp.h`
- document supplementary group helpers
- note new functions in the README
- test group list parsing

## Testing
- `make test` *(fails: build incomplete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685d7fb78ef88324bf732832bcd325f6