### PR TITLE
Implement aio_cancel descriptor check

### DIFF
--- a/src/aio.c
+++ b/src/aio.c
@@ -182,7 +182,9 @@ int aio_suspend(const struct aiocb *const list[], int n,
 
 int aio_cancel(int fd, struct aiocb *cb)
 {
-    (void)fd;
+    if (!cb || cb->aio_fildes != fd)
+        return AIO_ALLDONE;
+
     struct aio_task *t = get_task(cb);
     if (!t)
         return AIO_ALLDONE;


### PR DESCRIPTION
## Summary
- guard aio_cancel against `NULL` cb or mismatched descriptor
- extend tests with coverage for aio_cancel

## Testing
- `make test` *(fails: redefinition of `test_setenv_alloc_fail`)*

------
https://chatgpt.com/codex/tasks/task_e_68604df69a088324b4ad2a9c96a13fb3