### PR TITLE
Add getlogin_r and update docs/tests

### DIFF
--- a/docs/users_groups.md
+++ b/docs/users_groups.md
@@ -22,6 +22,7 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf, size_t buflen,
 int getpwnam_r(const char *name, struct passwd *pwd, char *buf, size_t buflen,
                struct passwd **result);
 char *getlogin(void);
+int getlogin_r(char *buf, size_t buflen);
 void setpwent(void);
 struct passwd *getpwent(void);
 void endpwent(void);
@@ -36,6 +37,10 @@ results in caller supplied memory so they are safe for concurrent use.
 `getlogin()` obtains the user name for the current UID using
 `getpwuid(getuid())`.  The resulting string is cached in thread-local
 storage so repeated calls are inexpensive.
+
+`getlogin_r()` provides a thread-safe variant that writes the login name
+into a user supplied buffer.  It returns `0` on success or an error code
+when the name cannot be obtained or the buffer is too small.
 
 `setpwent()`, `getpwent()` and `endpwent()` iterate sequentially
 through all passwd entries.  On BSD these wrappers call the host

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -47,6 +47,7 @@ long fpathconf(int fd, int name);
 int fchdir(int fd);
 
 char *getlogin(void);
+int getlogin_r(char *buf, size_t len);
 char *getpass(const char *prompt);
 char *crypt(const char *key, const char *salt);
 char *ttyname(int fd);

--- a/src/getlogin.c
+++ b/src/getlogin.c
@@ -9,21 +9,46 @@
 #include "unistd.h"
 #include "pwd.h"
 #include "string.h"
+#include "errno.h"
 
 /*
  * Obtain the login name for the current user by calling
  * getpwuid(getuid()). The resulting pw_name field is copied into a
  * thread-local buffer so repeated calls avoid further lookups.
  */
+static int getlogin_impl(char *buf, size_t len)
+{
+    if (!buf || len == 0)
+        return EINVAL;
+
+    struct passwd *pw = getpwuid(getuid());
+    if (!pw || !pw->pw_name)
+        return ENOENT;
+
+    size_t n = strlcpy(buf, pw->pw_name, len);
+    if (n >= len)
+        return ERANGE;
+    return 0;
+}
+
+int getlogin_r(char *buf, size_t len)
+{
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    return getlogin_impl(buf, len);
+#else
+    extern int host_getlogin_r(char *, size_t) __asm("getlogin_r");
+    return host_getlogin_r(buf, len);
+#endif
+}
+
 char *getlogin(void)
 {
     static __thread char name[64];
     if (name[0])
         return name;
-    struct passwd *pw = getpwuid(getuid());
-    if (!pw || !pw->pw_name)
+
+    if (getlogin_r(name, sizeof(name)) != 0)
         return NULL;
-    strncpy(name, pw->pw_name, sizeof(name) - 1);
-    name[sizeof(name) - 1] = '\0';
     return name;
 }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -5286,6 +5286,17 @@ static const char *test_getlogin_fn(void)
     return 0;
 }
 
+static const char *test_getlogin_r_fn(void)
+{
+    char buf[64];
+    int r = getlogin_r(buf, sizeof(buf));
+    char *name = getlogin();
+    mu_assert("getlogin_r", r == 0 && buf[0] != '\0');
+    if (name)
+        mu_assert("match", strcmp(name, buf) == 0);
+    return 0;
+}
+
 static const char *test_crypt_des(void)
 {
     const char *h = crypt("password", "ab");
@@ -6158,6 +6169,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_getgrouplist_basic),
         REGISTER_TEST("default", test_getgrouplist_overflow),
         REGISTER_TEST("default", test_getlogin_fn),
+        REGISTER_TEST("default", test_getlogin_r_fn),
         REGISTER_TEST("default", test_crypt_des),
         REGISTER_TEST("default", test_crypt_md5),
         REGISTER_TEST("default", test_crypt_sha256),


### PR DESCRIPTION
## Summary
- implement `getlogin_r` in `src/getlogin.c`
- expose the prototype in `include/unistd.h`
- document `getlogin_r` in user/group docs
- add tests for both `getlogin` and `getlogin_r`

## Testing
- `make test` (builds test suite)


------
https://chatgpt.com/codex/tasks/task_e_686041063f208324a3999bde2f957dff