### PR TITLE
Initialize ifaddrs flags before ioctl

### DIFF
--- a/src/ifaddrs.c
+++ b/src/ifaddrs.c
@@ -110,6 +110,7 @@ int getifaddrs(struct ifaddrs **ifap)
         struct ifreq req;
         memset(&req, 0, sizeof(req));
         strncpy(req.ifr_name, r->ifr_name, IFNAMSIZ - 1);
+        cur->ifa_flags = 0;
         if (ioctl(fd, SIOCGIFFLAGS, &req) == 0)
             cur->ifa_flags = (unsigned int)req.ifr_flags;
         if (ioctl(fd, SIOCGIFNETMASK, &req) == 0) {


### PR DESCRIPTION
## Summary
- ensure `struct ifreq req` and `ifa_flags` start with zeroed data
- keep `ifa_flags` at zero if `SIOCGIFFLAGS` fails

## Testing
- `make libvlibc.a`
- `make test` *(fails: redefinition of `test_setenv_alloc_fail`)*

------
https://chatgpt.com/codex/tasks/task_e_68604ce2de54832495f5ac103f58da36