### PR TITLE
Add timespec_get helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ SRC := \
     src/clock_settime.c \
     src/time.c \
     src/time_conv.c \
+    src/timespec_get.c \
     src/time_r.c \
     src/times.c \
     src/itimer.c \

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ clock_gettime(CLOCK_MONOTONIC, &ts);
 `CLOCK_REALTIME` returns the wall-clock time.
 `clock_settime` adjusts it when privileges allow.
 `clock_getres` queries the resolution of a given clock.
+`timespec_get` fills a `struct timespec` when passed `TIME_UTC`.
 Use `difftime` to compute the difference between two `time_t` values.
 
 ## Time Formatting

--- a/docs/time.md
+++ b/docs/time.md
@@ -61,6 +61,15 @@ struct timespec ts;
 clock_gettime(CLOCK_REALTIME, &ts);
 ```
 
+The C11 helper `timespec_get` fills a `struct timespec` using `TIME_UTC`:
+
+```c
+struct timespec ts;
+if (timespec_get(&ts, TIME_UTC)) {
+    /* ts now holds the current time */
+}
+```
+
 The resolution of a clock can be determined with `clock_getres`:
 
 ```c

--- a/include/time.h
+++ b/include/time.h
@@ -98,6 +98,9 @@ typedef struct vlibc_timer *timer_t;
 #ifndef CLOCK_MONOTONIC
 #define CLOCK_MONOTONIC 1
 #endif
+#ifndef TIME_UTC
+#define TIME_UTC 1
+#endif
 
 int clock_gettime(int clk_id, struct timespec *ts);
 /*
@@ -130,6 +133,11 @@ int gettimeofday(struct timeval *tv, void *tz);
  * Populate *tv with CLOCK_REALTIME expressed in seconds and
  * microseconds. Implemented via SYS_time or SYS_clock_gettime
  * with a host fallback when unavailable.
+ */
+int timespec_get(struct timespec *ts, int base);
+/*
+ * Fill *ts with the current time when base is TIME_UTC. Returns
+ * base on success and 0 on failure.
  */
 
 /* sleep helpers */

--- a/src/timespec_get.c
+++ b/src/timespec_get.c
@@ -1,0 +1,19 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the copyright
+ * notice and this permission notice appear in all copies. This software is
+ * provided "as is" without warranty.
+ *
+ * Purpose: Implements the C11 timespec_get helper for vlibc.
+ */
+
+#include "time.h"
+
+int timespec_get(struct timespec *ts, int base)
+{
+    if (base != TIME_UTC)
+        return 0;
+    if (clock_gettime(CLOCK_REALTIME, ts) != 0)
+        return 0;
+    return base;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2399,6 +2399,15 @@ static const char *test_getloadavg_basic(void)
     return 0;
 }
 
+static const char *test_timespec_get_basic(void)
+{
+    struct timespec ts;
+    int r = timespec_get(&ts, TIME_UTC);
+    mu_assert("timespec_get ret", r == TIME_UTC);
+    mu_assert("timespec_get sec", ts.tv_sec > 0);
+    return 0;
+}
+
 static const char *test_strftime_basic(void)
 {
     struct tm tm = {
@@ -4611,6 +4620,7 @@ static const char *all_tests(void)
     mu_run_test(test_getrusage_self);
     mu_run_test(test_times_self);
     mu_run_test(test_getloadavg_basic);
+    mu_run_test(test_timespec_get_basic);
     mu_run_test(test_strftime_basic);
     mu_run_test(test_strftime_extended);
     mu_run_test(test_wcsftime_basic);


### PR DESCRIPTION
## Summary
- implement `timespec_get` for TIME_UTC
- expose prototype and constant in `time.h`
- document the helper in the time guide
- mention the new function in the README
- test `timespec_get`

## Testing
- `make test` *(fails: build interrupted due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685d80ed114c8324b1e3d932a3f72b62