### PR TITLE
Improve docs for hostname, glob, and pathconf

### DIFF
--- a/src/glob.c
+++ b/src/glob.c
@@ -36,7 +36,12 @@
 #include "fnmatch.h"
 #include <errno.h>
 
-/* join_path() - join base path and name */
+/*
+ * join_path() - allocate a new string combining BASE and NAME.
+ *
+ * A '/' separator is inserted when needed.  The caller must free the
+ * returned string or NULL will be returned on allocation failure.
+ */
 static char *join_path(const char *base, const char *name)
 {
     size_t blen = base ? strlen(base) : 0;
@@ -56,7 +61,12 @@ static char *join_path(const char *base, const char *name)
     return res;
 }
 
-/* add_match() - append a path to glob results */
+/*
+ * add_match() - append PATH to the result list in G.
+ *
+ * The glob_t array is expanded and the string duplicated.  Returns 0
+ * on success or -1 when memory allocation fails.
+ */
 static int add_match(glob_t *g, const char *path)
 {
     char **tmp = realloc(g->gl_pathv, sizeof(char*) * (g->gl_pathc + 2));
@@ -118,7 +128,14 @@ static int handle_dir(const char *dir, const char *pattern, const char *rest,
     return ret;
 }
 
-/* expand() - recursively expand pattern */
+/*
+ * expand() - recursively expand PATTERN relative to BASE.
+ *
+ * Each path segment is processed in turn and directories are scanned
+ * to find matching entries.  Matches are accumulated into the glob_t
+ * structure via add_match().  Returns 0 on success or a GLOB_* error
+ * code.
+ */
 static int expand(const char *base, const char *pattern, glob_t *g, int flags,
                   int (*errfunc)(const char *, int))
 {
@@ -137,7 +154,14 @@ static int expand(const char *base, const char *pattern, glob_t *g, int flags,
     return handle_dir(base, part, rest, g, flags, errfunc);
 }
 
-/* glob() - perform pathname expansion */
+/*
+ * glob() - perform pathname expansion on PATTERN.
+ *
+ * The interface matches the POSIX glob() function.  Results are stored
+ * in PGLOB with behaviour controlled by FLAGS and ERRFUNC.  The helper
+ * expand() does the recursive directory traversal.  On success the
+ * function returns 0.  Otherwise a GLOB_* error code is returned.
+ */
 int glob(const char *pattern, int flags,
          int (*errfunc)(const char *epath, int eerrno), glob_t *pglob)
 {

--- a/src/hostname.c
+++ b/src/hostname.c
@@ -34,7 +34,15 @@
 #include <unistd.h>
 #include "syscall.h"
 
-/* gethostname() - retrieve current host name */
+/*
+ * gethostname() - retrieve the current host name.
+ *
+ * The caller supplies NAME, a buffer of length LEN, in which the
+ * system's host name will be stored.  The function wraps the
+ * SYS_gethostname syscall when available and falls back to a host
+ * helper otherwise.  A return value of 0 indicates success while -1
+ * means an error occurred and errno is set.
+ */
 int gethostname(char *name, size_t len)
 {
 #ifdef SYS_gethostname
@@ -50,7 +58,14 @@ int gethostname(char *name, size_t len)
 #endif
 }
 
-/* sethostname() - set the system host name */
+/*
+ * sethostname() - change the system host name.
+ *
+ * NAME specifies the new host name with length LEN.  When the
+ * SYS_sethostname syscall is available it is invoked directly; on
+ * other systems a host helper may be used.  The function returns 0 on
+ * success or -1 when an error occurs, with errno indicating the cause.
+ */
 int sethostname(const char *name, size_t len)
 {
 #ifdef SYS_sethostname

--- a/src/pathconf.c
+++ b/src/pathconf.c
@@ -1,9 +1,31 @@
 /*
- * BSD 2-Clause License: Redistribution and use in source and binary forms, with or without modification, are permitted provided that the copyright notice and this permission notice appear in all copies. This software is provided "as is" without warranty.
+ * BSD 2-Clause "Simplified" License
+ *
+ * Copyright (c) 2025, vlibc authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  *
  * Purpose: Implements the pathconf functions for vlibc. Provides wrappers and helpers used by the standard library.
- *
- * Copyright (c) 2025
  */
 
 #include "unistd.h"
@@ -11,6 +33,14 @@
 #include "errno.h"
 #include <limits.h>
 
+/*
+ * pathconf() - query configuration limits for a pathname.
+ *
+ * Only the _PC_NAME_MAX and _PC_PATH_MAX names are supported.  When
+ * requesting NAME_MAX the function uses statvfs() to obtain the value
+ * for PATH.  The limit is returned on success or -1 on failure with
+ * errno set.
+ */
 long pathconf(const char *path, int name)
 {
     struct statvfs sv;
@@ -31,6 +61,14 @@ long pathconf(const char *path, int name)
     }
 }
 
+/*
+ * fpathconf() - query configuration limits for an open file descriptor.
+ *
+ * This variant operates on FD instead of a pathname and mirrors the
+ * semantics of pathconf().  It supports _PC_NAME_MAX and _PC_PATH_MAX
+ * using fstatvfs() when necessary.  The limit is returned or -1 on
+ * error with errno set.
+ */
 long fpathconf(int fd, int name)
 {
     struct statvfs sv;


### PR DESCRIPTION
## Summary
- document `gethostname` and `sethostname`
- add detail comments in `glob.c`
- describe `pathconf` and `fpathconf` usage
- standardize simplified BSD license header in `pathconf.c`

## Testing
- `make test` *(fails: build interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68602f459b448324ba2da84381af1bf4