### PR TITLE
Implement sigsetjmp and siglongjmp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,7 @@ SRC := \
     src/vis.c \
     src/wprintf.c \
     src/wscanf.c \
+    src/sigsetjmp.c \
     src/progname.c
 
 ARCH_SRC := $(wildcard src/arch/$(ARCH)/*.c)

--- a/docs/other.md
+++ b/docs/other.md
@@ -43,10 +43,13 @@ For targets lacking a native implementation, custom versions live under
 ```c
 int setjmp(jmp_buf env);
 void longjmp(jmp_buf env, int val);
+int sigsetjmp(sigjmp_buf env, int save);
+void siglongjmp(sigjmp_buf env, int val);
 ```
 
-Jumping across signal handlers may leave blocked signals in an undefined
-state.
+Passing a non-zero `save` stores the current signal mask so that
+`siglongjmp` can restore it.  Jumping across signal handlers without
+saving the mask may leave blocked signals in an undefined state.
 
 ## Floating-Point Environment
 
@@ -87,8 +90,9 @@ speeds stored in a `termios` structure are changed with `cfsetispeed()` and
   [process.md](process.md).
 - Locale handling falls back to the host implementation for values other
   than `"C"` or `"POSIX"`.
-- `setjmp`/`longjmp` rely on the host C library when available.
-  Only an x86_64 fallback implementation is provided.
+- `setjmp`/`longjmp` and `sigsetjmp`/`siglongjmp` rely on the host C library
+  when available. Only an x86_64 fallback implementation is provided and
+  the signal-mask fields follow glibc's layout.
 - Regular expressions cover only a subset of POSIX syntax. Capture
   groups and numeric backreferences are supported but more advanced
   features remain unimplemented.

--- a/include/setjmp.h
+++ b/include/setjmp.h
@@ -12,4 +12,15 @@
 #  endif
 #endif
 
+#ifndef sigjmp_buf
+typedef jmp_buf sigjmp_buf;
+#endif
+
+#ifndef sigsetjmp
+int sigsetjmp(sigjmp_buf env, int save);
+#endif
+#ifndef siglongjmp
+void siglongjmp(sigjmp_buf env, int val);
+#endif
+
 #endif /* SETJMP_H */

--- a/src/sigsetjmp.c
+++ b/src/sigsetjmp.c
@@ -1,0 +1,42 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the copyright notice and
+ * this permission notice appear in all copies. This software is provided "as is" without warranty.
+ *
+ * Purpose: Implements sigsetjmp and siglongjmp for vlibc.
+ */
+
+#include "setjmp.h"
+#include <setjmp.h>
+#include "signal.h"
+
+#ifdef setjmp
+#undef setjmp
+#endif
+#ifdef longjmp
+#undef longjmp
+#endif
+#ifdef sigsetjmp
+#undef sigsetjmp
+#endif
+#ifdef siglongjmp
+#undef siglongjmp
+#endif
+
+int sigsetjmp(sigjmp_buf env, int save)
+{
+    if (save) {
+        env[0].__mask_was_saved = 1;
+        sigprocmask(SIG_BLOCK, NULL, &env[0].__saved_mask);
+    } else {
+        env[0].__mask_was_saved = 0;
+    }
+    return setjmp(env);
+}
+
+void siglongjmp(sigjmp_buf env, int val)
+{
+    if (env[0].__mask_was_saved)
+        sigprocmask(SIG_SETMASK, &env[0].__saved_mask, NULL);
+    longjmp(env, val);
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -66,6 +66,7 @@
 #include <errno.h>
 #include <sys/wait.h>
 #include <signal.h>
+#include "../include/setjmp.h"
 #include "../include/time.h"
 #include "../include/sys/resource.h"
 #include "../include/sys/times.h"
@@ -3535,6 +3536,48 @@ static const char *test_sigaltstack_basic(void)
     return 0;
 }
 
+static sigjmp_buf jbuf1;
+static const char *test_sigsetjmp_restore(void)
+{
+    sigset_t set, cur;
+    sigemptyset(&set);
+    sigaddset(&set, SIGUSR1);
+    sigprocmask(SIG_BLOCK, &set, NULL);
+
+    if (sigsetjmp(jbuf1, 1) == 0) {
+        sigprocmask(SIG_UNBLOCK, &set, NULL);
+        sigprocmask(SIG_BLOCK, NULL, &cur);
+        mu_assert("unblock", sigismember(&cur, SIGUSR1) == 0);
+        siglongjmp(jbuf1, 1);
+    }
+
+    sigprocmask(SIG_BLOCK, NULL, &cur);
+    int blocked = sigismember(&cur, SIGUSR1);
+    sigprocmask(SIG_UNBLOCK, &set, NULL);
+    mu_assert("restored", blocked == 1);
+    return 0;
+}
+
+static sigjmp_buf jbuf2;
+static const char *test_sigsetjmp_nosave(void)
+{
+    sigset_t set, cur;
+    sigemptyset(&set);
+    sigaddset(&set, SIGUSR1);
+    sigprocmask(SIG_BLOCK, &set, NULL);
+
+    if (sigsetjmp(jbuf2, 0) == 0) {
+        sigprocmask(SIG_UNBLOCK, &set, NULL);
+        siglongjmp(jbuf2, 1);
+    }
+
+    sigprocmask(SIG_BLOCK, NULL, &cur);
+    int blocked = sigismember(&cur, SIGUSR1);
+    sigprocmask(SIG_UNBLOCK, &set, NULL);
+    mu_assert("not restored", blocked == 0);
+    return 0;
+}
+
 static const char *test_mlock_basic(void)
 {
     char buf[128];
@@ -4783,6 +4826,8 @@ static const char *all_tests(void)
     mu_run_test(test_sigtimedwait_timeout);
     mu_run_test(test_sigqueue_value);
     mu_run_test(test_sigaltstack_basic);
+    mu_run_test(test_sigsetjmp_restore);
+    mu_run_test(test_sigsetjmp_nosave);
     mu_run_test(test_mlock_basic);
     mu_run_test(test_mprotect_anon);
     mu_run_test(test_shm_basic);


### PR DESCRIPTION
## Summary
- declare `sigsetjmp` and `siglongjmp`
- implement wrappers storing optional signal mask
- document usage caveats
- test restoration of signal masks

## Testing
- `make test` *(fails: environment timed out during build)*

------
https://chatgpt.com/codex/tasks/task_e_685d83d143508324aefd99a08a5dcf1e