### PR TITLE
Handle chdir failure in daemon()

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -46,8 +46,11 @@ int daemon(int nochdir, int noclose)
 #endif
 #endif
 
-    if (!nochdir)
-        chdir("/");
+    if (!nochdir) {
+        int cdret = chdir("/");
+        if (cdret < 0)
+            return -1;
+    }
     umask(0);
 
     if (!noclose) {


### PR DESCRIPTION
## Summary
- check `chdir("/")` when creating a daemon and fail on error

## Testing
- `make tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_685da05adf5c8324bcad243a6da35d0d