### PR TITLE
Implement timed mqueue docs and tests

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -134,5 +134,21 @@ mq_close(mq);
 mq_unlink("/example");
 ```
 
+Timed operations wait only until a specified absolute deadline. Build a
+`timespec` with `clock_gettime` and pass it to `mq_timedsend` or
+`mq_timedreceive`:
+
+```c
+struct timespec ts;
+clock_gettime(CLOCK_REALTIME, &ts);
+ts.tv_sec += 2; /* wait up to two seconds */
+mq_timedsend(mq, "bye", 4, 0, &ts);
+ts.tv_sec += 2;
+mq_timedreceive(mq, buf, sizeof(buf), NULL, &ts);
+```
+
+If the call cannot complete before the timeout expires it fails with
+`ETIMEDOUT`.
+
 See [mqueue.md](mqueue.md) for attribute queries and timed send/receive.
 

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -4674,6 +4674,57 @@ static const char *test_mqueue_timed(void)
     return 0;
 }
 
+static void *delayed_send(void *arg)
+{
+    mqd_t mq = *(mqd_t *)arg;
+    usleep(100000);
+    mq_send(mq, "dmsg", 5, 0);
+    return NULL;
+}
+
+static void *delayed_recv(void *arg)
+{
+    mqd_t mq = *(mqd_t *)arg;
+    char buf[8];
+    usleep(100000);
+    mq_receive(mq, buf, sizeof(buf), NULL);
+    return NULL;
+}
+
+static const char *test_mqueue_blocking_timed(void)
+{
+    const char *name = "/vlibc_test_mq_block";
+    struct mq_attr attr = {0};
+    attr.mq_maxmsg = 1;
+    attr.mq_msgsize = 8;
+    mqd_t mq = mq_open(name, O_CREAT | O_RDWR, 0600, &attr);
+    mu_assert("mq_open", mq >= 0);
+
+    /* timedreceive waits for sender */
+    pthread_t t;
+    pthread_create(&t, NULL, delayed_send, &mq);
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec += 1;
+    char buf[8];
+    ssize_t n = mq_timedreceive(mq, buf, sizeof(buf), NULL, &ts);
+    pthread_join(t, NULL);
+    mu_assert("timedrecv", n > 0 && strcmp(buf, "dmsg") == 0);
+
+    /* fill queue then timedsend waits for receiver */
+    mu_assert("send", mq_send(mq, "one", 4, 0) == 0);
+    pthread_create(&t, NULL, delayed_recv, &mq);
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec += 1;
+    int r = mq_timedsend(mq, "two", 4, 0, &ts);
+    pthread_join(t, NULL);
+    mu_assert("timedsend", r == 0);
+
+    mq_close(mq);
+    mq_unlink(name);
+    return 0;
+}
+
 static const char *test_mqueue_attr(void)
 {
     const char *name = "/vlibc_test_mq_attr";
@@ -6065,6 +6116,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("memory", test_sysv_shm_segment),
         REGISTER_TEST("default", test_mqueue_basic),
         REGISTER_TEST("default", test_mqueue_timed),
+        REGISTER_TEST("default", test_mqueue_blocking_timed),
         REGISTER_TEST("default", test_mqueue_attr),
         REGISTER_TEST("default", test_named_semaphore_create),
         REGISTER_TEST("default", test_sysv_sem_basic),


### PR DESCRIPTION
## Summary
- document timed message queue operations
- add test verifying blocking send/receive with timeouts

## Testing
- `make test-memory` *(fails: command hung)*

------
https://chatgpt.com/codex/tasks/task_e_68603dda93648324b0b6bd786ff1548f