### PR TITLE
Fix unused function warning

### DIFF
--- a/src/search_tree.c
+++ b/src/search_tree.c
@@ -15,7 +15,7 @@ struct node {
     struct node *right;
 };
 
-static void *node_key(struct node *n)
+static __attribute__((unused)) void *node_key(struct node *n)
 {
     return n ? (void *)&n->key : NULL;
 }


### PR DESCRIPTION
## Summary
- mark `node_key` in `search_tree.c` as `unused`
- verify build finishes without `-Wunused-function` warnings

## Testing
- `make clean >/dev/null`
- `make > /tmp/make.log`

------
https://chatgpt.com/codex/tasks/task_e_685dab93c2bc8324bbde2c863206afda