### PR TITLE
Fix environment ownership and add tests

### DIFF
--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3076,6 +3076,35 @@ static const char *test_setenv_overwrite_loop(void)
     return 0;
 }
 
+static const char *test_putenv_setenv_clearenv(void)
+{
+    env_init(NULL);
+    char buf[] = "VAR1=one";
+    mu_assert("putenv", putenv(buf) == 0);
+    mu_assert("getenv putenv", strcmp(getenv("VAR1"), "one") == 0);
+
+    mu_assert("setenv", setenv("VAR2", "two", 1) == 0);
+    mu_assert("getenv setenv", strcmp(getenv("VAR2"), "two") == 0);
+
+    mu_assert("clearenv", clearenv() == 0);
+    mu_assert("env empty", environ && environ[0] == NULL);
+
+    mu_assert("reuse", setenv("VAR3", "three", 1) == 0);
+    clearenv();
+    return 0;
+}
+
+static const char *test_putenv_unsetenv_stack(void)
+{
+    env_init(NULL);
+    char buf[] = "TEMP=val";
+    mu_assert("putenv", putenv(buf) == 0);
+    mu_assert("unsetenv", unsetenv("TEMP") == 0);
+    mu_assert("gone", getenv("TEMP") == NULL);
+    clearenv();
+    return 0;
+}
+
 static const char *test_locale_from_env(void)
 {
     env_init(NULL);
@@ -5308,6 +5337,8 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_environment),
         REGISTER_TEST("default", test_clearenv_fn),
         REGISTER_TEST("default", test_env_init_clearenv),
+        REGISTER_TEST("default", test_putenv_setenv_clearenv),
+        REGISTER_TEST("default", test_putenv_unsetenv_stack),
         REGISTER_TEST("default", test_locale_from_env),
         REGISTER_TEST("default", test_locale_objects),
         REGISTER_TEST("default", test_gethostname_fn),


### PR DESCRIPTION
## Summary
- duplicate environment strings when migrating so vlibc owns them
- track which env strings are owned
- only free owned strings in `unsetenv` and `clearenv`
- test `putenv`, `setenv`, and `clearenv` together

## Testing
- `make test` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685ed8ecb24483248dad3293b2a9f204