### PR TITLE
Add fmtmsg implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,7 @@ SRC := \
     src/wprintf.c \
     src/wscanf.c \
     src/sigsetjmp.c \
+    src/fmtmsg.c \
     src/progname.c
 
 ARCH_SRC := $(wildcard src/arch/$(ARCH)/*.c)

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -153,3 +153,14 @@ void collect(const void *node, VISIT v, int l)
 }
 twalk(root, collect);   // sum == 18
 ```
+
+## Message Formatting
+
+`fmtmsg` prints a formatted diagnostic to standard error when `MM_PRINT` is
+specified. The function accepts a classification mask, message label,
+severity level, text, action hint and tag string.
+
+```c
+fmtmsg(MM_PRINT, "util:sub", MM_ERROR,
+       "bad input", "retry with valid file", "UTIL:001");
+```

--- a/include/fmtmsg.h
+++ b/include/fmtmsg.h
@@ -1,0 +1,45 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Declarations for the fmtmsg message formatting function.
+ */
+#ifndef FMTMSG_H
+#define FMTMSG_H
+
+/* classification values */
+#define MM_HARD    0x001
+#define MM_SOFT    0x002
+#define MM_FIRM    0x004
+#define MM_APPL    0x008
+#define MM_UTIL    0x010
+#define MM_OPSYS   0x020
+#define MM_RECOVER 0x040
+#define MM_NRECOV  0x080
+#define MM_PRINT   0x100
+#define MM_CONSOLE 0x200
+
+/* severity levels */
+#define MM_NOSEV   0
+#define MM_HALT    1
+#define MM_ERROR   2
+#define MM_WARNING 3
+#define MM_INFO    4
+
+/* null values */
+#define MM_NULLLBL ((char *)0)
+#define MM_NULLSEV 0
+#define MM_NULLMC  ((long)0)
+#define MM_NULLTXT ((char *)0)
+#define MM_NULLACT ((char *)0)
+#define MM_NULLTAG ((char *)0)
+
+/* return values */
+#define MM_NOTOK -1
+#define MM_OK     0
+#define MM_NOMSG  1
+#define MM_NOCON  4
+
+int fmtmsg(long classification, const char *label, int severity,
+           const char *text, const char *action, const char *tag);
+
+#endif /* FMTMSG_H */

--- a/src/fmtmsg.c
+++ b/src/fmtmsg.c
@@ -1,0 +1,174 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Implements the fmtmsg function for vlibc following POSIX
+ * conventions. Only simple BSD style message formatting is provided.
+ */
+
+#include "fmtmsg.h"
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+
+#define DFLT_MSGVERB "label:severity:text:action:tag"
+#define MAX_MSGVERB  sizeof(DFLT_MSGVERB)
+
+static char *printfmt(char *, long, const char *, int,
+                      const char *, const char *, const char *);
+static char *nextcomp(const char *);
+static const char *sevinfo(int);
+static int validmsgverb(const char *);
+
+int
+fmtmsg(long class, const char *label, int sev, const char *text,
+       const char *action, const char *tag)
+{
+    FILE *fp;
+    char *env, *msgverb, *output;
+
+    if (class & MM_PRINT) {
+        if ((env = getenv("MSGVERB")) != NULL && *env != '\0' &&
+            strlen(env) <= strlen(DFLT_MSGVERB)) {
+            if ((msgverb = strdup(env)) == NULL)
+                return MM_NOTOK;
+            else if (validmsgverb(msgverb) == 0) {
+                free(msgverb);
+                goto def;
+            }
+        } else {
+        def:
+            if ((msgverb = strdup(DFLT_MSGVERB)) == NULL)
+                return MM_NOTOK;
+        }
+        output = printfmt(msgverb, class, label, sev, text, action, tag);
+        if (output == NULL) {
+            free(msgverb);
+            return MM_NOTOK;
+        }
+        if (*output != '\0')
+            fprintf(stderr, "%s", output);
+        free(msgverb);
+        free(output);
+    }
+    if (class & MM_CONSOLE) {
+        output = printfmt(DFLT_MSGVERB, class, label, sev, text, action, tag);
+        if (output == NULL)
+            return MM_NOCON;
+        if (*output != '\0') {
+            if ((fp = fopen("/dev/console", "ae")) == NULL) {
+                free(output);
+                return MM_NOCON;
+            }
+            fprintf(fp, "%s", output);
+            fclose(fp);
+        }
+        free(output);
+    }
+    return MM_OK;
+}
+
+#define INSERT_COLON   if (*output != '\0') strlcat(output, ": ", size)
+#define INSERT_NEWLINE if (*output != '\0') strlcat(output, "\n", size)
+#define INSERT_SPACE   if (*output != '\0') strlcat(output, " ", size)
+
+static char *
+printfmt(char *msgverb, long class, const char *label, int sev,
+        const char *text, const char *act, const char *tag)
+{
+    size_t size;
+    char *comp, *output;
+    const char *sevname;
+
+    size = 32;
+    if (label != MM_NULLLBL)
+        size += strlen(label);
+    if ((sevname = sevinfo(sev)) != NULL)
+        size += strlen(sevname);
+    if (text != MM_NULLTXT)
+        size += strlen(text);
+    if (act != MM_NULLACT)
+        size += strlen(act);
+    if (tag != MM_NULLTAG)
+        size += strlen(tag);
+
+    output = malloc(size);
+    if (output == NULL)
+        return NULL;
+    *output = '\0';
+    while ((comp = nextcomp(msgverb)) != NULL) {
+        if (strcmp(comp, "label") == 0 && label != MM_NULLLBL) {
+            INSERT_COLON;
+            strlcat(output, label, size);
+        } else if (strcmp(comp, "severity") == 0 && sevname != NULL) {
+            INSERT_COLON;
+            strlcat(output, sevname, size);
+        } else if (strcmp(comp, "text") == 0 && text != MM_NULLTXT) {
+            INSERT_COLON;
+            strlcat(output, text, size);
+        } else if (strcmp(comp, "action") == 0 && act != MM_NULLACT) {
+            INSERT_NEWLINE;
+            strlcat(output, "TO FIX: ", size);
+            strlcat(output, act, size);
+        } else if (strcmp(comp, "tag") == 0 && tag != MM_NULLTAG) {
+            INSERT_SPACE;
+            strlcat(output, tag, size);
+        }
+    }
+    INSERT_NEWLINE;
+    return output;
+}
+
+static char *
+nextcomp(const char *msgverb)
+{
+    static char lmsgverb[MAX_MSGVERB], *state;
+    char *retval;
+
+    if (*lmsgverb == '\0') {
+        strlcpy(lmsgverb, msgverb, sizeof(lmsgverb));
+        retval = strtok_r(lmsgverb, ":", &state);
+    } else {
+        retval = strtok_r(NULL, ":", &state);
+    }
+    if (retval == NULL)
+        *lmsgverb = '\0';
+    return retval;
+}
+
+static const char *
+sevinfo(int sev)
+{
+    switch (sev) {
+    case MM_HALT:
+        return "HALT";
+    case MM_ERROR:
+        return "ERROR";
+    case MM_WARNING:
+        return "WARNING";
+    case MM_INFO:
+        return "INFO";
+    default:
+        return NULL;
+    }
+}
+
+static int
+validmsgverb(const char *msgverb)
+{
+    const char *validlist = "label\0severity\0text\0action\0tag\0";
+    char *msgcomp;
+    size_t len1, len2;
+    const char *p;
+    int equality;
+
+    equality = 0;
+    while ((msgcomp = nextcomp(msgverb)) != NULL) {
+        equality--;
+        len1 = strlen(msgcomp);
+        for (p = validlist; (len2 = strlen(p)) != 0; p += len2 + 1) {
+            if (len1 == len2 && memcmp(msgcomp, p, len1) == 0)
+                equality++;
+        }
+    }
+    return !equality;
+}

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -66,6 +66,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include "../include/err.h"
+#include "../include/fmtmsg.h"
 #include <errno.h>
 #include <sys/wait.h>
 #include <signal.h>
@@ -3700,6 +3701,28 @@ static const char *test_warn_functions(void)
     return 0;
 }
 
+static const char *test_fmtmsg_basic(void)
+{
+    int p[2];
+    mu_assert("pipe", pipe(p) == 0);
+    int old = dup(2);
+    mu_assert("dup", old >= 0);
+    dup2(p[1], 2);
+    close(p[1]);
+    unsetenv("MSGVERB");
+    fmtmsg(MM_PRINT, "UTIL:TEST", MM_ERROR,
+           "bad input", "try again", "UTIL:123");
+    dup2(old, 2);
+    close(old);
+    char buf[128] = {0};
+    ssize_t n = read(p[0], buf, sizeof(buf) - 1);
+    close(p[0]);
+    mu_assert("fmtmsg output",
+              n > 0 && strcmp(buf,
+              "UTIL:TEST: ERROR: bad input\nTO FIX: try again  UTIL:123\n") == 0);
+    return 0;
+}
+
 static const char *test_err_functions(void)
 {
     int p[2];
@@ -6018,6 +6041,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_progname_setget),
         REGISTER_TEST("default", test_error_reporting),
         REGISTER_TEST("default", test_warn_functions),
+        REGISTER_TEST("default", test_fmtmsg_basic),
         REGISTER_TEST("default", test_err_functions),
         REGISTER_TEST("default", test_strsignal_names),
         REGISTER_TEST("default", test_process_group_wrappers),


### PR DESCRIPTION
## Summary
- implement `fmtmsg` and provide new header
- document message formatting
- test fmtmsg output

## Testing
- `make test` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68603dc89dd08324b71721a724bc6394