### PR TITLE
Handle ftw path overflow

### DIFF
--- a/src/ftw.c
+++ b/src/ftw.c
@@ -67,7 +67,13 @@ static int do_nftw(const char *path,
                 continue;
             size_t len = strlen(path);
             size_t add = len && path[len-1] != '/' ? 1 : 0;
-            char *child = malloc(len + add + strlen(e->d_name) + 1);
+            size_t name_len = strlen(e->d_name);
+            if (len > SIZE_MAX - add - name_len - 1) {
+                closedir(d);
+                errno = ENAMETOOLONG;
+                return -1;
+            }
+            char *child = malloc(len + add + name_len + 1);
             if (!child) {
                 closedir(d);
                 errno = ENOMEM;


### PR DESCRIPTION
## Summary
- prevent path size overflow in `ftw`
- test traversal failure on very long paths

## Testing
- `make test TEST_GROUP=ftw` *(fails: errno assertion)*

------
https://chatgpt.com/codex/tasks/task_e_685f25a73fa88324bdfd8a44679c0a50