### PR TITLE
Fix errno on strdup failure

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -126,6 +126,7 @@ int setenv(const char *name, const char *value, int overwrite)
                 char *dup = strdup(environ[i]);
                 if (!dup) {
                     free(entry);
+                    errno = ENOMEM;
                     return -1;
                 }
                 environ[i] = dup;
@@ -149,6 +150,7 @@ int setenv(const char *name, const char *value, int overwrite)
                 free(newenv);
                 free(newflags);
                 free(entry);
+                errno = ENOMEM;
                 return -1;
             }
             newflags[i] = 1;
@@ -212,8 +214,10 @@ int putenv(const char *str)
         for (int i = 0; i < count; ++i) {
             if (!environ_flags[i]) {
                 char *dup = strdup(environ[i]);
-                if (!dup)
+                if (!dup) {
+                    errno = ENOMEM;
                     return -1;
+                }
                 environ[i] = dup;
                 environ_flags[i] = 1;
             }
@@ -233,6 +237,7 @@ int putenv(const char *str)
                     free(newenv[j]);
                 free(newenv);
                 free(newflags);
+                errno = ENOMEM;
                 return -1;
             }
             newflags[i] = 1;
@@ -298,6 +303,7 @@ int clearenv(void)
                     free(newenv[j]);
                 free(newenv);
                 free(newflags);
+                errno = ENOMEM;
                 return -1;
             }
             newflags[i] = 1;

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3514,6 +3514,22 @@ static const char *test_setenv_alloc_fail(void)
     return 0;
 }
 
+static const char *test_setenv_strdup_fail(void)
+{
+    char *envp[] = { "BASE=1", NULL };
+    env_init(envp);
+
+    vlibc_test_alloc_fail_after = 3;
+    errno = 0;
+    int r = setenv("NEW", "val", 1);
+    mu_assert("dup fail", r == -1);
+    mu_assert("errno ENOMEM", errno == ENOMEM);
+    vlibc_test_alloc_fail_after = -1;
+
+    env_init(NULL);
+    return 0;
+}
+
 static const char *test_putenv_setenv_clearenv(void)
 {
     env_init(NULL);
@@ -6090,6 +6106,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("memory", test_recallocarray_grow),
         REGISTER_TEST("memory", test_setenv_overwrite_loop),
         REGISTER_TEST("memory", test_setenv_alloc_fail),
+        REGISTER_TEST("memory", test_setenv_strdup_fail),
         REGISTER_TEST("memory", test_memory_ops),
         REGISTER_TEST("default", test_io),
         REGISTER_TEST("default", test_lseek_dup),
@@ -6227,6 +6244,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_putenv_setenv_clearenv),
         REGISTER_TEST("default", test_putenv_unsetenv_stack),
         REGISTER_TEST("default", test_setenv_alloc_fail),
+        REGISTER_TEST("default", test_setenv_strdup_fail),
         REGISTER_TEST("default", test_locale_from_env),
         REGISTER_TEST("default", test_locale_objects),
         REGISTER_TEST("default", test_langinfo_codeset),


### PR DESCRIPTION
## Summary
- ensure `errno` is set when `strdup` fails in environment functions
- test this behaviour by forcing an allocation failure

## Testing
- `make test` *(fails: redefinition of `test_setenv_alloc_fail`)*

------
https://chatgpt.com/codex/tasks/task_e_68604bd2307c8324990d3d47e71d01e8