### PR TITLE
Fix path copying in directory traversal

### DIFF
--- a/src/ftw.c
+++ b/src/ftw.c
@@ -82,7 +82,7 @@ static int do_nftw(const char *path,
             memcpy(child, path, len);
             if (add)
                 child[len] = '/';
-            strcpy(child + len + add, e->d_name);
+            memcpy(child + len + add, e->d_name, name_len + 1);
             r = do_nftw(child, fn, fdlimit, flags, level + 1);
             free(child);
             if (r != 0) {


### PR DESCRIPTION
## Summary
- avoid overflow when assembling child paths
- use memcpy for bounded copying

## Testing
- `make test TEST_GROUP=default` *(fails: redefinition of `test_setenv_alloc_fail`)*

------
https://chatgpt.com/codex/tasks/task_e_68604cd86a7c83249bb31eb89add42dc