### PR TITLE
Use thread-local group buffers

### DIFF
--- a/docs/users_groups.md
+++ b/docs/users_groups.md
@@ -71,8 +71,9 @@ void endgrent(void);
 
 As with the password file, BSD platforms parse the group database directly.
 The path can be overridden via the `VLIBC_GROUP` environment variable when
-running tests. The `*_r` variants fill caller provided buffers and are
-thread-safe.
+running tests. `getgrgid()` and `getgrnam()` return pointers into thread-local
+storage so concurrent calls from different threads are independent. The `*_r`
+variants fill caller provided buffers and are thread-safe.
 
 `setgrent()`, `getgrent()` and `endgrent()` enumerate group entries in
 order.  As with the passwd enumeration, BSD platforms use the host

--- a/src/grp.c
+++ b/src/grp.c
@@ -52,9 +52,9 @@ static const char *group_path(void)
     return "/etc/group";
 }
 
-static struct group gr;
-static char *members[64];
-static char linebuf[256];
+static __thread struct group gr;
+static __thread char *members[64];
+static __thread char linebuf[256];
 
 /* parse_line() - parse an entry from the group file */
 static struct group *parse_line(const char *line)
@@ -171,11 +171,11 @@ static const char *group_path(void)
     return "/etc/group";
 }
 
-static struct group gr;
-static char *members[64];
-static char linebuf[256];
-static char filebuf[4096];
-static char *next_line;
+static __thread struct group gr;
+static __thread char *members[64];
+static __thread char linebuf[256];
+static __thread char filebuf[4096];
+static __thread char *next_line;
 
 /* parse_line() - parse an entry from the group file */
 static struct group *parse_line(const char *line)

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -232,6 +232,23 @@ static void *hostent_r_worker(void *arg)
     return NULL;
 }
 
+struct grp_thread_arg {
+    const char *name;
+    gid_t gid;
+};
+
+static void *grp_lookup_worker(void *arg)
+{
+    struct grp_thread_arg *g = arg;
+    struct group *by_name = getgrnam(g->name);
+    struct group *by_gid = getgrgid(g->gid);
+    if (!by_name || !by_gid)
+        return (void *)1;
+    if (strcmp(by_name->gr_name, g->name) != 0 || by_gid->gr_gid != g->gid)
+        return (void *)2;
+    return NULL;
+}
+
 static const char *test_malloc(void)
 {
     void *p = malloc(16);
@@ -5420,6 +5437,37 @@ static const char *test_group_enum(void)
     return 0;
 }
 
+static const char *test_group_threadsafe(void)
+{
+    char tmpl[] = "/tmp/grpthrXXXXXX";
+    int fd = mkstemp(tmpl);
+    mu_assert("mkstemp", fd >= 0);
+    const char data[] =
+        "root:x:0:\n"
+        "staff:x:50:alice,bob\n";
+    mu_assert("write", write(fd, data, sizeof(data) - 1) == (ssize_t)(sizeof(data) - 1));
+    close(fd);
+
+    setenv("VLIBC_GROUP", tmpl, 1);
+
+    struct grp_thread_arg a1 = { "root", 0 };
+    struct grp_thread_arg a2 = { "staff", 50 };
+    pthread_t t1, t2;
+    pthread_create(&t1, NULL, grp_lookup_worker, &a1);
+    pthread_create(&t2, NULL, grp_lookup_worker, &a2);
+    void *r1 = (void *)1;
+    void *r2 = (void *)1;
+    pthread_join(t1, &r1);
+    pthread_join(t2, &r2);
+
+    unsetenv("VLIBC_GROUP");
+    unlink(tmpl);
+
+    mu_assert("grp thread1", r1 == NULL);
+    mu_assert("grp thread2", r2 == NULL);
+    return 0;
+}
+
 static const char *test_getgrouplist_basic(void)
 {
     char tmpl[] = "/tmp/glstXXXXXX";
@@ -6368,6 +6416,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_passwd_enum),
         REGISTER_TEST("default", test_passwd_long_entries),
         REGISTER_TEST("default", test_group_enum),
+        REGISTER_TEST("default", test_group_threadsafe),
         REGISTER_TEST("default", test_getgrouplist_basic),
         REGISTER_TEST("default", test_getgrouplist_overflow),
         REGISTER_TEST("default", test_getlogin_fn),


### PR DESCRIPTION
## Summary
- ensure `grp.c` uses thread-local storage
- document thread-local group lookups
- test concurrent group lookups

## Testing
- `make test` *(fails: redefinition of `test_setenv_alloc_fail`)*

------
https://chatgpt.com/codex/tasks/task_e_6860503d7084832483174a909cdc9f3f