### PR TITLE
Implement ftok and add tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ SRC := \
     src/pathconf.c \
     src/mkfifo.c \
     src/mknod.c \
+    src/ftok.c \
     $(SYS_SRC) \
     src/mmap.c \
     src/msync.c \

--- a/docs/sysv_ipc.md
+++ b/docs/sysv_ipc.md
@@ -5,7 +5,9 @@
 vlibc exposes thin wrappers around the classical System‑V IPC
 facilities.  When running on BSD the native C library functions are
 invoked directly, while on Linux the wrappers issue the corresponding
-syscalls.
+syscalls.  The `ftok()` helper converts a pathname and project identifier
+into a `key_t` using inode and device numbers so that cooperating
+processes can agree on the same key.
 
 ### Example
 
@@ -16,7 +18,8 @@ syscalls.
 
 int main(void)
 {
-    int shmid = shmget(IPC_PRIVATE, 4096, IPC_CREAT | 0600);
+    key_t key = ftok("/tmp/app", 'v');
+    int shmid = shmget(key, 4096, IPC_CREAT | 0600);
     void *mem = shmat(shmid, NULL, 0);
 
     int semid = semget(IPC_PRIVATE, 1, IPC_CREAT | 0600);

--- a/src/ftok.c
+++ b/src/ftok.c
@@ -1,0 +1,22 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Portable implementation of ftok using stat and
+ *          the inode/device algorithm.
+ */
+
+#include "sys/ipc.h"
+#include "sys/stat.h"
+#include "stdint.h"
+#include "errno.h"
+
+key_t ftok(const char *pathname, int proj_id)
+{
+    struct stat st;
+    if (stat(pathname, &st) != 0)
+        return (key_t)-1;
+
+    return (key_t)((st.st_ino & 0xffff) |
+                   ((st.st_dev & 0xff) << 16) |
+                   ((proj_id & 0xff) << 24));
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3600,6 +3600,28 @@ static const char *test_sysv_sem_basic(void)
     return 0;
 }
 
+static const char *test_ftok_unique(void)
+{
+    char path1[] = "/tmp/vlibc_ftok1XXXXXX";
+    char path2[] = "/tmp/vlibc_ftok2XXXXXX";
+    int fd1 = mkstemp(path1);
+    int fd2 = mkstemp(path2);
+    mu_assert("mkstemp1", fd1 >= 0);
+    mu_assert("mkstemp2", fd2 >= 0);
+    close(fd1);
+    close(fd2);
+
+    key_t k1 = ftok(path1, 'A');
+    key_t k2 = ftok(path2, 'A');
+    mu_assert("ftok1", k1 != (key_t)-1);
+    mu_assert("ftok2", k2 != (key_t)-1);
+    mu_assert("unique keys", k1 != k2);
+
+    unlink(path1);
+    unlink(path2);
+    return 0;
+}
+
 static const char *test_atexit_handler(void)
 {
     mu_assert("pipe", pipe(exit_pipe) == 0);
@@ -4672,6 +4694,7 @@ static const char *all_tests(void)
     mu_run_test(test_mqueue_basic);
     mu_run_test(test_named_semaphore_create);
     mu_run_test(test_sysv_sem_basic);
+    mu_run_test(test_ftok_unique);
     mu_run_test(test_atexit_handler);
     mu_run_test(test_quick_exit_handler);
     mu_run_test(test_getcwd_chdir);


### PR DESCRIPTION
## Summary
- implement `ftok` using inode and device numbers
- compile new source
- document System V IPC key generation
- test that unique paths give different keys

## Testing
- `make test` *(fails: interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685d81148b2c83249f0271825a4279e6