### PR TITLE
Set errno for aligned_alloc misuse

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -297,8 +297,10 @@ int posix_memalign(void **memptr, size_t alignment, size_t size)
  */
 void *aligned_alloc(size_t alignment, size_t size)
 {
-    if (size % alignment != 0)
+    if (size % alignment != 0) {
+        errno = EINVAL;
         return NULL;
+    }
 
     void *ptr = NULL;
     if (posix_memalign(&ptr, alignment, size) != 0)

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -285,8 +285,10 @@ static const char *test_aligned_alloc(void)
 
 static const char *test_aligned_alloc_bad_size(void)
 {
+    errno = 0;
     void *p = aligned_alloc(32, 48);
     mu_assert("bad size NULL", p == NULL);
+    mu_assert("errno EINVAL", errno == EINVAL);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- set `errno=EINVAL` when `aligned_alloc` size check fails
- verify `errno` in `test_aligned_alloc_bad_size`

## Testing
- `make test-memory` *(fails: process exceeded time or requires unavailable resources)*

------
https://chatgpt.com/codex/tasks/task_e_685f0f30fae08324a67e45759f853ef5