### PR TITLE
Add documentation for progname, getcwd, getline helpers

### DIFF
--- a/src/getcwd.c
+++ b/src/getcwd.c
@@ -11,6 +11,11 @@
 
 extern char *host_getcwd(char *buf, size_t size) __asm__("getcwd");
 
+/*
+ * getcwd() - return the absolute path of the current working directory.
+ * When buf is NULL a buffer is allocated that must later be freed by the
+ * caller.  Returns NULL on failure with errno set.
+ */
 char *getcwd(char *buf, size_t size)
 {
     if (buf) {

--- a/src/getline.c
+++ b/src/getline.c
@@ -10,6 +10,11 @@
 #include "memory.h"
 #include "errno.h"
 
+/*
+ * getdelim() - read from a stream until the delimiter or EOF is encountered.
+ * The buffer pointed to by lineptr is resized as needed.  Returns the number
+ * of bytes read or -1 on error.
+ */
 ssize_t getdelim(char **lineptr, size_t *n, int delim, FILE *stream)
 {
     if (!lineptr || !n || !stream) {
@@ -47,6 +52,10 @@ ssize_t getdelim(char **lineptr, size_t *n, int delim, FILE *stream)
     return (ssize_t)pos;
 }
 
+/*
+ * getline() - convenience wrapper around getdelim() that uses a newline as
+ * the delimiter.
+ */
 ssize_t getline(char **lineptr, size_t *n, FILE *stream)
 {
     return getdelim(lineptr, n, '\n', stream);

--- a/src/progname.c
+++ b/src/progname.c
@@ -12,11 +12,20 @@
 
 static const char *progname = "";
 
+/*
+ * getprogname() - retrieve the stored program name.  If no name has been
+ * set then an empty string is returned.
+ */
 const char *getprogname(void)
 {
     return progname;
 }
 
+/*
+ * setprogname() - store the basename of the provided executable path so it
+ * can be returned by getprogname().  Passing NULL resets the name to an
+ * empty string.
+ */
 void setprogname(const char *name)
 {
     if (!name) {


### PR DESCRIPTION
## Summary
- add API comments for getprogname() and setprogname()
- document getdelim() and getline()
- describe getcwd() implementation

## Testing
- `make test` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685f6fa5191883248e4bbe3afa5263b5