### PR TITLE
Clamp mq_wait timeout

### DIFF
--- a/src/mqueue.c
+++ b/src/mqueue.c
@@ -19,6 +19,7 @@
 #include "poll.h"
 #include "fcntl.h"
 #include "syscall.h"
+#include <limits.h>
 
 #if defined(SYS_mq_timedsend_time64) || defined(SYS_mq_timedsend) || \
     defined(SYS_mq_timedreceive_time64) || defined(SYS_mq_timedreceive) || \
@@ -54,6 +55,9 @@ int mq_wait(mqd_t mqdes, short events, const struct timespec *abstime)
                        (abstime->tv_nsec - now.tv_nsec) / 1000000;
             if (ms < 0)
                 ms = 0;
+            /* Clamp to INT_MAX to avoid overflow when casting */
+            if (ms > INT_MAX)
+                ms = INT_MAX;
             timeout = (int)ms;
         }
         struct pollfd pfd = { mqdes, events, 0 };

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -4951,6 +4951,33 @@ static const char *test_mqueue_attr(void)
     return 0;
 }
 
+static const char *test_mqueue_large_abstime(void)
+{
+    const char *name = "/vlibc_test_mq_large";
+    struct mq_attr attr = {0};
+    attr.mq_maxmsg = 1;
+    attr.mq_msgsize = 8;
+    mqd_t mq = mq_open(name, O_CREAT | O_RDWR, 0600, &attr);
+    mu_assert("mq_open", mq >= 0);
+
+    /* fill queue so the next send blocks */
+    mu_assert("mq_send", mq_send(mq, "one", 4, 0) == 0);
+
+    pthread_t t;
+    pthread_create(&t, NULL, delayed_recv, &mq);
+
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec += (INT_MAX / 1000) + 2; /* huge absolute time */
+    int r = mq_timedsend(mq, "two", 4, 0, &ts);
+    pthread_join(t, NULL);
+    mu_assert("timedsend", r == 0);
+
+    mq_close(mq);
+    mq_unlink(name);
+    return 0;
+}
+
 static const char *test_named_semaphore_create(void)
 {
     const char *name = "/vlibc_test_sem";
@@ -6423,6 +6450,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_mqueue_timed),
         REGISTER_TEST("default", test_mqueue_blocking_timed),
         REGISTER_TEST("default", test_mqueue_attr),
+        REGISTER_TEST("default", test_mqueue_large_abstime),
         REGISTER_TEST("default", test_named_semaphore_create),
         REGISTER_TEST("default", test_sysv_sem_basic),
         REGISTER_TEST("default", test_ftok_unique),


### PR DESCRIPTION
## Summary
- prevent timeout overflow in mq_wait by clamping to `INT_MAX`
- test sending with a very large absolute timeout

## Testing
- `make test` *(fails: redefinition of `test_setenv_alloc_fail`)*

------
https://chatgpt.com/codex/tasks/task_e_686058ff62cc8324a7fb8f231e969f55