### PR TITLE
Fix AIO task cleanup on thread creation failure

### DIFF
--- a/src/aio.c
+++ b/src/aio.c
@@ -95,6 +95,7 @@ static int start_task(struct aiocb *cb, void *(*fn)(void *))
     int r = pthread_create(&t->thr, NULL, fn, t);
     if (r != 0) {
         free(t);
+        cb->__reserved[0] = 0;
         errno = r;
         return -1;
     }


### PR DESCRIPTION
## Summary
- clear `cb->__reserved[0]` if `pthread_create` fails in `aio.c`

## Testing
- `make test` *(fails: redefinition of `test_setenv_alloc_fail` in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68604bacacc48324a9e3237ce35ec3ab