### PR TITLE
Add comments for semaphore, string and time helpers

### DIFF
--- a/src/semaphore.c
+++ b/src/semaphore.c
@@ -9,7 +9,11 @@
 #include "semaphore.h"
 #include <errno.h>
 
-/* Initialize a semaphore with the given initial count. */
+/*
+ * Initialize a semaphore with the provided initial count.
+ * The pshared argument is ignored as all semaphores are
+ * process-local in this implementation.
+ */
 int sem_init(sem_t *sem, int pshared, unsigned value)
 {
     (void)pshared;
@@ -19,14 +23,22 @@ int sem_init(sem_t *sem, int pshared, unsigned value)
     return 0;
 }
 
-/* Destroy a semaphore object (no-op). */
+/*
+ * Destroy a semaphore object.  Nothing needs to be done for
+ * this simple atomic counter based implementation so it is a
+ * no-op.
+ */
 int sem_destroy(sem_t *sem)
 {
     (void)sem;
     return 0;
 }
 
-/* Decrement the semaphore count, blocking if it is zero. */
+/*
+ * Decrement the semaphore count, waiting in a loop if the
+ * count is zero.  The wait is implemented by repeatedly
+ * polling with a short sleep.
+ */
 int sem_wait(sem_t *sem)
 {
     if (!sem)
@@ -43,7 +55,10 @@ int sem_wait(sem_t *sem)
     }
 }
 
-/* Try to decrement the semaphore without blocking. */
+/*
+ * Try to decrement the semaphore without blocking.  If the
+ * count is already zero the call fails with EAGAIN.
+ */
 int sem_trywait(sem_t *sem)
 {
     if (!sem)
@@ -58,7 +73,9 @@ int sem_trywait(sem_t *sem)
     return EAGAIN;
 }
 
-/* Increment the semaphore count and wake waiters. */
+/*
+ * Increment the semaphore count and wake any waiting thread.
+ */
 int sem_post(sem_t *sem)
 {
     if (!sem)

--- a/src/string.c
+++ b/src/string.c
@@ -9,7 +9,11 @@
 #include "string.h"
 #include "memory.h"
 
-/* Return the length of a NUL terminated string. */
+/*
+ * Return the length of a NUL terminated string. This helper
+ * is used internally so that we do not rely on the host
+ * implementation of strlen.
+ */
 size_t vstrlen(const char *s)
 {
     const char *p = s;
@@ -18,7 +22,10 @@ size_t vstrlen(const char *s)
     return (size_t)(p - s);
 }
 
-/* Like strlen but stops after maxlen characters. */
+/*
+ * Like strlen but stops scanning after maxlen characters.
+ * The return value will not exceed maxlen.
+ */
 size_t strnlen(const char *s, size_t maxlen)
 {
     const char *p = s;
@@ -27,7 +34,10 @@ size_t strnlen(const char *s, size_t maxlen)
     return (size_t)(p - s);
 }
 
-/* Copy src string to dest, returning dest. */
+/*
+ * Copy the NUL terminated string src to dest and return dest.
+ * The destination buffer must be large enough to hold src.
+ */
 char *vstrcpy(char *dest, const char *src)
 {
     char *d = dest;
@@ -38,7 +48,10 @@ char *vstrcpy(char *dest, const char *src)
     return dest;
 }
 
-/* Compare two strings up to n characters. */
+/*
+ * Compare two strings up to n characters and return the
+ * difference of the first mismatching bytes.
+ */
 int vstrncmp(const char *s1, const char *s2, size_t n)
 {
     while (n--) {
@@ -52,13 +65,19 @@ int vstrncmp(const char *s1, const char *s2, size_t n)
     return 0;
 }
 
-/* Wrapper around vstrncmp for complete comparison. */
+/*
+ * Wrapper around vstrncmp for convenience when comparing
+ * entire strings.
+ */
 int strcmp(const char *s1, const char *s2)
 {
     return vstrncmp(s1, s2, (size_t)-1);
 }
 
-/* Find the first occurrence of c in s. */
+/*
+ * Find the first occurrence of the character c in the
+ * string s.  A pointer to the character or NULL is returned.
+ */
 char *strchr(const char *s, int c)
 {
     unsigned char ch = (unsigned char)c;
@@ -72,7 +91,10 @@ char *strchr(const char *s, int c)
     return NULL;
 }
 
-/* Allocate a duplicate of s using malloc. */
+/*
+ * Allocate a duplicate of the string s using malloc.
+ * Returns NULL if memory allocation fails.
+ */
 char *strdup(const char *s)
 {
     size_t len = vstrlen(s);
@@ -83,7 +105,10 @@ char *strdup(const char *s)
     return dup;
 }
 
-/* Bounded string copy that NUL pads the result. */
+/*
+ * Bounded string copy that writes at most n characters from
+ * src into dest and NUL pads the remainder of the buffer.
+ */
 char *strncpy(char *dest, const char *src, size_t n)
 {
     char *d = dest;
@@ -97,7 +122,9 @@ char *strncpy(char *dest, const char *src, size_t n)
     return dest;
 }
 
-/* Append src to dest. */
+/*
+ * Append the NUL terminated src string to the end of dest.
+ */
 char *strcat(char *dest, const char *src)
 {
     char *d = dest;
@@ -109,7 +136,10 @@ char *strcat(char *dest, const char *src)
     return dest;
 }
 
-/* Append at most n characters from src to dest. */
+/*
+ * Append at most n characters from src to the end of dest
+ * and always terminate dest with a NUL byte.
+ */
 char *strncat(char *dest, const char *src, size_t n)
 {
     char *d = dest;
@@ -124,7 +154,11 @@ char *strncat(char *dest, const char *src, size_t n)
 /* Fallback storage for strtok when strtok_r is not used. */
 static char *strtok_static;
 
-/* Reentrant tokenizer splitting a string using delimiters. */
+/*
+ * Reentrant string tokenizer.  Splits str into tokens using
+ * any of the delimiter characters from delim and stores the
+ * parsing state in saveptr.
+ */
 char *strtok_r(char *str, const char *delim, char **saveptr)
 {
     char *s;
@@ -163,7 +197,10 @@ char *strtok_r(char *str, const char *delim, char **saveptr)
     return token;
 }
 
-/* Non-reentrant tokenizer using a static state. */
+/*
+ * Non-reentrant wrapper around strtok_r that keeps the parser
+ * state in a static variable.
+ */
 char *strtok(char *str, const char *delim)
 {
     return strtok_r(str, delim, &strtok_static);

--- a/src/time.c
+++ b/src/time.c
@@ -26,9 +26,10 @@ extern int host_gettimeofday(struct timeval *tv, void *tz)
 #endif
 
 /*
- * Return seconds since the Unix epoch. Depending on the
- * platform this uses SYS_time, SYS_clock_gettime with
- * CLOCK_REALTIME, or falls back to the host time() call.
+ * Return seconds since the Unix epoch.  The wrapper uses the
+ * best available kernel interface: SYS_time, SYS_clock_gettime
+ * with CLOCK_REALTIME, or as a last resort the host time()
+ * implementation.
  */
 time_t time(time_t *t)
 {
@@ -59,8 +60,9 @@ time_t time(time_t *t)
 
 /*
  * Fill in a timeval structure with the current time of day.
- * The implementation uses SYS_time or SYS_clock_gettime when
- * possible and falls back to the host gettimeofday().
+ * Like time(), this wrapper prefers SYS_time or
+ * SYS_clock_gettime when available and otherwise relies on the
+ * host gettimeofday().
  */
 int gettimeofday(struct timeval *tv, void *tz)
 {
@@ -96,8 +98,8 @@ int gettimeofday(struct timeval *tv, void *tz)
 
 /*
  * Schedule delivery of SIGALRM after the given number of
- * seconds. Uses the SYS_alarm syscall when present and
- * otherwise emulates it via setitimer().
+ * seconds.  When the SYS_alarm syscall is missing the
+ * functionality is emulated using setitimer().
  */
 unsigned int alarm(unsigned int seconds)
 {


### PR DESCRIPTION
## Summary
- ensure BSD-2 license headers are present
- document semaphore helpers
- expand comments on string helpers
- clarify time related wrappers

## Testing
- `make test` *(fails: build interrupted before completion)*

------
https://chatgpt.com/codex/tasks/task_e_685f6d0fd898832497abea7ffd47756c