### PR TITLE
Add missing function comments

### DIFF
--- a/src/getopt_long_only.c
+++ b/src/getopt_long_only.c
@@ -11,9 +11,9 @@
 #include "string.h"
 
 /*
- * Parse command line options allowing long options with a single dash.
- * If a matching long option is not found, fall back to getopt() for
- * short option processing.
+ * getopt_long_only() - variant of getopt_long() that accepts long options
+ * prefixed with a single '-'.  If no long option matches, processing
+ * falls back to getopt() so traditional short options still work.
  */
 int getopt_long_only(int argc, char * const argv[], const char *optstring,
                      const struct option *longopts, int *longindex)

--- a/src/getrusage.c
+++ b/src/getrusage.c
@@ -12,6 +12,11 @@
 #include <unistd.h>
 #include "syscall.h"
 
+/*
+ * getrusage() - retrieve resource usage statistics for the given target.
+ * Performs a direct syscall when possible or falls back to the host libc
+ * implementation.  Returns 0 on success and -1 on error with errno set.
+ */
 int getrusage(int who, struct rusage *usage)
 {
 #if defined(SYS_getrusage)


### PR DESCRIPTION
## Summary
- document function behavior in `getopt_long_only.c`, `grp_r.c`, and `getrusage.c`
- leave BSD-2 headers intact at file starts

## Testing
- `make -s test` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6860342aebec83249711861aaf4801bd