### PR TITLE
Fix mkostemps suffixlen checks

### DIFF
--- a/docs/io.md
+++ b/docs/io.md
@@ -261,8 +261,9 @@ characters and opens the resulting file. `mkdtemp` performs the same
 replacement but creates a directory instead. `mkostemp` behaves like
 `mkstemp` but accepts additional open flags such as `O_CLOEXEC`.  The
 `mkostemps` variant allows a static suffix to remain after the replaced
-`XXXXXX` sequence. `tmpfile` returns a stream backed by an anonymous
-temporary file that is unlinked immediately.
+`XXXXXX` sequence. The suffix length must be non-negative and less than
+the length of `template` minus six. `tmpfile` returns a stream backed by
+an anonymous temporary file that is unlinked immediately.
 
 ```c
 char path[] = "/tmp/exampleXXXXXX";

--- a/src/tempfile.c
+++ b/src/tempfile.c
@@ -103,20 +103,14 @@ int mkostemp(char *template, int flags)
  */
 int mkostemps(char *template, int suffixlen, int flags)
 {
-    if (!template || suffixlen < 0) {
-        errno = EINVAL;
-        return -1;
-    }
+    if (!template)
+        goto invalid;
     size_t len = strlen(template);
-    if (len < (size_t)(suffixlen + 6)) {
-        errno = EINVAL;
-        return -1;
-    }
+    if (len < 6 || suffixlen < 0 || (size_t)suffixlen >= len - 6)
+        goto invalid;
     char *pos = template + len - suffixlen - 6;
-    if (strncmp(pos, "XXXXXX", 6) != 0) {
-        errno = EINVAL;
-        return -1;
-    }
+    if (strncmp(pos, "XXXXXX", 6) != 0)
+        goto invalid;
     for (int i = 0; i < 100; i++) {
         if (replace_x_at(pos) < 0)
             return -1;
@@ -127,6 +121,9 @@ int mkostemps(char *template, int suffixlen, int flags)
             return -1;
     }
     errno = EEXIST;
+    return -1;
+invalid:
+    errno = EINVAL;
     return -1;
 }
 

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -861,6 +861,16 @@ static const char *test_mkostemps_cloexec(void)
     return 0;
 }
 
+static const char *test_mkostemps_invalid_suffixlen(void)
+{
+    char tmpl[] = "XXXXXXabc";
+    errno = 0;
+    int fd = mkostemps(tmpl, 3, O_CLOEXEC);
+    mu_assert("invalid suffix", fd == -1);
+    mu_assert("errno EINVAL", errno == EINVAL);
+    return 0;
+}
+
 static const char *test_isatty_stdin(void)
 {
     int fd = open("tmp_isatty_file", O_CREAT | O_RDWR, 0644);
@@ -6169,6 +6179,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_pipe2_cloexec),
         REGISTER_TEST("default", test_mkostemp_cloexec),
         REGISTER_TEST("default", test_mkostemps_cloexec),
+        REGISTER_TEST("default", test_mkostemps_invalid_suffixlen),
         REGISTER_TEST("default", test_byte_order),
         REGISTER_TEST("default", test_isatty_stdin),
         REGISTER_TEST("default", test_ttyname_dev_tty),


### PR DESCRIPTION
## Summary
- validate that mkostemps uses a non-negative suffix shorter than the template minus six
- document suffix length constraint
- test mkostemps invalid suffix handling

## Testing
- `make test` *(fails: redefinition of `test_setenv_alloc_fail`)*

------
https://chatgpt.com/codex/tasks/task_e_68605014aa2c8324ba7504426e703574