### PR TITLE
Add comment for abort

### DIFF
--- a/src/abort.c
+++ b/src/abort.c
@@ -9,6 +9,9 @@
 #include "stdlib.h"
 #include "process.h"
 
+/*
+ * abort() - send SIGABRT to the current process and then exit.
+ */
 void abort(void)
 {
     kill(getpid(), SIGABRT);


### PR DESCRIPTION
## Summary
- document that `abort()` sends SIGABRT before exiting

## Testing
- `make test` *(fails: process interrupted)*
- `./tests/run_tests default` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685f5574024c8324a5868cc243c09e9b