### PR TITLE
Add error handling in vsyslog send

### DIFF
--- a/docs/other.md
+++ b/docs/other.md
@@ -26,7 +26,8 @@ static void debug(const char *fmt, ...)
 ```
 
 Messages are written using a Unix datagram socket so applications can integrate
-with the host's syslog daemon.
+with the host's syslog daemon. If sending the message fails `vsyslog` reports
+the error via `perror` and the `errno` value reflects the failure.
 
 ## Raw System Calls
 

--- a/src/syslog.c
+++ b/src/syslog.c
@@ -96,8 +96,11 @@ void vsyslog(int priority, const char *format, va_list ap)
     memcpy(buf + n, msg, len);
     n += len;
 
-    if (log_fd != -1)
-        send(log_fd, buf, n, 0);
+    if (log_fd != -1) {
+        ssize_t r = send(log_fd, buf, n, 0);
+        if (r < 0)
+            perror("vsyslog");
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- check the return value of `send` in `vsyslog`
- document new error handling behavior

## Testing
- `make test`
- `./tests/run_tests` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_686049f534288324bb5b768a664f9864