### PR TITLE
Fix wcsftime memory prototypes

### DIFF
--- a/src/wcsftime.c
+++ b/src/wcsftime.c
@@ -9,6 +9,7 @@
 #include "wchar.h"
 #include "time.h"
 #include "stdlib.h"
+#include "memory.h"
 
 size_t wcsftime(wchar_t *s, size_t max, const wchar_t *format, const struct tm *tm)
 {


### PR DESCRIPTION
## Summary
- include `memory.h` in `wcsftime.c` so prototypes for `malloc`/`free` are available

## Testing
- `make clean >/dev/null && make`

------
https://chatgpt.com/codex/tasks/task_e_685da83541b08324b75ff0bdb3d54ad0