### PR TITLE
Handle integer overflows in strto functions

### DIFF
--- a/src/strto.c
+++ b/src/strto.c
@@ -9,6 +9,8 @@
 #include "stdlib.h"
 #include "string.h"
 #include <stdint.h>
+#include <limits.h>
+#include <errno.h>
 
 static int digit_val(char c)
 {
@@ -54,8 +56,18 @@ long strtol(const char *nptr, char **endptr, int base)
     unsigned long val = 0;
     const char *start = s;
     int d;
+    unsigned long cutoff = neg ? (unsigned long)LONG_MAX + 1UL : (unsigned long)LONG_MAX;
+    unsigned long cutdiv = cutoff / (unsigned long)base;
+    unsigned long cutlim = cutoff % (unsigned long)base;
+    int overflow = 0;
     while ((d = digit_val(*s)) >= 0 && d < base) {
-        val = val * (unsigned long)base + (unsigned long)d;
+        if (!overflow) {
+            if (val > cutdiv || (val == cutdiv && (unsigned long)d > cutlim)) {
+                overflow = 1;
+            } else {
+                val = val * (unsigned long)base + (unsigned long)d;
+            }
+        }
         s++;
     }
 
@@ -64,6 +76,11 @@ long strtol(const char *nptr, char **endptr, int base)
 
     if (s == start)
         return 0;
+
+    if (overflow) {
+        errno = ERANGE;
+        return neg ? LONG_MIN : LONG_MAX;
+    }
 
     long result = (long)val;
     if (neg)
@@ -105,8 +122,18 @@ unsigned long strtoul(const char *nptr, char **endptr, int base)
     unsigned long val = 0;
     const char *start = s;
     int d;
+    unsigned long cutoff = ULONG_MAX;
+    unsigned long cutdiv = cutoff / (unsigned long)base;
+    unsigned long cutlim = cutoff % (unsigned long)base;
+    int overflow = 0;
     while ((d = digit_val(*s)) >= 0 && d < base) {
-        val = val * (unsigned long)base + (unsigned long)d;
+        if (!overflow) {
+            if (val > cutdiv || (val == cutdiv && (unsigned long)d > cutlim)) {
+                overflow = 1;
+            } else {
+                val = val * (unsigned long)base + (unsigned long)d;
+            }
+        }
         s++;
     }
 
@@ -115,6 +142,11 @@ unsigned long strtoul(const char *nptr, char **endptr, int base)
 
     if (s == start)
         return 0;
+
+    if (overflow) {
+        errno = ERANGE;
+        return ULONG_MAX;
+    }
 
     if (neg)
         return (unsigned long)(-(long)val);
@@ -155,8 +187,18 @@ long long strtoll(const char *nptr, char **endptr, int base)
     unsigned long long val = 0;
     const char *start = s;
     int d;
+    unsigned long long cutoff = neg ? (unsigned long long)LLONG_MAX + 1ULL : (unsigned long long)LLONG_MAX;
+    unsigned long long cutdiv = cutoff / (unsigned long long)base;
+    unsigned long long cutlim = cutoff % (unsigned long long)base;
+    int overflow = 0;
     while ((d = digit_val(*s)) >= 0 && d < base) {
-        val = val * (unsigned long long)base + (unsigned long long)d;
+        if (!overflow) {
+            if (val > cutdiv || (val == cutdiv && (unsigned long long)d > cutlim)) {
+                overflow = 1;
+            } else {
+                val = val * (unsigned long long)base + (unsigned long long)d;
+            }
+        }
         s++;
     }
 
@@ -165,6 +207,11 @@ long long strtoll(const char *nptr, char **endptr, int base)
 
     if (s == start)
         return 0;
+
+    if (overflow) {
+        errno = ERANGE;
+        return neg ? LLONG_MIN : LLONG_MAX;
+    }
 
     long long result = (long long)val;
     if (neg)
@@ -206,8 +253,18 @@ unsigned long long strtoull(const char *nptr, char **endptr, int base)
     unsigned long long val = 0;
     const char *start = s;
     int d;
+    unsigned long long cutoff = ULLONG_MAX;
+    unsigned long long cutdiv = cutoff / (unsigned long long)base;
+    unsigned long long cutlim = cutoff % (unsigned long long)base;
+    int overflow = 0;
     while ((d = digit_val(*s)) >= 0 && d < base) {
-        val = val * (unsigned long long)base + (unsigned long long)d;
+        if (!overflow) {
+            if (val > cutdiv || (val == cutdiv && (unsigned long long)d > cutlim)) {
+                overflow = 1;
+            } else {
+                val = val * (unsigned long long)base + (unsigned long long)d;
+            }
+        }
         s++;
     }
 
@@ -216,6 +273,11 @@ unsigned long long strtoull(const char *nptr, char **endptr, int base)
 
     if (s == start)
         return 0;
+
+    if (overflow) {
+        errno = ERANGE;
+        return ULLONG_MAX;
+    }
 
     if (neg)
         return (unsigned long long)(-(long long)val);

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1250,6 +1250,46 @@ static const char *test_string_helpers(void)
     mu_assert("strtoumax max",
               strtoumax(numbuf, &end, 10) == UINTMAX_MAX && *end == '\0');
 
+    errno = 0;
+    snprintf(numbuf, sizeof(numbuf), "%ld0", (long)LONG_MAX);
+    mu_assert("strtol overflow",
+              strtol(numbuf, &end, 10) == LONG_MAX && errno == ERANGE && *end == '\0');
+    errno = 0;
+    unsigned long big = (unsigned long)LONG_MAX + 2UL;
+    snprintf(numbuf, sizeof(numbuf), "-%lu", big);
+    mu_assert("strtol underflow",
+              strtol(numbuf, &end, 10) == LONG_MIN && errno == ERANGE && *end == '\0');
+    errno = 0;
+    snprintf(numbuf, sizeof(numbuf), "%lu0", (unsigned long)ULONG_MAX);
+    mu_assert("strtoul overflow",
+              strtoul(numbuf, &end, 10) == ULONG_MAX && errno == ERANGE && *end == '\0');
+    errno = 0;
+    snprintf(numbuf, sizeof(numbuf), "%lld0", (long long)LLONG_MAX);
+    mu_assert("strtoll overflow",
+              strtoll(numbuf, &end, 10) == LLONG_MAX && errno == ERANGE && *end == '\0');
+    errno = 0;
+    unsigned long long bigll = (unsigned long long)LLONG_MAX + 2ULL;
+    snprintf(numbuf, sizeof(numbuf), "-%llu", bigll);
+    mu_assert("strtoll underflow",
+              strtoll(numbuf, &end, 10) == LLONG_MIN && errno == ERANGE && *end == '\0');
+    errno = 0;
+    snprintf(numbuf, sizeof(numbuf), "%llu0", (unsigned long long)ULLONG_MAX);
+    mu_assert("strtoull overflow",
+              strtoull(numbuf, &end, 10) == ULLONG_MAX && errno == ERANGE && *end == '\0');
+    errno = 0;
+    snprintf(numbuf, sizeof(numbuf), "%jd0", (intmax_t)INTMAX_MAX);
+    mu_assert("strtoimax overflow",
+              strtoimax(numbuf, &end, 10) == INTMAX_MAX && errno == ERANGE && *end == '\0');
+    errno = 0;
+    unsigned long long bigimax = (unsigned long long)INTMAX_MAX + 2ULL;
+    snprintf(numbuf, sizeof(numbuf), "-%llu", bigimax);
+    mu_assert("strtoimax underflow",
+              strtoimax(numbuf, &end, 10) == INTMAX_MIN && errno == ERANGE && *end == '\0');
+    errno = 0;
+    snprintf(numbuf, sizeof(numbuf), "%ju0", (uintmax_t)UINTMAX_MAX);
+    mu_assert("strtoumax overflow",
+              strtoumax(numbuf, &end, 10) == UINTMAX_MAX && errno == ERANGE && *end == '\0');
+
     wchar_t wbuf[64];
     mbstowcs(wbuf, "ff", 64);
     wchar_t *wend;


### PR DESCRIPTION
## Summary
- detect overflow and underflow in `strtol`, `strtoul`, `strtoll`, and `strtoull`
- clamp to the correct limits and set `errno=ERANGE`
- add unit tests verifying overflow handling

## Testing
- `make -j$(nproc)`
- `make test` *(fails: output empty in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_685f11886dfc8324b4eca3f28c330126