### PR TITLE
Add license comments and clarify wmem functions

### DIFF
--- a/include/netinet/in.h
+++ b/include/netinet/in.h
@@ -1,3 +1,8 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Network address structures and byte order helpers.
+ */
 #ifndef NETINET_IN_H
 #define NETINET_IN_H
 

--- a/src/wmem.c
+++ b/src/wmem.c
@@ -6,6 +6,7 @@
 
 #include "wchar.h"
 
+/* Fill n wide characters of s with c. */
 wchar_t *wmemset(wchar_t *s, wchar_t c, size_t n)
 {
     wchar_t *p = s;
@@ -14,6 +15,7 @@ wchar_t *wmemset(wchar_t *s, wchar_t c, size_t n)
     return s;
 }
 
+/* Copy n wide characters from src to dest. */
 wchar_t *wmemcpy(wchar_t *dest, const wchar_t *src, size_t n)
 {
     wchar_t *d = dest;
@@ -23,6 +25,7 @@ wchar_t *wmemcpy(wchar_t *dest, const wchar_t *src, size_t n)
     return dest;
 }
 
+/* Move n wide characters from src to dest with overlap handling. */
 wchar_t *wmemmove(wchar_t *dest, const wchar_t *src, size_t n)
 {
     wchar_t *d = dest;
@@ -41,6 +44,7 @@ wchar_t *wmemmove(wchar_t *dest, const wchar_t *src, size_t n)
     return dest;
 }
 
+/* Compare two wide character arrays. */
 int wmemcmp(const wchar_t *s1, const wchar_t *s2, size_t n)
 {
     while (n--) {

--- a/tests/minunit.h
+++ b/tests/minunit.h
@@ -1,3 +1,8 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Minimal unit test framework macros.
+ */
 #ifndef MINUNIT_H
 #define MINUNIT_H
 


### PR DESCRIPTION
## Summary
- add BSD 2-Clause header blocks to `netinet/in.h` and `tests/minunit.h`
- document wide memory functions in `src/wmem.c`

## Testing
- `make -s clean`
- `make -s -j2 test` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_685f5b2ff1b88324ba130171770c3588