### PR TITLE
Fix overflow check in posix_memalign

### DIFF
--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -237,6 +237,15 @@ static const char *test_aligned_alloc(void)
     return 0;
 }
 
+static const char *test_posix_memalign_overflow(void)
+{
+    void *p = (void *)1;
+    int r = posix_memalign(&p, 16, SIZE_MAX);
+    mu_assert("overflow ENOMEM", r == ENOMEM);
+    mu_assert("memptr unchanged", p == (void *)1);
+    return 0;
+}
+
 static const char *test_reallocarray_overflow(void)
 {
     size_t big = (size_t)-1 / 2 + 1;
@@ -4783,6 +4792,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_posix_memalign_basic),
         REGISTER_TEST("default", test_posix_memalign),
         REGISTER_TEST("default", test_aligned_alloc),
+        REGISTER_TEST("default", test_posix_memalign_overflow),
         REGISTER_TEST("default", test_reallocarray_overflow),
         REGISTER_TEST("default", test_reallocarray_basic),
         REGISTER_TEST("default", test_recallocarray_grow),


### PR DESCRIPTION
## Summary
- ensure posix_memalign doesn't overflow when adding alignment and header
- test overflow handling in posix_memalign

## Testing
- `make test-memory`
- `timeout 60 make test` *(fails: terminated)*

------
https://chatgpt.com/codex/tasks/task_e_685d97218df8832488f2155d029dae3f