### PR TITLE
Fix lseek errno handling

### DIFF
--- a/src/fd.c
+++ b/src/fd.c
@@ -29,7 +29,7 @@
 off_t lseek(int fd, off_t offset, int whence)
 {
     long ret = vlibc_syscall(SYS_lseek, fd, (long)offset, whence, 0, 0, 0);
-    if (ret == -1) {
+    if (ret < 0) {
         errno = -ret;
         return (off_t)-1;
     }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -532,6 +532,15 @@ static const char *test_lseek_negative_offset(void)
     return 0;
 }
 
+static const char *test_lseek_errno(void)
+{
+    errno = 0;
+    off_t off = lseek(-1, 0, SEEK_SET);
+    mu_assert("lseek fail", off == (off_t)-1);
+    mu_assert("errno EBADF", errno == EBADF);
+    return 0;
+}
+
 static const char *test_pread_pwrite(void)
 {
     const char *fname = "tmp_pread_file";
@@ -6158,6 +6167,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_io),
         REGISTER_TEST("default", test_lseek_dup),
         REGISTER_TEST("default", test_lseek_negative_offset),
+        REGISTER_TEST("default", test_lseek_errno),
         REGISTER_TEST("default", test_pread_pwrite),
         REGISTER_TEST("default", test_preadv_pwritev),
         REGISTER_TEST("default", test_readv_writev),


### PR DESCRIPTION
## Summary
- handle all error returns in `lseek`
- add regression test for errno propagation

## Testing
- `make test` *(fails: redefinition of `test_setenv_alloc_fail`)*

------
https://chatgpt.com/codex/tasks/task_e_6860502fef7083248e8b39a78ff63fbf