### PR TITLE
Improve pthread condition variables

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -29,7 +29,8 @@ typedef struct {
 #define PTHREAD_MUTEX_RECURSIVE 1
 
 typedef struct {
-    atomic_int seq;
+    atomic_int seq;  /* number of signals issued */
+    atomic_int next; /* next ticket for waiting threads */
 } pthread_cond_t;
 
 typedef struct {


### PR DESCRIPTION
## Summary
- fix condition variable semantics so `pthread_cond_signal` wakes only one waiter
- implement proper broadcast behavior
- add unit tests for both signal and broadcast

## Testing
- `make -j4`
- `make test` *(fails: timed out or hangs)*

------
https://chatgpt.com/codex/tasks/task_e_685dfb70c6e883249d08407d1b47f8a9