### PR TITLE
Improve tmpnam safety

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -59,6 +59,9 @@ typedef struct {
 #ifndef BUFSIZ
 #define BUFSIZ 1024
 #endif
+#ifndef L_tmpnam
+#define L_tmpnam 20
+#endif
 
 extern FILE *stdin;
 extern FILE *stdout;
@@ -123,6 +126,7 @@ int pclose(FILE *stream);
 
 int mkstemp(char *template);
 FILE *tmpfile(void);
+/* Buffer must hold at least L_tmpnam characters or be NULL */
 char *tmpnam(char *s);
 char *tempnam(const char *dir, const char *pfx);
 

--- a/src/tempfile.c
+++ b/src/tempfile.c
@@ -95,7 +95,14 @@ FILE *tmpfile(void)
 
 char *tmpnam(char *s)
 {
-    static char buf[32];
+    static char buf[L_tmpnam];
+    if (s) {
+        size_t sz = __builtin_object_size(s, 0);
+        if (sz != (size_t)-1 && sz < L_tmpnam) {
+            errno = ERANGE;
+            return NULL;
+        }
+    }
     char *out = s ? s : buf;
     strcpy(out, "/tmp/vlibcXXXXXX");
     int fd = mkstemp(out);

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3760,6 +3760,18 @@ static const char *test_temp_files(void)
     mu_assert("tmpnam open", fd >= 0);
     close(fd);
     unlink(name);
+
+    char small[8];
+    errno = 0;
+    mu_assert("tmpnam ERANGE", tmpnam(small) == NULL && errno == ERANGE);
+
+    char buf2[L_tmpnam];
+    errno = 0;
+    mu_assert("tmpnam sized", tmpnam(buf2) == buf2);
+    fd = open(buf2, O_RDWR | O_CREAT | O_EXCL, 0600);
+    mu_assert("tmpnam open2", fd >= 0);
+    close(fd);
+    unlink(buf2);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- define `L_tmpnam` constant
- clarify `tmpnam` buffer requirements in stdio.h
- add size checks and ERANGE error handling in `tmpnam`
- test tmpnam with small and adequate buffers

## Testing
- `make -j4 tests/run_tests`
- `time ./tests/run_tests > /tmp/test.log` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_685ec9cfa824832482ce0732a885b310