### PR TITLE
Add nl_langinfo support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ SRC := \
     src/getsubopt.c \
     src/locale.c \
     src/locale_extra.c \
+    src/langinfo.c \
     src/wchar.c \
     src/wchar_conv.c \
     src/wchar_io.c \

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -22,8 +22,8 @@ The **string** module provides fundamental operations needed by most C programs:
 - Basic locale handling reads the `LC_ALL` and `LANG` environment variables.
   `setlocale` defaults to those values and, on BSD systems, falls back to the
   host `setlocale(3)` when a locale other than `"C"` or `"POSIX"` is
-  requested. `localeconv` exposes formatting data. All strings are treated as
-  byte sequences.
+  requested. `localeconv` exposes formatting data and `nl_langinfo` queries
+  locale items such as `CODESET`. All strings are treated as byte sequences.
 - Utility functions for tokenizing and simple formatting.
 - `printf` style routines understand `%d`, `%u`, `%s`, `%x`, `%X`, `%o`, `%p`,
   and `%c` with basic field width and precision handling.

--- a/include/langinfo.h
+++ b/include/langinfo.h
@@ -1,0 +1,69 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Declarations for locale information queries.
+ */
+#ifndef LANGINFO_H
+#define LANGINFO_H
+
+/* item identifier type */
+typedef int nl_item;
+
+/* constants for nl_langinfo */
+enum {
+    CODESET,
+    D_T_FMT,
+    D_FMT,
+    T_FMT,
+    T_FMT_AMPM,
+    AM_STR,
+    PM_STR,
+    DAY_1,
+    DAY_2,
+    DAY_3,
+    DAY_4,
+    DAY_5,
+    DAY_6,
+    DAY_7,
+    ABDAY_1,
+    ABDAY_2,
+    ABDAY_3,
+    ABDAY_4,
+    ABDAY_5,
+    ABDAY_6,
+    ABDAY_7,
+    MON_1,
+    MON_2,
+    MON_3,
+    MON_4,
+    MON_5,
+    MON_6,
+    MON_7,
+    MON_8,
+    MON_9,
+    MON_10,
+    MON_11,
+    MON_12,
+    ABMON_1,
+    ABMON_2,
+    ABMON_3,
+    ABMON_4,
+    ABMON_5,
+    ABMON_6,
+    ABMON_7,
+    ABMON_8,
+    ABMON_9,
+    ABMON_10,
+    ABMON_11,
+    ABMON_12,
+    RADIXCHAR,
+    THOUSEP,
+    YESEXPR,
+    NOEXPR,
+    CRNCYSTR
+};
+
+/* obtain locale specific information */
+char *nl_langinfo(nl_item item);
+
+#endif /* LANGINFO_H */

--- a/src/langinfo.c
+++ b/src/langinfo.c
@@ -1,0 +1,98 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms, with or without modification, are permitted provided that the copyright notice and this permission notice appear in all copies. This software is provided "as is" without warranty.
+ *
+ * Purpose: Implements the nl_langinfo function for vlibc. Provides minimal locale tables or defers to the host implementation on BSD systems.
+ */
+
+#include "langinfo.h"
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+#define nl_langinfo host_nl_langinfo
+#include_next <langinfo.h>
+#undef nl_langinfo
+extern char *host_nl_langinfo(nl_item) __asm("nl_langinfo");
+
+char *nl_langinfo(nl_item item)
+{
+    return host_nl_langinfo(item);
+}
+#else
+
+static const char *const abday[7] = {
+    "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
+};
+
+static const char *const day[7] = {
+    "Sunday", "Monday", "Tuesday", "Wednesday",
+    "Thursday", "Friday", "Saturday"
+};
+
+static const char *const abmon[12] = {
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+};
+
+static const char *const mon[12] = {
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"
+};
+
+char *nl_langinfo(nl_item item)
+{
+    switch (item) {
+    case CODESET:    return (char *)"ASCII";
+    case D_T_FMT:    return (char *)"%a %b %e %H:%M:%S %Y";
+    case D_FMT:      return (char *)"%m/%d/%y";
+    case T_FMT:      return (char *)"%H:%M:%S";
+    case T_FMT_AMPM: return (char *)"%I:%M:%S %p";
+    case AM_STR:     return (char *)"AM";
+    case PM_STR:     return (char *)"PM";
+    case DAY_1:      return (char *)day[0];
+    case DAY_2:      return (char *)day[1];
+    case DAY_3:      return (char *)day[2];
+    case DAY_4:      return (char *)day[3];
+    case DAY_5:      return (char *)day[4];
+    case DAY_6:      return (char *)day[5];
+    case DAY_7:      return (char *)day[6];
+    case ABDAY_1:    return (char *)abday[0];
+    case ABDAY_2:    return (char *)abday[1];
+    case ABDAY_3:    return (char *)abday[2];
+    case ABDAY_4:    return (char *)abday[3];
+    case ABDAY_5:    return (char *)abday[4];
+    case ABDAY_6:    return (char *)abday[5];
+    case ABDAY_7:    return (char *)abday[6];
+    case MON_1:      return (char *)mon[0];
+    case MON_2:      return (char *)mon[1];
+    case MON_3:      return (char *)mon[2];
+    case MON_4:      return (char *)mon[3];
+    case MON_5:      return (char *)mon[4];
+    case MON_6:      return (char *)mon[5];
+    case MON_7:      return (char *)mon[6];
+    case MON_8:      return (char *)mon[7];
+    case MON_9:      return (char *)mon[8];
+    case MON_10:     return (char *)mon[9];
+    case MON_11:     return (char *)mon[10];
+    case MON_12:     return (char *)mon[11];
+    case ABMON_1:    return (char *)abmon[0];
+    case ABMON_2:    return (char *)abmon[1];
+    case ABMON_3:    return (char *)abmon[2];
+    case ABMON_4:    return (char *)abmon[3];
+    case ABMON_5:    return (char *)abmon[4];
+    case ABMON_6:    return (char *)abmon[5];
+    case ABMON_7:    return (char *)abmon[6];
+    case ABMON_8:    return (char *)abmon[7];
+    case ABMON_9:    return (char *)abmon[8];
+    case ABMON_10:   return (char *)abmon[9];
+    case ABMON_11:   return (char *)abmon[10];
+    case ABMON_12:   return (char *)abmon[11];
+    case RADIXCHAR:  return (char *)".";
+    case THOUSEP:    return (char *)"";
+    case YESEXPR:    return (char *)"^[yY]";
+    case NOEXPR:     return (char *)"^[nN]";
+    case CRNCYSTR:   return (char *)"";
+    default:        return "";
+    }
+}
+#endif
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -48,6 +48,7 @@
 #include "../include/fenv.h"
 #include "../include/complex.h"
 #include "../include/locale.h"
+#include "../include/langinfo.h"
 #include "../include/regex.h"
 #include "../include/ftw.h"
 #include "../include/fts.h"
@@ -3434,6 +3435,13 @@ static const char *test_locale_objects(void)
     return 0;
 }
 
+static const char *test_langinfo_codeset(void)
+{
+    const char *cs = nl_langinfo(CODESET);
+    mu_assert("codeset", cs && cs[0] != '\0');
+    return 0;
+}
+
 static const char *test_gethostname_fn(void)
 {
     char buf[256];
@@ -5849,6 +5857,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_putenv_unsetenv_stack),
         REGISTER_TEST("default", test_locale_from_env),
         REGISTER_TEST("default", test_locale_objects),
+        REGISTER_TEST("default", test_langinfo_codeset),
         REGISTER_TEST("default", test_gethostname_fn),
         REGISTER_TEST("default", test_uname_fn),
         REGISTER_TEST("default", test_confstr_path),


### PR DESCRIPTION
## Summary
- implement minimal `<langinfo.h>` header
- add internal `nl_langinfo` with basic tables
- document `nl_langinfo` usage
- test querying `CODESET`

## Testing
- `make test` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68603b4597508324a68455324287df06