### PR TITLE
Fix timer malloc warnings

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -18,6 +18,7 @@
 #include <sys/event.h>
 #include <sys/time.h>
 #endif
+#include "memory.h"
 
 struct vlibc_timer {
 #if defined(__linux__) || defined(__NetBSD__)


### PR DESCRIPTION
## Summary
- include `memory.h` in `src/timer.c`

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685da04fb1f08324b5a36f764447eac7