### PR TITLE
Document wide char, dl, and wordexp functions

### DIFF
--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -33,6 +33,7 @@ static struct dl_handle *dl_list;
 
 static void set_error(const char *msg);
 
+/* Apply relocation entries to the mapped object. */
 static int apply_relocs(struct dl_handle *h, Elf64_Rela *rela, size_t relasz)
 {
 #ifdef __x86_64__
@@ -69,6 +70,7 @@ static int apply_relocs(struct dl_handle *h, Elf64_Rela *rela, size_t relasz)
 #endif
 }
 
+/* Simple pread replacement using lseek and read. */
 static ssize_t pread_fd(int fd, void *buf, size_t count, off_t offset)
 {
     if (lseek(fd, offset, SEEK_SET) < 0)
@@ -76,6 +78,7 @@ static ssize_t pread_fd(int fd, void *buf, size_t count, off_t offset)
     return read(fd, buf, count);
 }
 
+/* Store an error message for retrieval by dlerror(). */
 static void set_error(const char *msg)
 {
     size_t len = strlen(msg);
@@ -85,6 +88,7 @@ static void set_error(const char *msg)
     dl_err[len] = '\0';
 }
 
+/* Return the most recent dynamic loading error message. */
 const char *dlerror(void)
 {
     if (dl_err[0] == '\0')
@@ -92,6 +96,7 @@ const char *dlerror(void)
     return dl_err;
 }
 
+/* Map the shared object located at filename into memory and return a handle. */
 void *dlopen(const char *filename, int flag)
 {
     (void)flag;
@@ -250,6 +255,7 @@ void *dlopen(const char *filename, int flag)
     return h;
 }
 
+/* Look up the address of the named symbol in the given handle. */
 void *dlsym(void *handle, const char *symbol)
 {
     struct dl_handle *h = handle;
@@ -263,6 +269,7 @@ void *dlsym(void *handle, const char *symbol)
     return NULL;
 }
 
+/* Unload the shared object referenced by handle. */
 int dlclose(void *handle)
 {
     struct dl_handle *h = handle;
@@ -279,6 +286,7 @@ int dlclose(void *handle)
     return 0;
 }
 
+/* Query symbol and object information for an address. */
 int dladdr(void *addr, Dl_info *info)
 {
     if (!info)

--- a/src/wchar_io.c
+++ b/src/wchar_io.c
@@ -6,6 +6,12 @@
 
 #include "wchar.h"
 #include "stdio.h"
+/*
+ * Read the next wide character from the given stream. If the stream
+ * comes from open_wmemstream() the value is read directly. Otherwise
+ * the next multibyte sequence is converted with mbrtowc(). Returns
+ * WEOF on failure.
+ */
 
 wint_t fgetwc(FILE *stream)
 {
@@ -25,6 +31,12 @@ wint_t fgetwc(FILE *stream)
         return -1;
     return (wint_t)wc;
 }
+/*
+ * Write a wide character to the stream. Memory backed streams
+ * store the character directly while normal streams use wcrtomb()
+ * to encode it as multibyte bytes. Returns the character written or
+ * WEOF on error.
+ */
 
 wint_t fputwc(wchar_t wc, FILE *stream)
 {

--- a/src/wordexp.c
+++ b/src/wordexp.c
@@ -20,6 +20,7 @@ struct part {
     int do_glob;
 };
 
+/* Append a single word to the result array, reallocating as needed. */
 static int add_word(wordexp_t *we, const char *str)
 {
     char **tmp = realloc(we->we_wordv, sizeof(char*) * (we->we_wordc + 2));
@@ -34,6 +35,7 @@ static int add_word(wordexp_t *we, const char *str)
     return 0;
 }
 
+/* Expand the part using glob() when wildcard characters are present. */
 static int do_glob_expand(wordexp_t *we, struct part *p)
 {
     if (!p->do_glob) {
@@ -57,6 +59,7 @@ static int do_glob_expand(wordexp_t *we, struct part *p)
     return -1;
 }
 
+/* Parse one shell-style word from *strp into out, handling quotes and escapes. */
 static int parse_word(const char **strp, struct part *out)
 {
     const char *s = *strp;
@@ -131,6 +134,7 @@ static int parse_word(const char **strp, struct part *out)
     return 0;
 }
 
+/* Expand a shell words string into a list of words with globbing. */
 int wordexp(const char *words, wordexp_t *pwordexp)
 {
     if (!words || !pwordexp)
@@ -150,6 +154,7 @@ int wordexp(const char *words, wordexp_t *pwordexp)
     return 0;
 }
 
+/* Free storage allocated by wordexp(). */
 void wordfree(wordexp_t *pwordexp)
 {
     if (!pwordexp) return;


### PR DESCRIPTION
## Summary
- document fgetwc/fputwc helper functions
- comment helper internals and public APIs in dlfcn.c
- explain wordexp helpers and exports

## Testing
- `make test` *(fails: build interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685f5b6419a0832494269a2f84e2e334