### PR TITLE
Fix env realloc cleanup and add test

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -106,6 +106,10 @@ int setenv(const char *name, const char *value, int overwrite)
         newflags = realloc(environ_flags, sizeof(unsigned char) * (count + 2));
         if (!newenv || !newflags) {
             free(entry);
+            if (newenv && newenv != environ)
+                free(newenv);
+            if (newflags && newflags != environ_flags)
+                free(newflags);
             return -1;
         }
         environ = newenv;

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3501,6 +3501,19 @@ static const char *test_setenv_overwrite_loop(void)
     return 0;
 }
 
+static const char *test_setenv_alloc_fail(void)
+{
+    env_init(NULL);
+    setenv("A", "1", 1);
+    vlibc_test_alloc_fail_after = 2;
+    errno = 0;
+    int r = setenv("B", "2", 1);
+    mu_assert("alloc fail", r == -1 && errno == ENOMEM);
+    vlibc_test_alloc_fail_after = -1;
+    clearenv();
+    return 0;
+}
+
 static const char *test_putenv_setenv_clearenv(void)
 {
     env_init(NULL);
@@ -6048,6 +6061,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("memory", test_reallocarray_basic),
         REGISTER_TEST("memory", test_recallocarray_grow),
         REGISTER_TEST("memory", test_setenv_overwrite_loop),
+        REGISTER_TEST("memory", test_setenv_alloc_fail),
         REGISTER_TEST("memory", test_memory_ops),
         REGISTER_TEST("default", test_io),
         REGISTER_TEST("default", test_lseek_dup),


### PR DESCRIPTION
## Summary
- fix partial allocation cleanup in `setenv`
- add regression test covering allocation failure in `setenv`

## Testing
- `make test TEST_GROUP=memory` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_686044b1ca8083249fa25f733052fd32