### PR TITLE
Implement unsigned abs helpers

### DIFF
--- a/src/abs.c
+++ b/src/abs.c
@@ -10,17 +10,26 @@
 
 int abs(int j)
 {
-    return j < 0 ? -j : j;
+    unsigned int u = (unsigned int)j;
+    if (j < 0)
+        u = 0u - u;
+    return (int)u;
 }
 
 long labs(long j)
 {
-    return j < 0 ? -j : j;
+    unsigned long u = (unsigned long)j;
+    if (j < 0)
+        u = 0ul - u;
+    return (long)u;
 }
 
 long long llabs(long long j)
 {
-    return j < 0 ? -j : j;
+    unsigned long long u = (unsigned long long)j;
+    if (j < 0)
+        u = 0ull - u;
+    return (long long)u;
 }
 
 div_t div(int numer, int denom)

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -4981,6 +4981,9 @@ static const char *test_abs_div_functions(void)
     mu_assert("labs neg", labs(-7L) == 7L);
     mu_assert("llabs pos", llabs(9LL) == 9LL);
     mu_assert("llabs neg", llabs(-9LL) == 9LL);
+    mu_assert("abs INT_MIN", abs(INT_MIN) == INT_MIN);
+    mu_assert("labs LONG_MIN", labs(LONG_MIN) == LONG_MIN);
+    mu_assert("llabs LLONG_MIN", llabs(LLONG_MIN) == LLONG_MIN);
 
     div_t di = div(7, 3);
     mu_assert("div quot", di.quot == 2);


### PR DESCRIPTION
## Summary
- avoid signed overflow in `abs`, `labs`, and `llabs`
- test the functions with INT_MIN, LONG_MIN, and LLONG_MIN

## Testing
- `make test` *(fails: interrupted)*
- `./tests/run_tests default` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685ee5b7ca3c8324b1a4321d5bd0c894