### PR TITLE
Include memory header for search_hash

### DIFF
--- a/src/search_hash.c
+++ b/src/search_hash.c
@@ -8,6 +8,7 @@
 #include "search.h"
 #include "stdlib.h"
 #include "string.h"
+#include "memory.h"
 
 static ENTRY *table;
 static unsigned char *used;


### PR DESCRIPTION
## Summary
- ensure search_hash.c includes memory.h for calloc/free declarations

## Testing
- `make src/search_hash.o`

------
https://chatgpt.com/codex/tasks/task_e_685da848927c83249115be032ad6bf9d