### PR TITLE
Fix aligned_alloc size check

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -47,7 +47,8 @@ void *aligned_alloc(size_t alignment, size_t size);
   alignment. It returns `0` on success, `EINVAL` if the alignment is not a power
   of two or not a multiple of `sizeof(void *)`, or `ENOMEM` when the allocation
   fails.
-- `aligned_alloc` wraps `posix_memalign` and returns `NULL` on failure.
+- `aligned_alloc` wraps `posix_memalign` and returns `NULL` on failure or when
+  `size` is not a multiple of `alignment`.
 
 ```c
 void *p;

--- a/src/memory.c
+++ b/src/memory.c
@@ -273,6 +273,9 @@ int posix_memalign(void **memptr, size_t alignment, size_t size)
  */
 void *aligned_alloc(size_t alignment, size_t size)
 {
+    if (size % alignment != 0)
+        return NULL;
+
     void *ptr = NULL;
     if (posix_memalign(&ptr, alignment, size) != 0)
         return NULL;

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -242,6 +242,20 @@ static const char *test_aligned_alloc(void)
     return 0;
 }
 
+static const char *test_aligned_alloc_bad_size(void)
+{
+    void *p = aligned_alloc(32, 48);
+    mu_assert("bad size NULL", p == NULL);
+    return 0;
+}
+
+static const char *test_aligned_alloc_bad_alignment(void)
+{
+    void *p = aligned_alloc(24, 48);
+    mu_assert("bad alignment NULL", p == NULL);
+    return 0;
+}
+
 static const char *test_posix_memalign_overflow(void)
 {
     void *p = (void *)1;
@@ -5092,6 +5106,8 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("memory", test_posix_memalign_basic),
         REGISTER_TEST("memory", test_posix_memalign),
         REGISTER_TEST("memory", test_aligned_alloc),
+        REGISTER_TEST("memory", test_aligned_alloc_bad_size),
+        REGISTER_TEST("memory", test_aligned_alloc_bad_alignment),
         REGISTER_TEST("memory", test_posix_memalign_overflow),
         REGISTER_TEST("memory", test_malloc_overflow),
         REGISTER_TEST("memory", test_calloc_overflow),


### PR DESCRIPTION
## Summary
- return `NULL` when `size` is not a multiple of `alignment`
- document the new behavior
- test invalid `aligned_alloc` usage

## Testing
- `make -s -j5 test-memory` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685ec1a00120832496c7db67b70443fa