### PR TITLE
Fix stpncpy return pointer

### DIFF
--- a/src/string_extra.c
+++ b/src/string_extra.c
@@ -264,7 +264,7 @@ char *stpncpy(char *dest, const char *src, size_t n)
     }
     if (n) {
         vmemset(d, 0, n);
-        return d;
+        return d + n;
     }
     return d;
 }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1227,6 +1227,11 @@ static const char *test_stpcpy_functions(void)
     mu_assert("stpncpy trunc", p == buf3 + 3);
     mu_assert("stpncpy trunc str", strncmp(buf3, "xyz", 3) == 0);
 
+    char buf4[8];
+    p = stpncpy(buf4, "hi", 6);
+    mu_assert("stpncpy pad end", p == buf4 + 6);
+    mu_assert("stpncpy pad str", strcmp(buf4, "hi") == 0 && buf4[2] == '\0');
+
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- fix pointer returned when stpncpy pads with zeros
- test stpncpy pointer for padded copies

## Testing
- `make test` *(fails: build takes too long)*

------
https://chatgpt.com/codex/tasks/task_e_685eb04825b08324a1d33f35cea08448