### PR TITLE
Add stdlib include to crypt.c

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -62,6 +62,7 @@
 #include <arpa/inet.h>
 #include <pwd.h>
 #include <string.h>
+#include "stdlib.h"
 #include <alloca.h>
 #include <openssl/md5.h>
 #include <openssl/sha.h>


### PR DESCRIPTION
## Summary
- include `stdlib.h` in `src/crypt.c`

## Testing
- `make test` *(fails: interrupted due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685da9a329c88324b47de17ef20d37bd