### PR TITLE
Fix sigset_t operations for struct type

### DIFF
--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3132,7 +3132,7 @@ static const char *test_system_interrupted(void)
     struct sigaction sa;
     sa.sa_handler = handle_usr1;
     sa.sa_flags = 0;
-    sa.sa_mask = 0;
+    sigemptyset(&sa.sa_mask);
     sigaction(SIGUSR1, &sa, NULL);
 
     pthread_t t;
@@ -3593,7 +3593,7 @@ static const char *test_sigaction_install(void)
     got_signal = 0;
     struct sigaction sa;
     sa.sa_handler = handle_usr1;
-    sa.sa_mask = 0;
+    sigemptyset(&sa.sa_mask);
     sa.sa_flags = 0;
     mu_assert("sigaction", sigaction(SIGUSR1, &sa, NULL) == 0);
     kill(getpid(), SIGUSR1);
@@ -3606,7 +3606,7 @@ static const char *test_sigprocmask_block(void)
     got_signal = 0;
     struct sigaction sa;
     sa.sa_handler = handle_usr1;
-    sa.sa_mask = 0;
+    sigemptyset(&sa.sa_mask);
     sa.sa_flags = 0;
     sigaction(SIGUSR1, &sa, NULL);
     sigset_t mask;


### PR DESCRIPTION
## Summary
- handle platforms where `sigset_t` is a struct
- include `string.h` for `vmemset`
- adjust tests to use `sigemptyset` instead of direct assignment

## Testing
- `make src/signal.o`
- `make`
- `make test` *(fails: tests hang or require unavailable features)*

------
https://chatgpt.com/codex/tasks/task_e_685df2fcea4483249aa13d176f4b9291