### PR TITLE
Fix tdelete return value

### DIFF
--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -144,7 +144,7 @@ int values[] = {4, 2, 7, 1, 6};
 for (int i = 0; i < 5; i++)
     tsearch(&values[i], &root, int_cmp);
 int *p = tfind(&values[2], &root, int_cmp);  // points to 7
-tdelete(&values[1], &root, int_cmp);         // remove 2
+int *parent = tdelete(&values[1], &root, int_cmp); // remove 2, parent->4
 static int sum = 0;
 void collect(const void *node, VISIT v, int l)
 {
@@ -153,6 +153,9 @@ void collect(const void *node, VISIT v, int l)
 }
 twalk(root, collect);   // sum == 18
 ```
+
+`tdelete` returns a pointer to the parent node's key (or a dangling pointer if
+the removed node was the root).
 
 ## Message Formatting
 

--- a/src/search_tree.c
+++ b/src/search_tree.c
@@ -57,16 +57,26 @@ void *tfind(const void *key, void *const *rootp,
 void *tdelete(const void *key, void **rootp,
               int (*compar)(const void *, const void *))
 {
+    if (!rootp || !*rootp)
+        return NULL;
+
     struct node **p = (struct node **)rootp;
+    struct node *parent = NULL;
+
+    while (*p) {
+        int r = compar(key, (*p)->key);
+        if (r == 0)
+            break;
+        parent = *p;
+        p = (r < 0) ? &(*p)->left : &(*p)->right;
+    }
+
     if (!*p)
         return NULL;
-    int r = compar(key, (*p)->key);
-    if (r < 0)
-        return tdelete(key, (void **)&(*p)->left, compar);
-    if (r > 0)
-        return tdelete(key, (void **)&(*p)->right, compar);
 
     struct node *t = *p;
+    void *ret = parent ? (void *)&parent->key : (void *)&t->key; /* POSIX */
+
     if (!t->left) {
         *p = t->right;
         free(t);
@@ -85,7 +95,7 @@ void *tdelete(const void *key, void **rootp,
         free(min);
         *minp = child;
     }
-    return *p;
+    return ret;
 }
 
 static void walk(const struct node *n,

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -5676,7 +5676,8 @@ static const char *test_tsearch_basic(void)
     int *p = tfind(&vals[2], &root, int_cmp);
     mu_assert("find 7", p && *p == 7);
 
-    tdelete(&vals[1], &root, int_cmp);
+    int *parent = tdelete(&vals[1], &root, int_cmp);
+    mu_assert("delete ret", parent && *parent == 4);
     mu_assert("deleted", tfind(&vals[1], &root, int_cmp) == NULL);
 
     tree_sum = 0;


### PR DESCRIPTION
## Summary
- return the parent node's key from `tdelete`
- check the returned value in the tree tests
- document parent-return behavior

## Testing
- `make test` *(fails: redefinition of `test_setenv_alloc_fail`)*

------
https://chatgpt.com/codex/tasks/task_e_68605046011483249033b8c1c6efe157