### PR TITLE
Add docs for custom stream helpers

### DIFF
--- a/src/fopencookie.c
+++ b/src/fopencookie.c
@@ -36,6 +36,7 @@ struct fun_bridge {
     int (*closefn)(void *);
 };
 
+/* read wrapper passed to fopencookie */
 static ssize_t fun_read(void *c, char *buf, size_t n)
 {
     struct fun_bridge *b = c;
@@ -45,6 +46,7 @@ static ssize_t fun_read(void *c, char *buf, size_t n)
     return r < 0 ? -1 : r;
 }
 
+/* write wrapper passed to fopencookie */
 static ssize_t fun_write(void *c, const char *buf, size_t n)
 {
     struct fun_bridge *b = c;
@@ -54,6 +56,7 @@ static ssize_t fun_write(void *c, const char *buf, size_t n)
     return r < 0 ? -1 : r;
 }
 
+/* seek wrapper passed to fopencookie */
 static int fun_seek(void *c, off_t *off, int whence)
 {
     struct fun_bridge *b = c;
@@ -66,6 +69,7 @@ static int fun_seek(void *c, off_t *off, int whence)
     return 0;
 }
 
+/* close wrapper passed to fopencookie */
 static int fun_close(void *c)
 {
     struct fun_bridge *b = c;
@@ -76,6 +80,7 @@ static int fun_close(void *c)
     return r;
 }
 
+/* BSD funopen implementation using cookie_io_functions_t */
 FILE *funopen(const void *cookie,
               int (*readfn)(void *, char *, int),
               int (*writefn)(void *, const char *, int),

--- a/src/getloadavg.c
+++ b/src/getloadavg.c
@@ -19,6 +19,8 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 
+/* BSD variant reading VM_LOADAVG via sysctl */
+
 int getloadavg(double loadavg[], int nelem)
 {
     if (!loadavg || nelem <= 0)
@@ -36,6 +38,8 @@ int getloadavg(double loadavg[], int nelem)
 
 #else /* Linux and others */
 #include "stdio.h"
+
+/* Linux variant parsing /proc/loadavg */
 
 int getloadavg(double loadavg[], int nelem)
 {

--- a/src/wcsftime.c
+++ b/src/wcsftime.c
@@ -11,6 +11,10 @@
 #include "stdlib.h"
 #include "memory.h"
 
+/*
+ * wcsftime() - format time data as a wide-character string using strftime
+ * as the backing implementation.
+ */
 size_t wcsftime(wchar_t *s, size_t max, const wchar_t *format, const struct tm *tm)
 {
     if (!s || !format || !tm || max == 0)


### PR DESCRIPTION
## Summary
- document cookie I/O helpers in `fopencookie.c`
- comment each `getloadavg` implementation
- add overview above `wcsftime`

## Testing
- `make test` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685f5b59dcb88324be3c63d0ea7a022b