### PR TITLE
Fix setenv realloc failure and add test

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -113,10 +113,7 @@ int setenv(const char *name, const char *value, int overwrite)
             if (newflags && newflags != environ_flags)
                 free(newflags);
             free(entry);
-            if (newenv && newenv != environ)
-                free(newenv);
-            if (newflags && newflags != environ_flags)
-                free(newflags);
+            errno = ENOMEM;
             return -1;
         }
         environ = newenv;

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3584,7 +3584,7 @@ static const char *test_setenv_overwrite_loop(void)
     return 0;
 }
 
-static const char *test_setenv_alloc_fail(void)
+static const char *test_setenv_alloc_fail_basic(void)
 {
     env_init(NULL);
     setenv("A", "1", 1);
@@ -3593,6 +3593,23 @@ static const char *test_setenv_alloc_fail(void)
     int r = setenv("B", "2", 1);
     mu_assert("alloc fail", r == -1 && errno == ENOMEM);
     vlibc_test_alloc_fail_after = -1;
+    clearenv();
+    return 0;
+}
+
+static const char *test_setenv_realloc_fail_errno(void)
+{
+    env_init(NULL);
+    /* establish initial environment */
+    mu_assert("setenv", setenv("A", "1", 1) == 0);
+
+    vlibc_test_alloc_fail_after = 2;
+    errno = 0;
+    int r = setenv("B", "2", 1);
+    mu_assert("realloc fail ret", r == -1);
+    mu_assert("errno ENOMEM", errno == ENOMEM);
+    vlibc_test_alloc_fail_after = -1;
+
     clearenv();
     return 0;
 }
@@ -6220,7 +6237,8 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("memory", test_reallocarray_basic),
         REGISTER_TEST("memory", test_recallocarray_grow),
         REGISTER_TEST("memory", test_setenv_overwrite_loop),
-        REGISTER_TEST("memory", test_setenv_alloc_fail),
+        REGISTER_TEST("memory", test_setenv_alloc_fail_basic),
+        REGISTER_TEST("memory", test_setenv_realloc_fail_errno),
         REGISTER_TEST("memory", test_setenv_strdup_fail),
         REGISTER_TEST("memory", test_memory_ops),
         REGISTER_TEST("default", test_io),
@@ -6361,7 +6379,8 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_env_init_clearenv),
         REGISTER_TEST("default", test_putenv_setenv_clearenv),
         REGISTER_TEST("default", test_putenv_unsetenv_stack),
-        REGISTER_TEST("default", test_setenv_alloc_fail),
+        REGISTER_TEST("default", test_setenv_alloc_fail_basic),
+        REGISTER_TEST("default", test_setenv_realloc_fail_errno),
         REGISTER_TEST("default", test_setenv_strdup_fail),
         REGISTER_TEST("default", test_locale_from_env),
         REGISTER_TEST("default", test_locale_objects),


### PR DESCRIPTION
## Summary
- avoid duplicate frees in `setenv`
- set `errno = ENOMEM` when `realloc` fails
- add regression test for failing `setenv`
- rename existing alloc fail test to avoid duplicate symbol

## Testing
- `make test` *(fails: test execution requires manual interruption)*

------
https://chatgpt.com/codex/tasks/task_e_6860584860d883248ae036d0a6961a05