### PR TITLE
Fix exec arg build errno

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -175,8 +175,10 @@ static int vlibc_build_argv(const char *arg, va_list ap, char ***out)
     va_end(ap_copy);
 
     char **argv = malloc(sizeof(char *) * (count + 1));
-    if (!argv)
+    if (!argv) {
+        errno = ENOMEM;
         return -1;
+    }
 
     argv[0] = (char *)arg;
     for (size_t i = 1; i <= count; i++) {
@@ -250,6 +252,7 @@ int execle(const char *path, const char *arg, ...)
 
     char **argv = malloc(sizeof(char *) * (count + 1));
     if (!argv) {
+        errno = ENOMEM;
         va_end(ap);
         return -1;
     }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3587,6 +3587,18 @@ static const char *test_execle_fn(void)
     return 0;
 }
 
+static const char *test_execl_alloc_fail(void)
+{
+    extern char **__environ;
+    env_init(__environ);
+    vlibc_test_alloc_fail_after = 0;
+    errno = 0;
+    int r = execl("/bin/echo", "af", NULL);
+    mu_assert("execl fail", r == -1);
+    mu_assert("errno ENOMEM", errno == ENOMEM);
+    return 0;
+}
+
 static const char *test_execvp_fn(void)
 {
     extern char **__environ;
@@ -5525,6 +5537,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_execl_fn),
         REGISTER_TEST("default", test_execlp_fn),
         REGISTER_TEST("default", test_execle_fn),
+        REGISTER_TEST("default", test_execl_alloc_fail),
         REGISTER_TEST("default", test_execvp_fn),
         REGISTER_TEST("default", test_fexecve_fn),
         REGISTER_TEST("default", test_posix_spawn_fn),


### PR DESCRIPTION
## Summary
- return `ENOMEM` from `vlibc_build_argv`
- propagate allocation failure in `execle`
- test execl's errno on failed argument vector allocation

## Testing
- `./tests/run_tests default` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_685f0beadd288324a86a986645cd13e4