### PR TITLE
Add vfork wrapper

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -9,6 +9,7 @@ and installing signal handlers.  The companion `signal.h` header offers
 
 ```c
 pid_t fork(void);
+pid_t vfork(void);
 int execve(const char *pathname, char *const argv[], char *const envp[]);
 int fexecve(int fd, char *const argv[], char *const envp[]);
 int execvp(const char *file, char *const argv[]);
@@ -73,6 +74,11 @@ int atexit(void (*fn)(void));
 void abort(void);
 void exit(int status);
 ```
+
+`vfork` returns 0 in the child process and the child's PID in the parent,
+matching the behaviour of `fork`. When the host provides the `SYS_vfork`
+system call it is used directly, otherwise the wrapper falls back to
+`fork`.
 
 These wrappers retrieve and manipulate process information. `getuid`,
 `geteuid`, `getgid`, and `getegid` return the real and effective user and

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -20,6 +20,12 @@
 int isatty(int fd);
 int daemon(int nochdir, int noclose);
 int chroot(const char *path);
+/*
+ * Create a child process using the SYS_vfork syscall when available.
+ * Falls back to fork() when the syscall is missing. Returns 0 in the
+ * child and the child's PID in the parent, or -1 on error with errno set.
+ */
+pid_t vfork(void);
 
 uid_t getuid(void);
 uid_t geteuid(void);

--- a/src/process.c
+++ b/src/process.c
@@ -59,6 +59,25 @@ pid_t fork(void)
 }
 
 /*
+ * vfork() - create a new process sharing the parent's address space until
+ * the child either execs or exits. When the SYS_vfork syscall exists it is
+ * invoked directly, otherwise the wrapper falls back to fork().
+ */
+pid_t vfork(void)
+{
+#ifdef SYS_vfork
+    long ret = vlibc_syscall(SYS_vfork, 0, 0, 0, 0, 0, 0);
+    if (ret < 0) {
+        errno = -ret;
+        return -1;
+    }
+    return (pid_t)ret;
+#else
+    return fork();
+#endif
+}
+
+/*
  * execve() - execute a program via the SYS_execve system call wrapper. On
  * failure the return value from vlibc_syscall is negated and stored in errno
  * and -1 is returned.
@@ -774,16 +793,7 @@ int posix_spawnattr_getpgroup(const posix_spawnattr_t *attr, pid_t *pgroup)
  */
 static __attribute__((unused)) pid_t vlibc_vfork(void)
 {
-#ifdef SYS_vfork
-    long ret = vlibc_syscall(SYS_vfork, 0, 0, 0, 0, 0, 0);
-    if (ret < 0) {
-        errno = -ret;
-        return -1;
-    }
-    return (pid_t)ret;
-#else
-    return fork();
-#endif
+    return vfork();
 }
 
 /*

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3782,6 +3782,18 @@ static const char *test_process_group_wrappers(void)
     return 0;
 }
 
+static const char *test_vfork_basic(void)
+{
+    pid_t pid = vfork();
+    mu_assert("vfork", pid >= 0);
+    if (pid == 0)
+        _exit(5);
+    int status = 0;
+    waitpid(pid, &status, 0);
+    mu_assert("child", WIFEXITED(status) && WEXITSTATUS(status) == 5);
+    return 0;
+}
+
 static const char *test_system_fn(void)
 {
     int r = system("true");
@@ -6021,6 +6033,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_err_functions),
         REGISTER_TEST("default", test_strsignal_names),
         REGISTER_TEST("default", test_process_group_wrappers),
+        REGISTER_TEST("default", test_vfork_basic),
         REGISTER_TEST("default", test_system_fn),
         REGISTER_TEST("default", test_system_interrupted),
         REGISTER_TEST("default", test_execv_fn),


### PR DESCRIPTION
## Summary
- support `vfork` syscall with fallback to `fork`
- expose `vfork` via `unistd.h`
- document `vfork` usage
- test `vfork` return behavior

## Testing
- `make -s test TEST_GROUP=default` *(fails: environment interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68603dd0a8948324a93b6e84260008ba