### PR TITLE
Document scanf, fenv and wprintf APIs

### DIFF
--- a/src/fenv.c
+++ b/src/fenv.c
@@ -72,6 +72,10 @@ extern int host_fegetexceptflag(fexcept_t *, int) __asm__("fegetexceptflag");
 extern int host_fesetexceptflag(const fexcept_t *, int) __asm__("fesetexceptflag");
 #endif
 
+/*
+ * feclearexcept clears the supported floating-point exceptions listed in
+ * 'excepts'.
+ */
 int feclearexcept(int excepts)
 {
 #ifdef USE_BUILTIN_FECLEAREXCEPT
@@ -81,6 +85,10 @@ int feclearexcept(int excepts)
 #endif
 }
 
+/*
+ * fegetexceptflag stores the current status of the exception flags
+ * specified by 'excepts' into the object pointed to by 'flagp'.
+ */
 int fegetexceptflag(fexcept_t *flagp, int excepts)
 {
 #ifdef USE_BUILTIN_FEGETEXCEPTFLAG
@@ -90,6 +98,10 @@ int fegetexceptflag(fexcept_t *flagp, int excepts)
 #endif
 }
 
+/*
+ * fesetexceptflag sets the floating-point exception flags indicated by
+ * 'excepts' to the values stored in '*flagp'.
+ */
 int fesetexceptflag(const fexcept_t *flagp, int excepts)
 {
 #ifdef USE_BUILTIN_FESETEXCEPTFLAG
@@ -99,6 +111,9 @@ int fesetexceptflag(const fexcept_t *flagp, int excepts)
 #endif
 }
 
+/*
+ * feraiseexcept raises the floating-point exceptions provided in 'excepts'.
+ */
 int feraiseexcept(int excepts)
 {
 #ifdef USE_BUILTIN_FERAISEEXCEPT
@@ -108,6 +123,10 @@ int feraiseexcept(int excepts)
 #endif
 }
 
+/*
+ * fetestexcept tests which of the exceptions listed in 'excepts' are set
+ * and returns the subset that are currently raised.
+ */
 int fetestexcept(int excepts)
 {
     fexcept_t flag;
@@ -115,6 +134,9 @@ int fetestexcept(int excepts)
     return flag & excepts;
 }
 
+/*
+ * fegetround returns the current floating-point rounding mode.
+ */
 int fegetround(void)
 {
 #ifdef USE_BUILTIN_FEGETROUND
@@ -124,6 +146,9 @@ int fegetround(void)
 #endif
 }
 
+/*
+ * fesetround sets the floating-point rounding mode to 'mode'.
+ */
 int fesetround(int mode)
 {
 #ifdef USE_BUILTIN_FESETROUND
@@ -133,6 +158,10 @@ int fesetround(int mode)
 #endif
 }
 
+/*
+ * fegetenv stores the entire floating-point environment into the object
+ * pointed to by 'envp'.
+ */
 int fegetenv(fenv_t *envp)
 {
 #ifdef USE_BUILTIN_FEGETENV
@@ -142,6 +171,10 @@ int fegetenv(fenv_t *envp)
 #endif
 }
 
+/*
+ * feholdexcept saves the current environment and clears all exception
+ * flags. The previous state is stored in '*envp'.
+ */
 int feholdexcept(fenv_t *envp)
 {
 #ifdef USE_BUILTIN_FEHOLDEXCEPT
@@ -151,6 +184,9 @@ int feholdexcept(fenv_t *envp)
 #endif
 }
 
+/*
+ * fesetenv installs the floating-point environment referenced by 'envp'.
+ */
 int fesetenv(const fenv_t *envp)
 {
 #ifdef USE_BUILTIN_FESETENV
@@ -160,6 +196,10 @@ int fesetenv(const fenv_t *envp)
 #endif
 }
 
+/*
+ * feupdateenv restores the environment pointed to by 'envp' and then
+ * raises any exceptions that were pending when the function was called.
+ */
 int feupdateenv(const fenv_t *envp)
 {
 #ifdef USE_BUILTIN_FEUPDATEENV

--- a/src/scanf.c
+++ b/src/scanf.c
@@ -18,6 +18,12 @@ static const char *skip_ws(const char *s)
     return s;
 }
 
+/*
+ * vsscanf_impl is the workhorse for all sscanf variants. It parses the
+ * supplied string according to the given format string using the provided
+ * va_list and stores the results into the caller supplied pointers. The
+ * function returns the number of successfully scanned fields.
+ */
 static int vsscanf_impl(const char *str, const char *fmt, va_list ap)
 {
     const char *s = str;
@@ -114,11 +120,19 @@ static int vsscanf_impl(const char *str, const char *fmt, va_list ap)
     return count;
 }
 
+/*
+ * vsscanf is the public interface that scans formatted input from a memory
+ * buffer using a variable argument list.
+ */
 int vsscanf(const char *str, const char *format, va_list ap)
 {
     return vsscanf_impl(str, format, ap);
 }
 
+/*
+ * sscanf scans formatted input from a string. It forwards the variable
+ * arguments to vsscanf_impl and returns the number of fields obtained.
+ */
 int sscanf(const char *str, const char *format, ...)
 {
     va_list ap;
@@ -128,6 +142,11 @@ int sscanf(const char *str, const char *format, ...)
     return r;
 }
 
+/*
+ * vfscanf_impl reads a line from the given FILE stream and then parses it
+ * using vsscanf_impl. Only a small buffer is used and scanning stops at a
+ * newline or EOF.
+ */
 static int vfscanf_impl(FILE *stream, const char *format, va_list ap)
 {
     char buf[256];
@@ -142,11 +161,20 @@ static int vfscanf_impl(FILE *stream, const char *format, va_list ap)
     return vsscanf_impl(buf, format, ap);
 }
 
+/*
+ * vfscanf is the stdio variant that accepts a va_list and reads from a
+ * FILE stream.
+ */
 int vfscanf(FILE *stream, const char *format, va_list ap)
 {
     return vfscanf_impl(stream, format, ap);
 }
 
+/*
+ * fscanf reads formatted data from the given FILE stream. It is implemented
+ * on top of vfscanf_impl and returns the number of successfully scanned
+ * fields.
+ */
 int fscanf(FILE *stream, const char *format, ...)
 {
     va_list ap;

--- a/src/wprintf.c
+++ b/src/wprintf.c
@@ -169,11 +169,19 @@ static int vswprintf_impl(wchar_t *str, size_t size, const wchar_t *fmt, va_list
     return (int)pos;
 }
 
+/*
+ * vswprintf formats data into a wide-character buffer using a va_list.
+ * It simply forwards to vswprintf_impl.
+ */
 int vswprintf(wchar_t *str, size_t size, const wchar_t *format, va_list ap)
 {
     return vswprintf_impl(str, size, format, ap);
 }
 
+/*
+ * swprintf is the variadic form of vswprintf. It formats the input and
+ * stores the result in the provided wide-character buffer.
+ */
 int swprintf(wchar_t *str, size_t size, const wchar_t *format, ...)
 {
     va_list ap;
@@ -203,6 +211,10 @@ static int vfdwprintf(int fd, const wchar_t *format, va_list ap)
     return len;
 }
 
+/*
+ * vfwprintf writes formatted wide-character output to a FILE stream using
+ * a va_list.
+ */
 int vfwprintf(FILE *stream, const wchar_t *format, va_list ap)
 {
     if (stream && stream->is_mem) {
@@ -245,6 +257,10 @@ int vfwprintf(FILE *stream, const wchar_t *format, va_list ap)
     return vfdwprintf(stream ? stream->fd : -1, format, ap);
 }
 
+/*
+ * vwprintf is the wide-character equivalent of vprintf and writes the
+ * formatted output to stdout.
+ */
 int vwprintf(const wchar_t *format, va_list ap)
 {
     return vfdwprintf(1, format, ap);


### PR DESCRIPTION
## Summary
- add header comments describing scanf helpers and wrappers
- document floating-point environment functions
- expand comments on wide printf functions

## Testing
- `make test -j4` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685f6fbad5f8832495a7ff1613c648bf