### PR TITLE
Fix implicit snprintf warning in shm

### DIFF
--- a/src/shm.c
+++ b/src/shm.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>
+#include "stdio.h"
 #include "syscall.h"
 
 int shm_open(const char *name, int oflag, mode_t mode)


### PR DESCRIPTION
## Summary
- include `stdio.h` in `src/shm.c`

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685d9f36e7ec83249727bd79e0e66d4a