### PR TITLE
Fix env memory leak on overwrite

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -66,6 +66,8 @@ int setenv(const char *name, const char *value, int overwrite)
     entry[nlen + 1 + vlen] = '\0';
 
     if (idx >= 0) {
+        if (environ_owned)
+            free(environ[idx]);
         environ[idx] = entry;
         return 0;
     }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3053,6 +3053,18 @@ static const char *test_env_init_clearenv(void)
     return 0;
 }
 
+static const char *test_setenv_overwrite_loop(void)
+{
+    env_init(NULL);
+    for (int i = 0; i < 100; i++) {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "v%d", i);
+        mu_assert("setenv", setenv("OVERRIDE", buf, 1) == 0);
+    }
+    clearenv();
+    return 0;
+}
+
 static const char *test_locale_from_env(void)
 {
     env_init(NULL);
@@ -5114,6 +5126,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("memory", test_reallocarray_overflow),
         REGISTER_TEST("memory", test_reallocarray_basic),
         REGISTER_TEST("memory", test_recallocarray_grow),
+        REGISTER_TEST("memory", test_setenv_overwrite_loop),
         REGISTER_TEST("memory", test_memory_ops),
         REGISTER_TEST("default", test_io),
         REGISTER_TEST("default", test_lseek_dup),


### PR DESCRIPTION
## Summary
- free old environment string when overwriting entries
- add test for repeatedly overwriting the same variable

## Testing
- `cc -Iinclude /tmp/overwrite_test.c libvlibc.a -lpthread -lm -o /tmp/overwrite_test`
- `valgrind --leak-check=full /tmp/overwrite_test`

------
https://chatgpt.com/codex/tasks/task_e_685ecb4b03b88324a9afabe959dd3ea1