### PR TITLE
Fix INT_MIN formatting in printf

### DIFF
--- a/src/printf.c
+++ b/src/printf.c
@@ -105,8 +105,10 @@ static int vsnprintf_impl(char *str, size_t size, const char *fmt, va_list ap)
         case 'd': {
             int v = va_arg(ap, int);
             sign = v < 0;
-            len = uint_to_base(sign ? (unsigned int)-v : (unsigned int)v,
-                              10, 0, buf, sizeof(buf));
+            unsigned int uv = (unsigned int)v;
+            if (sign)
+                uv = 0u - uv;
+            len = uint_to_base(uv, 10, 0, buf, sizeof(buf));
             break;
         }
         case 'u': {

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -77,6 +77,7 @@
 #include "../include/sys/msg.h"
 #include "../include/mqueue.h"
 #include "../include/sched.h"
+#include <limits.h>
 
 /* use host printf for test output */
 int printf(const char *fmt, ...);
@@ -1731,6 +1732,12 @@ static const char *test_printf_functions(void)
 
     n = snprintf(buf, sizeof(buf), "[%.4x]", 3);
     mu_assert("precision", strcmp(buf, "[0003]") == 0);
+
+    n = snprintf(buf, sizeof(buf), "%d", INT_MIN);
+    mu_assert("snprintf INT_MIN len", n == (int)strlen(buf));
+    char *endptr;
+    mu_assert("snprintf INT_MIN value",
+              strtol(buf, &endptr, 10) == INT_MIN && *endptr == '\0');
 
     FILE *f = fopen("tmp_pf", "w");
     mu_assert("fopen failed", f != NULL);


### PR DESCRIPTION
## Summary
- handle `INT_MIN` without overflow by using unsigned math in printf
- test that `%d` handles `INT_MIN`

## Testing
- `make test`
- `timeout 15 ./tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_685edce271f88324bcd4ad8bca1c55cb