### PR TITLE
Mark unused vfork helper

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -702,7 +702,7 @@ int posix_spawnattr_getpgroup(const posix_spawnattr_t *attr, pid_t *pgroup)
 }
 
 /* Internal helper to use vfork()/fork as available */
-static pid_t vlibc_vfork(void)
+static __attribute__((unused)) pid_t vlibc_vfork(void)
 {
 #ifdef SYS_vfork
     long ret = vlibc_syscall(SYS_vfork, 0, 0, 0, 0, 0, 0);


### PR DESCRIPTION
## Summary
- silence unused function warning in process.c

## Testing
- `make -j$(nproc)`
- `timeout 30s make test` *(fails: tests timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685da5a50f648324890b76abed04d59f