### PR TITLE
Handle spawn action allocation failure

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -583,8 +583,19 @@ int posix_spawn_file_actions_addopen(posix_spawn_file_actions_t *acts, int fd,
     a->oflag = oflag;
     a->mode = mode;
     a->path = strdup(path);
-    if (!a->path)
+    if (!a->path) {
+        acts->count--;
+        if (acts->count == 0) {
+            free(acts->actions);
+            acts->actions = NULL;
+        } else {
+            struct posix_spawn_file_action *tmp =
+                realloc(acts->actions, acts->count * sizeof(*tmp));
+            if (tmp)
+                acts->actions = tmp;
+        }
         return ENOMEM;
+    }
     return 0;
 }
 

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3696,6 +3696,25 @@ static const char *test_posix_spawn_pgroup(void)
     return 0;
 }
 
+static const char *test_posix_spawn_actions_alloc_fail(void)
+{
+    posix_spawn_file_actions_t fa;
+    posix_spawn_file_actions_init(&fa);
+
+    vlibc_test_alloc_fail_after = 1;
+    int r = posix_spawn_file_actions_addopen(&fa, 0, "/dev/null", O_RDONLY, 0);
+    mu_assert("alloc fail", r == ENOMEM);
+    mu_assert("count zero", fa.count == 0 && fa.actions == NULL);
+
+    vlibc_test_alloc_fail_after = -1;
+    r = posix_spawn_file_actions_addopen(&fa, 1, "/dev/null", O_RDONLY, 0);
+    mu_assert("alloc success", r == 0);
+    mu_assert("count one", fa.count == 1);
+
+    posix_spawn_file_actions_destroy(&fa);
+    return 0;
+}
+
 static const char *test_popen_fn(void)
 {
     FILE *f = popen("echo popen", "r");
@@ -5454,6 +5473,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_posix_spawn_actions),
         REGISTER_TEST("default", test_posix_spawn_sigmask),
         REGISTER_TEST("default", test_posix_spawn_pgroup),
+        REGISTER_TEST("default", test_posix_spawn_actions_alloc_fail),
         REGISTER_TEST("default", test_popen_fn),
         REGISTER_TEST("default", test_rand_fn),
         REGISTER_TEST("default", test_rand48_fn),


### PR DESCRIPTION
## Summary
- manage allocation failure after `strdup` in `posix_spawn_file_actions_addopen`
- add regression test for actions list when allocation fails

## Testing
- `make test TEST_GROUP=default` *(fails: running all tests exceeded time/limits)*

------
https://chatgpt.com/codex/tasks/task_e_685ee5a0c90c8324b6a893ec0b65c452