### PR TITLE
Document memstream and process helpers

### DIFF
--- a/src/atexit.c
+++ b/src/atexit.c
@@ -32,6 +32,10 @@ int at_quick_exit(void (*func)(void))
     return 0;
 }
 
+/*
+ * __run_atexit() - invoke regular atexit handlers in reverse registration
+ * order.  Used by the exit() implementation to run cleanups.
+ */
 void __run_atexit(void)
 {
     for (int i = handler_count - 1; i >= 0; --i) {
@@ -40,6 +44,10 @@ void __run_atexit(void)
     }
 }
 
+/*
+ * __run_quick_exit() - invoke quick exit handlers in reverse order.
+ * Called internally by quick_exit() and _Exit() wrappers.
+ */
 static void __run_quick_exit(void)
 {
     for (int i = quick_count - 1; i >= 0; --i) {
@@ -50,6 +58,10 @@ static void __run_quick_exit(void)
 
 extern void _exit(int);
 
+/*
+ * quick_exit() - run registered quick exit handlers and then terminate the
+ * process without flushing stdio buffers.
+ */
 void quick_exit(int status)
 {
     __run_quick_exit();

--- a/src/memstream.c
+++ b/src/memstream.c
@@ -11,6 +11,11 @@
 #include "string.h"
 #include "errno.h"
 
+/*
+ * open_memstream() - create a memory backed FILE stream that dynamically
+ * grows to hold all written data.  The resulting buffer address and size
+ * are returned via the provided pointers when the stream is closed.
+ */
 FILE *open_memstream(char **bufp, size_t *sizep)
 {
     if (!bufp || !sizep) {
@@ -39,6 +44,11 @@ FILE *open_memstream(char **bufp, size_t *sizep)
     return f;
 }
 
+/*
+ * open_wmemstream() - wide character variant of open_memstream().  The
+ * stream stores wchar_t elements and returns the buffer and element count
+ * on close.
+ */
 FILE *open_wmemstream(wchar_t **bufp, size_t *sizep)
 {
     if (!bufp || !sizep) {
@@ -68,6 +78,11 @@ FILE *open_wmemstream(wchar_t **bufp, size_t *sizep)
     return f;
 }
 
+/*
+ * fmemopen() - open a memory area as a FILE stream.  If buf is NULL a
+ * new buffer of the specified size is allocated.  The mode string controls
+ * readability and writability similar to fopen().
+ */
 FILE *fmemopen(void *buf, size_t size, const char *mode)
 {
     if (size == 0) {

--- a/src/process.c
+++ b/src/process.c
@@ -161,6 +161,11 @@ int execv(const char *path, char *const argv[])
     return execve(path, argv, environ);
 }
 
+/*
+ * vlibc_build_argv() - helper to construct a NULL terminated argv array from
+ * a variable argument list.  Memory is allocated for the array and returned
+ * via the out parameter.
+ */
 static int vlibc_build_argv(const char *arg, va_list ap, char ***out)
 {
     va_list ap_copy;
@@ -553,7 +558,11 @@ int posix_spawn_file_actions_destroy(posix_spawn_file_actions_t *acts)
     return 0;
 }
 
-/* Helper to grow the file actions array */
+/*
+ * file_actions_add() - internal utility to append a new action to a
+ * posix_spawn_file_actions_t list.  Reallocates the array as needed and
+ * returns a pointer to the new slot via out.
+ */
 static int file_actions_add(posix_spawn_file_actions_t *acts,
                             struct posix_spawn_file_action **out)
 {
@@ -712,7 +721,10 @@ int posix_spawnattr_getpgroup(const posix_spawnattr_t *attr, pid_t *pgroup)
     return 0;
 }
 
-/* Internal helper to use vfork()/fork as available */
+/*
+ * vlibc_vfork() - small wrapper selecting vfork() when available and falling
+ * back to fork() otherwise.  Used internally by posix_spawn().
+ */
 static __attribute__((unused)) pid_t vlibc_vfork(void)
 {
 #ifdef SYS_vfork


### PR DESCRIPTION
## Summary
- document `open_memstream`, `open_wmemstream`, and `fmemopen`
- add comments for `__run_quick_exit` and `quick_exit`
- comment internal helpers in process code

## Testing
- `make test` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685f63225ef48324b67be616e0e8f35d