### PR TITLE
Fix unused mq_wait warnings

### DIFF
--- a/src/mqueue.c
+++ b/src/mqueue.c
@@ -20,7 +20,8 @@
 #include "fcntl.h"
 #include "syscall.h"
 
-static int mq_wait(mqd_t mqdes, short events, const struct timespec *abstime)
+static __attribute__((unused))
+int mq_wait(mqd_t mqdes, short events, const struct timespec *abstime)
 {
     struct timespec now;
     while (1) {


### PR DESCRIPTION
## Summary
- mark `mq_wait` with `__attribute__((unused))` to silence unused warnings

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6860491e50c88324a4b3a093173a9866