### PR TITLE
Document syscall wrappers and setjmp

### DIFF
--- a/src/arch/bsd/syscall.c
+++ b/src/arch/bsd/syscall.c
@@ -11,6 +11,11 @@
 #include <sys/syscall.h>
 #include_next <errno.h>
 
+/*
+ * vlibc_syscall() - generic syscall wrapper used on BSD systems.
+ * Invokes the host syscall() function with up to six arguments and
+ * returns the result or -errno on failure.
+ */
 long vlibc_syscall(long number, ...)
 {
     va_list ap;

--- a/src/arch/win32/syscall.c
+++ b/src/arch/win32/syscall.c
@@ -10,6 +10,10 @@
 #include_next <errno.h>
 #include "syscall.h"
 
+/*
+ * vlibc_syscall() - Windows stub that reports unsupported calls.
+ * Always sets errno to ENOSYS and returns -1.
+ */
 long vlibc_syscall(long number, ...)
 {
     (void)number;

--- a/src/arch/x86_64/setjmp.c
+++ b/src/arch/x86_64/setjmp.c
@@ -8,6 +8,12 @@
 
 #include "setjmp.h"
 
+/*
+ * setjmp() - save callee-saved registers and stack state.
+ * Stores the program counter along with rbp, rbx and r12-r15
+ * into the provided jmp_buf. Returns 0 when saving the state
+ * and the value supplied to longjmp() when restoring.
+ */
 int setjmp(jmp_buf env)
 {
     int r;
@@ -30,6 +36,11 @@ int setjmp(jmp_buf env)
     return r;
 }
 
+/*
+ * longjmp() - resume execution from a saved setjmp context.
+ * Restores registers and jumps to the stored program counter.
+ * A zero value is translated to one before returning.
+ */
 void longjmp(jmp_buf env, int val)
 {
     if (val == 0)


### PR DESCRIPTION
## Summary
- document vlibc_syscall wrappers for BSD and Windows
- add explanations for assembly-based setjmp/longjmp implementations

## Testing
- `make test` *(fails: command interrupted due to long compile times)*

------
https://chatgpt.com/codex/tasks/task_e_685f631d1d1c8324b648865dcc012cb9