### PR TITLE
Fix missing sprintf prototype

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -62,6 +62,7 @@
 #include <arpa/inet.h>
 #include <pwd.h>
 #include <string.h>
+#include "stdio.h"
 #include "stdlib.h"
 #include <alloca.h>
 #include <openssl/md5.h>


### PR DESCRIPTION
## Summary
- include `stdio.h` in `crypt.c` for `sprintf`

## Testing
- `make test` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685dadb70c388324815a4c99a3d02662