### PR TITLE
Add comments for permission check wrappers

### DIFF
--- a/include/io.h
+++ b/include/io.h
@@ -53,7 +53,9 @@ int mkdir(const char *pathname, mode_t mode);
 int mkdirat(int dirfd, const char *pathname, mode_t mode);
 int rmdir(const char *pathname);
 int chdir(const char *path);
+/* Check permissions for pathname; returns 0 or -1 and sets errno. */
 int access(const char *pathname, int mode);
+/* Dirfd-relative permission check returning 0 or -1 with errno set. */
 int faccessat(int dirfd, const char *pathname, int mode, int flags);
 /* Flush all pending writes for a descriptor using SYS_fsync or host fsync. */
 int fsync(int fd);

--- a/src/access.c
+++ b/src/access.c
@@ -13,6 +13,11 @@
 #include <unistd.h>
 #include "syscall.h"
 
+/*
+ * Wrapper for access(2). Passes pathname and mode directly to SYS_access
+ * when available or to a host fallback. Returns 0 on success or -1 with
+ * errno set to the negative syscall result.
+ */
 int access(const char *pathname, int mode)
 {
 #ifdef SYS_access
@@ -33,6 +38,12 @@ int access(const char *pathname, int mode)
 #endif
 }
 
+/*
+ * Wrapper for faccessat(2). The dirfd, pathname, mode and flags
+ * arguments are forwarded to SYS_faccessat or a host fallback.
+ * Returns 0 on success or -1 with errno reflecting the syscall
+ * error value.
+ */
 int faccessat(int dirfd, const char *pathname, int mode, int flags)
 {
 #ifdef SYS_faccessat


### PR DESCRIPTION
## Summary
- document behavior of `access` and `faccessat`

## Testing
- `make test` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685f5580b8e483248899dc154e09133a