### PR TITLE
Fix strtol declaration warning in inet_aton

### DIFF
--- a/src/inet_aton.c
+++ b/src/inet_aton.c
@@ -9,6 +9,7 @@
 
 #include "arpa/inet.h"
 #include "stdio.h"
+#include "stdlib.h"
 #include <stdint.h>
 #include <string.h>
 


### PR DESCRIPTION
## Summary
- include `stdlib.h` so `strtol` is declared in `inet_aton.c`
- rebuild to confirm warning disappearance

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_685d9f251df48324b950208cad90672e