### PR TITLE
Fix longjmp const cast warning

### DIFF
--- a/src/ucontext.c
+++ b/src/ucontext.c
@@ -58,7 +58,7 @@ int setcontext(const ucontext_t *ucp)
         return -1;
     }
     sigprocmask(SIG_SETMASK, &ucp->uc_sigmask, NULL);
-    longjmp(ucp->__jmpbuf, 1);
+    longjmp((struct __jmp_buf_tag *)ucp->__jmpbuf, 1);
     __builtin_unreachable();
 }
 


### PR DESCRIPTION
## Summary
- cast `ucp->__jmpbuf` to `struct __jmp_buf_tag*` in `setcontext`

## Testing
- `make 2>&1 | tee /tmp/make.log >/tmp/make_stdout.log`
- `grep -n "discard" /tmp/make.log`

------
https://chatgpt.com/codex/tasks/task_e_68604897287083248704c7b7f735c10b