### PR TITLE
Fix syscall failure detection

### DIFF
--- a/src/fd.c
+++ b/src/fd.c
@@ -25,7 +25,7 @@
 off_t lseek(int fd, off_t offset, int whence)
 {
     long ret = vlibc_syscall(SYS_lseek, fd, (long)offset, whence, 0, 0, 0);
-    if (ret < 0) {
+    if (ret == -1) {
         errno = -ret;
         return (off_t)-1;
     }

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -25,7 +25,14 @@ long vlibc_syscall(long number, ...)
     va_end(ap);
 
     long ret = syscall(number, a1, a2, a3, a4, a5, a6);
-    if (ret < 0)
-        return -errno;
+    /*
+     * POSIX semantics: syscall() returns -1 on failure and sets errno.
+     * Negative values other than -1 are valid results for some calls,
+     * so check explicitly for -1 and propagate errno as a negative code.
+     */
+    if (ret == -1) {
+        int err = errno;
+        return -err;
+    }
     return ret;
 }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -369,6 +369,23 @@ static const char *test_lseek_dup(void)
     return 0;
 }
 
+static const char *test_lseek_negative_offset(void)
+{
+    const char *fname = "tmp_neg_seek";
+    int fd = open(fname, O_CREAT | O_RDWR, 0644);
+    mu_assert("open failed", fd >= 0);
+
+    const char *msg = "abcdef";
+    mu_assert("write", write(fd, msg, strlen(msg)) == (ssize_t)strlen(msg));
+
+    off_t off = lseek(fd, -2, SEEK_END);
+    mu_assert("seek result", off == (off_t)strlen(msg) - 2);
+
+    close(fd);
+    unlink(fname);
+    return 0;
+}
+
 static const char *test_pread_pwrite(void)
 {
     const char *fname = "tmp_pread_file";
@@ -4632,6 +4649,7 @@ static const char *all_tests(void)
     mu_run_test(test_memory_ops);
     mu_run_test(test_io);
     mu_run_test(test_lseek_dup);
+    mu_run_test(test_lseek_negative_offset);
     mu_run_test(test_pread_pwrite);
     mu_run_test(test_preadv_pwritev);
     mu_run_test(test_readv_writev);


### PR DESCRIPTION
## Summary
- handle only `-1` as failure in `vlibc_syscall`
- update `lseek` wrapper for new semantics
- add regression test for seeking with negative offset

## Testing
- `make -j4 test` *(fails: interrupted due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685d85f4062c83248fe5ffb72ed4e9e9