### PR TITLE
Add memory.h include to grp.c

### DIFF
--- a/src/grp.c
+++ b/src/grp.c
@@ -10,6 +10,7 @@
 #include "io.h"
 #include "string.h"
 #include "stdlib.h"
+#include "memory.h"
 #include "env.h"
 #include <fcntl.h>
 #include <unistd.h>


### PR DESCRIPTION
## Summary
- include `memory.h` so malloc and free prototypes are available

## Testing
- `make test` *(fails: build interrupted due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685dadc26c7c832492f0edf05f4fdc3c