### PR TITLE
Guard unused mq_wait when timed syscalls present

### DIFF
--- a/src/mqueue.c
+++ b/src/mqueue.c
@@ -20,6 +20,22 @@
 #include "fcntl.h"
 #include "syscall.h"
 
+#if defined(SYS_mq_timedsend_time64) || defined(SYS_mq_timedsend) || \
+    defined(SYS_mq_timedreceive_time64) || defined(SYS_mq_timedreceive) || \
+    defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+
+static inline __attribute__((unused))
+int mq_wait(mqd_t mqdes, short events, const struct timespec *abstime)
+{
+    (void)mqdes;
+    (void)events;
+    (void)abstime;
+    return 0;
+}
+
+#else
+
 static __attribute__((unused))
 int mq_wait(mqd_t mqdes, short events, const struct timespec *abstime)
 {
@@ -54,6 +70,8 @@ int mq_wait(mqd_t mqdes, short events, const struct timespec *abstime)
         return 0;
     }
 }
+
+#endif
 
 /* Open or create a POSIX message queue. */
 mqd_t mq_open(const char *name, int oflag, ...)


### PR DESCRIPTION
## Summary
- guard `mq_wait` definition with timed message queue syscall check
- use a static inline stub when timed syscalls are available

## Testing
- `make test` *(fails: redefinition of `test_setenv_alloc_fail`)*

------
https://chatgpt.com/codex/tasks/task_e_68605021bd64832493477edb0b4133b8