### PR TITLE
Fix missing memory header include

### DIFF
--- a/src/search_tree.c
+++ b/src/search_tree.c
@@ -7,6 +7,7 @@
 
 #include "search.h"
 #include "stdlib.h"
+#include "memory.h"
 
 struct node {
     const void *key;


### PR DESCRIPTION
## Summary
- include `memory.h` in `search_tree.c`

## Testing
- `make test` *(fails: command interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685da9896138832488eac64e2b28e99e