### PR TITLE
Fix unused parameter warning in fmtmsg

### DIFF
--- a/src/fmtmsg.c
+++ b/src/fmtmsg.c
@@ -75,6 +75,7 @@ static char *
 printfmt(char *msgverb, long class, const char *label, int sev,
         const char *text, const char *act, const char *tag)
 {
+    (void)class;
     size_t size;
     char *comp, *output;
     const char *sevname;


### PR DESCRIPTION
## Summary
- silence warning in `printfmt` for unused `class`

## Testing
- `make test` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_686048a1ccd0832489710113a6092e7b