### PR TITLE
Add comments to error and directory functions

### DIFF
--- a/src/default_shell.c
+++ b/src/default_shell.c
@@ -12,6 +12,11 @@
 #define VLIBC_SHELL_PATH "/bin/sh"
 #endif
 
+/*
+ * Return the path of the shell used by vlibc. If the environment
+ * variable VLIBC_SHELL is set and non-empty it is used, otherwise
+ * the compile time default is returned.
+ */
 const char *vlibc_default_shell(void)
 {
     const char *s = getenv("VLIBC_SHELL");

--- a/src/dirent.c
+++ b/src/dirent.c
@@ -13,16 +13,19 @@
 #undef readdir
 #undef closedir
 
+/* Open a directory stream, returning a DIR handle. */
 DIR *vlibc_opendir(const char *name)
 {
     return opendir(name);
 }
 
+/* Read the next directory entry from the stream. */
 struct dirent *vlibc_readdir(DIR *dirp)
 {
     return readdir(dirp);
 }
 
+/* Close a directory stream opened with vlibc_opendir(). */
 int vlibc_closedir(DIR *dirp)
 {
     return closedir(dirp);

--- a/src/err.c
+++ b/src/err.c
@@ -14,6 +14,7 @@
 #include "errno.h"
 #include "process.h"
 
+/* Print a formatted warning to stderr, optionally appending errno. */
 static void vwarn_internal(const char *fmt, va_list ap, int use_errno)
 {
     if (fmt && *fmt)
@@ -27,11 +28,13 @@ static void vwarn_internal(const char *fmt, va_list ap, int use_errno)
     fprintf(stderr, "\n");
 }
 
+/* Warn with errno using a va_list. */
 void vwarn(const char *fmt, va_list ap)
 {
     vwarn_internal(fmt, ap, 1);
 }
 
+/* Variadic wrapper around vwarn(). */
 void warn(const char *fmt, ...)
 {
     va_list ap;
@@ -40,11 +43,13 @@ void warn(const char *fmt, ...)
     va_end(ap);
 }
 
+/* Warn without errno using a va_list. */
 void vwarnx(const char *fmt, va_list ap)
 {
     vwarn_internal(fmt, ap, 0);
 }
 
+/* Variadic wrapper around vwarnx(). */
 void warnx(const char *fmt, ...)
 {
     va_list ap;
@@ -53,6 +58,10 @@ void warnx(const char *fmt, ...)
     va_end(ap);
 }
 
+/*
+ * Common helper used by err* functions. Prints the message and exits
+ * with the supplied status code.
+ */
 static void __attribute__((noreturn))
 verr_internal(int status, const char *fmt, va_list ap, int use_errno)
 {
@@ -61,11 +70,13 @@ verr_internal(int status, const char *fmt, va_list ap, int use_errno)
     __builtin_unreachable();
 }
 
+/* Print warning with errno and exit. */
 void verr(int status, const char *fmt, va_list ap)
 {
     verr_internal(status, fmt, ap, 1);
 }
 
+/* Variadic wrapper around verr(). */
 void err(int status, const char *fmt, ...)
 {
     va_list ap;
@@ -74,11 +85,13 @@ void err(int status, const char *fmt, ...)
     va_end(ap);
 }
 
+/* Print warning without errno and exit. */
 void verrx(int status, const char *fmt, va_list ap)
 {
     verr_internal(status, fmt, ap, 0);
 }
 
+/* Variadic wrapper around verrx(). */
 void errx(int status, const char *fmt, ...)
 {
     va_list ap;


### PR DESCRIPTION
## Summary
- document functions in `err.c`
- document directory helpers in `dirent.c`
- document default shell helper in `default_shell.c`

## Testing
- `make test` *(fails: compilation interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685f6f8d10448324a08a4ac30de668f1