### PR TITLE
Fix ftw memory header

### DIFF
--- a/src/ftw.c
+++ b/src/ftw.c
@@ -10,6 +10,7 @@
 #include "dirent.h"
 #include "string.h"
 #include "stdlib.h"
+#include "memory.h"
 #include "errno.h"
 #include "unistd.h"
 #include "sys/stat.h"


### PR DESCRIPTION
## Summary
- include memory management declarations in `ftw.c`

## Testing
- `make test` *(fails: cc and link steps run but test binary not produced due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685dadce13b48324b7cb5304bf9b1c27