### PR TITLE
Implement mblen with BSD fallback

### DIFF
--- a/docs/strings.md
+++ b/docs/strings.md
@@ -124,7 +124,7 @@ int w = wcswidth(L"hello", 5);      // 5
 ### Single-Byte Conversions
 
 `mblen` returns the number of bytes forming the next multibyte
-character or `-1` when the sequence is invalid. `btowc` converts a
+character or `-1` when the sequence is invalid. ASCII input is handled directly and on BSD systems other locales are passed to the host C library. `btowc` converts a
 single byte to a `wchar_t` using `mbrtowc` and yields `-1` on failure.
 `wctob` performs the opposite operation through `wcrtomb`, returning the
 resulting byte or `-1` when the character cannot be represented.

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -28,6 +28,7 @@ typedef struct { int __dummy; } mbstate_t;
 int mbtowc(wchar_t *pwc, const char *s, size_t n);
 /* Convert a wide character to a multibyte sequence */
 int wctomb(char *s, wchar_t wc);
+int mblen(const char *s, size_t n);
 /* Length of a wide-character string */
 size_t wcslen(const wchar_t *s);
 /* Copy a wide-character string */

--- a/src/wchar.c
+++ b/src/wchar.c
@@ -34,6 +34,27 @@ int wctomb(char *s, wchar_t wc)
     return 1;
 }
 
+/* Return length in bytes of next multibyte character. */
+int mblen(const char *s, size_t n)
+{
+    if (!s)
+        return 0;
+    if (n == 0)
+        return -1;
+    unsigned char c = (unsigned char)*s;
+    if (c < 0x80)
+        return c ? 1 : 0;
+#if defined(__FreeBSD__) || defined(__NetBSD__) ||  \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    extern int host_mblen(const char *, size_t) __asm("mblen");
+    return host_mblen(s, n);
+#else
+    (void)n;
+    return -1;
+#endif
+}
+
+
 /* Return the length of wide-character string. */
 size_t wcslen(const wchar_t *s)
 {

--- a/src/wchar_conv.c
+++ b/src/wchar_conv.c
@@ -83,14 +83,6 @@ int wctob(wchar_t wc)
     return (unsigned char)buf[0];
 }
 
-/* Return length in bytes of next multibyte character */
-int mblen(const char *s, size_t n)
-{
-    size_t r = mbrtowc(NULL, s, n, NULL);
-    if (r == (size_t)-1 || r == (size_t)-2)
-        return -1;
-    return (int)r;
-}
 
 /* Check if multibyte string contains non-ASCII characters. */
 static int has_non_ascii_mb(const char *s)

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1769,6 +1769,12 @@ static const char *test_single_byte_conv(void)
 {
     char bad[] = { (char)0xC0, 0 };
     mu_assert("mblen ascii", mblen("A", 1) == 1);
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+    mu_assert("mblen utf8", mblen("\xC3\xA9", 2) == 2);
+#else
+    mu_assert("mblen utf8", mblen("\xC3\xA9", 2) == -1);
+#endif
     mu_assert("btowc ascii", btowc('A') == L'A');
     mu_assert("wctob ascii", wctob(L'A') == 'A');
     mu_assert("btowc eof", btowc(-1) == -1);


### PR DESCRIPTION
## Summary
- implement `mblen` in `src/wchar.c`
- remove old implementation from `wchar_conv.c`
- expose the function via `wchar.h`
- document the behaviour in `strings.md`
- test single and multi-byte cases for `mblen`

## Testing
- `make test` *(fails: couldn't run tests due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68603f69fea083249bdedda6ec8a3200