### PR TITLE
Add documentation for filesystem wrappers

### DIFF
--- a/src/dir.c
+++ b/src/dir.c
@@ -18,9 +18,12 @@
 #endif
 
 /*
- * mkdir() - create a new directory at PATHNAME with the given MODE.
- * Uses SYS_mkdir when available or falls back to mkdirat with
- * AT_FDCWD on platforms lacking the direct syscall.
+ * mkdir() - create a new directory at PATHNAME with MODE.
+ *
+ * This is a thin wrapper around the SYS_mkdir or SYS_mkdirat system
+ * calls invoked via vlibc_syscall.  When SYS_mkdir is unavailable the
+ * implementation falls back to mkdirat with AT_FDCWD.  The return
+ * value is checked and converted to the usual errno/-1 convention.
  */
 int mkdir(const char *pathname, mode_t mode)
 {
@@ -38,7 +41,10 @@ int mkdir(const char *pathname, mode_t mode)
 
 /*
  * rmdir() - remove an empty directory specified by PATHNAME.
- * Returns 0 on success or -1 and sets errno when the syscall fails.
+ *
+ * The function invokes the SYS_rmdir syscall through vlibc_syscall.
+ * A negative return from the syscall is converted into -1 with errno
+ * set to the corresponding error code.
  */
 int rmdir(const char *pathname)
 {

--- a/src/fts.c
+++ b/src/fts.c
@@ -28,7 +28,10 @@ struct _fts {
 };
 
 /*
- * queue_push - append a path node to the traversal queue.
+ * queue_push() - append a new path node to the internal traversal queue.
+ *
+ * PATH is duplicated and stored along with LEVEL indicating depth in the
+ * hierarchy.  Returns 0 on success or -1 if memory allocation fails.
  */
 static int queue_push(FTS *fts, const char *path, int level)
 {
@@ -51,7 +54,9 @@ static int queue_push(FTS *fts, const char *path, int level)
 }
 
 /*
- * queue_pop - remove and return the next node from the queue.
+ * queue_pop() - remove and return the next queued path node.
+ *
+ * Returns a pointer to the node or NULL if the queue is empty.
  */
 static struct node *queue_pop(FTS *fts)
 {
@@ -66,6 +71,10 @@ static struct node *queue_pop(FTS *fts)
 
 /*
  * fts_open() - start a file hierarchy traversal.
+ *
+ * PATHS is a NULL terminated list of root paths to traverse. OPTIONS
+ * controls traversal behaviour and COMPAR is an optional sorting
+ * callback.  Returns a new FTS handle or NULL on allocation failure.
  * Paths are queued and returned incrementally by fts_read().
  */
 FTS *fts_open(char * const *paths, int options,
@@ -101,8 +110,10 @@ static void free_entry(FTSENT *e)
 
 /*
  * fts_read() - return the next entry from the traversal queue.
- * Directories are expanded and their children queued for later
- * processing.
+ *
+ * The returned FTSENT describes the next path in the hierarchy.  If a
+ * directory is encountered its children are queued for later processing.
+ * NULL is returned when traversal is complete or on allocation failure.
  */
 FTSENT *fts_read(FTS *fts)
 {
@@ -189,6 +200,9 @@ FTSENT *fts_read(FTS *fts)
 
 /*
  * fts_close() - free all resources used by an FTS handle.
+ *
+ * Releases any queued paths and the current entry.  Returns 0 on
+ * success or -1 if the provided handle is NULL.
  */
 int fts_close(FTS *fts)
 {

--- a/src/mkfifo.c
+++ b/src/mkfifo.c
@@ -24,6 +24,12 @@ extern int host_mkfifo(const char *path, mode_t mode) __asm__("mkfifo");
 extern int host_mkfifoat(int dirfd, const char *path, mode_t mode) __asm__("mkfifoat");
 #endif
 
+/*
+ * mkfifo() - create a FIFO special file at PATH with permissions MODE.
+ *
+ * Returns 0 on success or -1 with errno set when the underlying
+ * system call fails.
+ */
 int mkfifo(const char *path, mode_t mode)
 {
 #ifdef SYS_mkfifo
@@ -38,6 +44,13 @@ int mkfifo(const char *path, mode_t mode)
 #endif
 }
 
+/*
+ * mkfifoat() - create a FIFO relative to DIRFD.  PATH is interpreted
+ * relative to DIRFD unless it begins with a '/'.  MODE specifies the
+ * permissions of the new FIFO.
+ *
+ * Returns 0 on success or -1 with errno set on failure.
+ */
 int mkfifoat(int dirfd, const char *path, mode_t mode)
 {
 #ifdef SYS_mkfifoat


### PR DESCRIPTION
## Summary
- expand mkdir and rmdir comments in `dir.c`
- document helper functions and APIs in `fts.c`
- document mkfifo/mkfifoat usage in `mkfifo.c`

## Testing
- `make test` *(fails: interrupted during build)*

------
https://chatgpt.com/codex/tasks/task_e_685f74aed7a483248f8485299bfc18bb