### PR TITLE
Update docs to list test categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,13 +361,14 @@ Example tests live in the `tests/` directory. Run them with:
 make test
 ```
 
-Set `TEST_GROUP` to run only a subset:
+Set `TEST_GROUP` to run only a subset. Available groups are `default`,
+`memory`, `network`, and `fdopen`:
 
 ```sh
-make test TEST_GROUP=memory
+make test TEST_GROUP=fdopen
 ```
 
-Convenience targets are also available:
+Convenience targets are available for the `memory` and `network` groups:
 
 ```sh
 make test-memory
@@ -377,9 +378,10 @@ make test-network
 This builds the test binary and exercises many of the library functions.
 
 Tests are organized into categories that can be run individually.  The
-`default` group contains the standard suite.  To run only a specific
-group pass its name to the test binary or provide the `TEST_GROUP`
-variable when invoking `make`:
+`default` group contains the standard suite.  Additional groups include
+`memory`, `network`, and `fdopen`.  To run only a specific group pass its
+name to the test binary or provide the `TEST_GROUP` variable when invoking
+`make`:
 
 ```sh
 ./tests/run_tests default

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -56,13 +56,18 @@ make install PREFIX=/usr/local
 make test
 ```
 
-You can run a subset using the `TEST_GROUP` variable or convenience targets:
+You can run a subset by setting the `TEST_GROUP` variable or by invoking one of
+the convenience targets:
 
 ```sh
-make test TEST_GROUP=memory
-make test-memory
-make test-network
+make test TEST_GROUP=memory   # run only memory tests
+make test TEST_GROUP=fdopen   # run fdopen related tests
+make test-memory              # same as TEST_GROUP=memory
+make test-network             # same as TEST_GROUP=network
 ```
 
-This builds `tests/run_tests` and executes the suite.
+Available groups are `default`, `memory`, `network`, and `fdopen`. You can also
+pass a group name directly to `tests/run_tests`.
+
+This builds `tests/run_tests` and executes the selected category.
 


### PR DESCRIPTION
## Summary
- explain test categories in overview
- document same groups in README

## Testing
- `make test TEST_GROUP=fdopen` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685e0dd86ba88324916e0801dc1c6995