### PR TITLE
Fix header include in wchar_conv

### DIFF
--- a/src/wchar_conv.c
+++ b/src/wchar_conv.c
@@ -10,6 +10,7 @@
 #include_next <wchar.h>
 #include "string.h"
 #include "stdlib.h"
+#include "memory.h"
 
 extern size_t host_mbrtowc(wchar_t *, const char *, size_t, mbstate_t *) __asm__("mbrtowc");
 extern size_t host_wcrtomb(char *, wchar_t, mbstate_t *) __asm__("wcrtomb");


### PR DESCRIPTION
## Summary
- include memory.h in `wchar_conv.c`

## Testing
- `make -B src/wchar_conv.o`

------
https://chatgpt.com/codex/tasks/task_e_685da9948de48324be7f5530d387fd21