### PR TITLE
Add strfmon support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ SRC := \
     src/strftime.c \
     src/wcsftime.c \
     src/strptime.c \
+    src/strfmon.c \
     src/stat.c \
     src/statvfs.c \
     src/utime.c \

--- a/docs/provided_headers.md
+++ b/docs/provided_headers.md
@@ -14,6 +14,7 @@ err.h        - err/warn convenience helpers
 getopt.h     - option parsing
 io.h         - unbuffered I/O primitives
 locale.h     - locale helpers
+monetary.h   - currency formatting helper
 math.h       - basic math routines
 complex.h   - basic complex math routines
 memory.h     - heap allocation

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -213,3 +213,15 @@ two accept an array of `struct option` describing long names. The
 prefixed with a single dash. Both long parsing functions return the
 option's value field or set a flag when supplied in the table.
 
+
+## Monetary Formatting
+
+`strfmon` converts floating point values to formatted currency strings.
+Only the `"C"` locale is supported, so the dollar sign is used as the
+currency symbol. Width and precision specifiers are honored but
+advanced flags are ignored.
+
+```c
+char out[32];
+strfmon(out, sizeof(out), "%8.2n", 12.3); // "   $12.30"
+```

--- a/include/monetary.h
+++ b/include/monetary.h
@@ -1,0 +1,14 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Purpose: Declarations for monetary formatting.
+ */
+#ifndef MONETARY_H
+#define MONETARY_H
+
+#include <sys/types.h>
+#include <stddef.h>
+
+ssize_t strfmon(char *s, size_t max, const char *format, ...);
+
+#endif /* MONETARY_H */

--- a/src/strfmon.c
+++ b/src/strfmon.c
@@ -1,0 +1,132 @@
+/*
+ * BSD 2-Clause License: Redistribution and use in source and binary forms, with or without modification, are permitted provided that the copyright notice and this permission notice appear in all copies. This software is provided "as is" without warranty.
+ *
+ * Purpose: Implements a minimal strfmon for vlibc. Provides basic POSIX compliant monetary formatting for ASCII locales.
+ */
+
+#include "monetary.h"
+#include "string.h"
+#include "stdio.h"
+#include "errno.h"
+#include <stdarg.h>
+
+ssize_t strfmon(char *s, size_t max, const char *format, ...)
+{
+    if (!s || !format || max == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    va_list ap;
+    va_start(ap, format);
+    size_t pos = 0;
+
+    for (const char *p = format; *p; ++p) {
+        if (*p != '%') {
+            if (pos + 1 >= max) {
+                errno = E2BIG;
+                va_end(ap);
+                return -1;
+            }
+            s[pos++] = *p;
+            continue;
+        }
+        ++p;
+        if (*p == '%') {
+            if (pos + 1 >= max) {
+                errno = E2BIG;
+                va_end(ap);
+                return -1;
+            }
+            s[pos++] = '%';
+            continue;
+        }
+
+        int left_align = 0;
+        int width = 0;
+        int prec = 2;
+        /* Skip flags we don't implement */
+        for (;; ++p) {
+            if (*p == '-') {
+                left_align = 1;
+            } else if (*p == '+' || *p == '(' || *p == '!' || *p == '^' || *p == '=') {
+                /* ignore */
+            } else {
+                break;
+            }
+        }
+        /* Parse width */
+        while (*p >= '0' && *p <= '9') {
+            width = width * 10 + (*p - '0');
+            ++p;
+        }
+        if (*p == '.') {
+            ++p;
+            prec = 0;
+            while (*p >= '0' && *p <= '9') {
+                prec = prec * 10 + (*p - '0');
+                ++p;
+            }
+        }
+        char conv = *p;
+        if (conv != 'n' && conv != 'i') {
+            errno = EINVAL;
+            va_end(ap);
+            return -1;
+        }
+        double val = va_arg(ap, double);
+        int neg = val < 0.0;
+        if (neg)
+            val = -val;
+
+        char numbuf[64];
+        if (snprintf(numbuf, sizeof(numbuf), "%.*f", prec, val) >= (int)sizeof(numbuf)) {
+            errno = E2BIG;
+            va_end(ap);
+            return -1;
+        }
+
+        char curbuf[80];
+        if (neg)
+            snprintf(curbuf, sizeof(curbuf), "-$%s", numbuf);
+        else
+            snprintf(curbuf, sizeof(curbuf), "$%s", numbuf);
+
+        size_t len = strlen(curbuf);
+        size_t pad = 0;
+        if (width > 0 && (size_t)width > len)
+            pad = (size_t)width - len;
+
+        if (!left_align) {
+            if (pos + pad + len >= max) {
+                errno = E2BIG;
+                va_end(ap);
+                return -1;
+            }
+            for (size_t i = 0; i < pad; ++i)
+                s[pos++] = ' ';
+            memcpy(s + pos, curbuf, len);
+            pos += len;
+        } else {
+            if (pos + pad + len >= max) {
+                errno = E2BIG;
+                va_end(ap);
+                return -1;
+            }
+            memcpy(s + pos, curbuf, len);
+            pos += len;
+            for (size_t i = 0; i < pad; ++i)
+                s[pos++] = ' ';
+        }
+    }
+
+    if (pos >= max) {
+        errno = E2BIG;
+        va_end(ap);
+        return -1;
+    }
+    s[pos] = '\0';
+    va_end(ap);
+    return (ssize_t)pos;
+}
+

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -49,6 +49,7 @@
 #include "../include/complex.h"
 #include "../include/locale.h"
 #include "../include/langinfo.h"
+#include "../include/monetary.h"
 #include "../include/regex.h"
 #include "../include/ftw.h"
 #include "../include/fts.h"
@@ -3224,6 +3225,15 @@ static const char *test_wcsftime_extended(void)
     return 0;
 }
 
+static const char *test_strfmon_basic(void)
+{
+    char buf[32];
+    ssize_t n = strfmon(buf, sizeof(buf), "%n", 42.5);
+    mu_assert("strfmon len", n == (ssize_t)strlen("$42.50"));
+    mu_assert("strfmon out", strcmp(buf, "$42.50") == 0);
+    return 0;
+}
+
 static const char *test_strptime_basic(void)
 {
     struct tm tm;
@@ -6140,6 +6150,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_strftime_extended),
         REGISTER_TEST("default", test_wcsftime_basic),
         REGISTER_TEST("default", test_wcsftime_extended),
+        REGISTER_TEST("default", test_strfmon_basic),
         REGISTER_TEST("default", test_strptime_basic),
         REGISTER_TEST("default", test_strptime_short_input),
         REGISTER_TEST("default", test_time_conversions),


### PR DESCRIPTION
## Summary
- implement minimal `strfmon` currency formatter
- expose new API in `include/monetary.h`
- document monetary formatting usage
- add basic strfmon tests
- compile new object in the build
- list `monetary.h` among provided headers

## Testing
- `make test` *(fails: cc compile output only)*
- `timeout 5 ./tests/run_tests` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_686041a4cef48324bc05541212298778