### PR TITLE
Fix stat initialization in fts_read

### DIFF
--- a/src/fts.c
+++ b/src/fts.c
@@ -127,6 +127,7 @@ FTSENT *fts_read(FTS *fts)
         return NULL;
 
     struct stat st;
+    memset(&st, 0, sizeof(st));
     int r;
     if (fts->options & FTS_PHYSICAL)
         r = lstat(n->path, &st);
@@ -156,6 +157,8 @@ FTSENT *fts_read(FTS *fts)
     }
     if (r == 0)
         ent->fts_stat = st;
+    else
+        memset(&ent->fts_stat, 0, sizeof(ent->fts_stat));
 
     if (ent->fts_info == FTS_D) {
         DIR *d = opendir(ent->fts_path);


### PR DESCRIPTION
## Summary
- avoid using uninitialized memory in `fts_read`
- clear the returned `fts_stat` field when stat/lstat fails

## Testing
- `make test` *(fails: redefinition of `test_setenv_alloc_fail` in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68604dffb6848324842ab01be907b883