### PR TITLE
Improve comments in core modules

### DIFF
--- a/src/locale.c
+++ b/src/locale.c
@@ -41,6 +41,12 @@ static struct lconv c_lconv = {
     .n_sign_posn = 127,
 };
 
+/*
+ * setlocale() - set or query the program's current locale.
+ * The category is mostly ignored unless forwarding to the
+ * host's implementation. Passing NULL returns the current
+ * locale name; an empty string selects the environment locale.
+ */
 char *setlocale(int category, const char *locale)
 {
     (void)category;
@@ -74,7 +80,10 @@ char *setlocale(int category, const char *locale)
     return NULL;
 #endif
 }
-
+/*
+ * localeconv() - return a pointer to the locale formatting
+ * conventions. Only the "C" locale is currently provided.
+ */
 struct lconv *localeconv(void)
 {
     return &c_lconv;

--- a/src/math.c
+++ b/src/math.c
@@ -8,13 +8,21 @@
 
 #include "math.h"
 
+/* Value of pi used by the trig approximations */
 static const double PI = 3.14159265358979323846;
 
+/*
+ * fabs_approx() - lightweight absolute value used internally.
+ */
 static double fabs_approx(double x)
 {
     return x < 0 ? -x : x;
 }
 
+/*
+ * sin() - compute sine using a Taylor series approximation.
+ * The input is reduced to the range [-pi, pi] for better accuracy.
+ */
 double sin(double x)
 {
     while (x > PI)
@@ -31,6 +39,10 @@ double sin(double x)
     return sum;
 }
 
+/*
+ * cos() - compute cosine using a Taylor series approximation.
+ * The angle is reduced similarly to sin().
+ */
 double cos(double x)
 {
     while (x > PI)
@@ -47,6 +59,10 @@ double cos(double x)
     return sum;
 }
 
+/*
+ * tan() - compute tangent as sin(x)/cos(x).
+ * Returns 0 when cosine is zero to avoid division by zero.
+ */
 double tan(double x)
 {
     double s = sin(x);
@@ -54,6 +70,10 @@ double tan(double x)
     return c == 0.0 ? 0.0 : s / c;
 }
 
+/*
+ * sqrt() - compute square root using Newton's method.
+ * Returns 0 for non-positive inputs.
+ */
 double sqrt(double x)
 {
     if (x <= 0.0)
@@ -65,6 +85,10 @@ double sqrt(double x)
     return guess;
 }
 
+/*
+ * log_approx() - natural logarithm approximation using
+ * an arithmetic series expansion.
+ */
 static double log_approx(double x)
 {
     if (x <= 0.0)
@@ -80,6 +104,10 @@ static double log_approx(double x)
     return 2.0 * sum;
 }
 
+/*
+ * exp_approx() - approximate exponential function using
+ * a truncated power series.
+ */
 static double exp_approx(double x)
 {
     double term = 1.0;
@@ -91,6 +119,11 @@ static double exp_approx(double x)
     return sum;
 }
 
+/*
+ * pow() - raise a base to an exponent using repeated
+ * multiplication or the exp/log identities for fractional
+ * exponents.
+ */
 double pow(double base, double exp)
 {
     if (exp == 0.0)
@@ -109,16 +142,19 @@ double pow(double base, double exp)
     return exp_approx(exp * log_approx(base));
 }
 
+/* Return the natural logarithm using log_approx. */
 double log(double x)
 {
     return log_approx(x);
 }
 
+/* Return e raised to the given power using exp_approx. */
 double exp(double x)
 {
     return exp_approx(x);
 }
 
+/* Round toward negative infinity. */
 double floor(double x)
 {
     long i = (long)x;
@@ -127,6 +163,7 @@ double floor(double x)
     return (double)i;
 }
 
+/* Round toward positive infinity. */
 double ceil(double x)
 {
     long i = (long)x;
@@ -135,6 +172,7 @@ double ceil(double x)
     return (double)i;
 }
 
+/* Standard absolute value wrapper. */
 double fabs(double x)
 {
     return x < 0.0 ? -x : x;

--- a/src/memory.c
+++ b/src/memory.c
@@ -50,6 +50,9 @@ struct block_header {
 static struct block_header *free_list = NULL;
 static pthread_mutex_t free_lock = { ATOMIC_FLAG_INIT, PTHREAD_MUTEX_NORMAL, 0, 0 };
 
+/*
+ * free_impl() - return a block to the internal free list.
+ */
 static void free_impl(void *ptr)
 {
     if (!ptr)
@@ -166,6 +169,9 @@ void *malloc(size_t size)
     return (void *)(hdr + 1);
 }
 
+/*
+ * free_impl() - unmap a block allocated with mmap.
+ */
 static void free_impl(void *ptr)
 {
     if (!ptr)


### PR DESCRIPTION
## Summary
- clarify setlocale usage and add localeconv overview
- document helper functions in math routines
- add missing memory allocator comments

## Testing
- `make test` *(fails: build hangs)*

------
https://chatgpt.com/codex/tasks/task_e_685f6c806e6883248e08dd00ba451ba3