### PR TITLE
Remove null check in execvp

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -108,9 +108,6 @@ int fexecve(int fd, char *const argv[], char *const envp[])
  */
 int execvp(const char *file, char *const argv[])
 {
-    if (!file || !argv)
-        return -1;
-
     if (strchr(file, '/'))
         return execve(file, argv, environ);
 


### PR DESCRIPTION
## Summary
- rely on caller to pass valid file and argv pointers in `execvp`

## Testing
- `make test` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685da5b102c48324b651068d5e5fdcb3