### PR TITLE
Use void** for memory stream buffers

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -24,7 +24,7 @@ typedef struct {
     unsigned char ungot_char;    /* character from ungetc() */
     int is_mem;                  /* stream operates on memory rather than fd */
     int is_wmem;                 /* stream stores wchar_t instead of bytes */
-    char **mem_bufp;             /* pointer to buffer pointer for mem streams */
+    void **mem_bufp;             /* pointer to buffer pointer for mem streams */
     size_t *mem_sizep;           /* pointer to size for mem streams */
     int readable;                /* stream opened for reading */
     int writable;                /* stream opened for writing */

--- a/src/memstream.c
+++ b/src/memstream.c
@@ -30,7 +30,7 @@ FILE *open_memstream(char **bufp, size_t *sizep)
     f->fd = -1;
     f->is_mem = 1;
     f->writable = 1;
-    f->mem_bufp = bufp;
+    f->mem_bufp = (void **)bufp;
     f->mem_sizep = sizep;
     f->bufsize = 128;
     f->buf = malloc(f->bufsize);
@@ -65,7 +65,7 @@ FILE *open_wmemstream(wchar_t **bufp, size_t *sizep)
     f->is_mem = 1;
     f->is_wmem = 1;
     f->writable = 1;
-    f->mem_bufp = (char **)bufp;
+    f->mem_bufp = (void **)bufp;
     f->mem_sizep = sizep;
     f->bufsize = 128 * sizeof(wchar_t);
     f->buf = malloc(f->bufsize);

--- a/src/stdio.c
+++ b/src/stdio.c
@@ -45,8 +45,12 @@ static int flush_buffer(FILE *stream)
             memset(stream->buf + stream->buflen, 0, sizeof(wchar_t));
         else
             stream->buf[stream->buflen] = '\0';
-        if (stream->mem_bufp)
-            *stream->mem_bufp = (char *)stream->buf;
+        if (stream->mem_bufp) {
+            if (stream->is_wmem)
+                *(wchar_t **)stream->mem_bufp = (wchar_t *)stream->buf;
+            else
+                *(char **)stream->mem_bufp = (char *)stream->buf;
+        }
         if (stream->mem_sizep)
             *stream->mem_sizep = stream->is_wmem ?
                 stream->buflen / sizeof(wchar_t) : stream->buflen;


### PR DESCRIPTION
## Summary
- update `FILE` so `mem_bufp` uses a generic void pointer
- update memory stream initializers for new field type
- ensure flushing assigns typed pointers correctly

## Testing
- `make test` *(fails: redefinition of `test_setenv_alloc_fail`)*

------
https://chatgpt.com/codex/tasks/task_e_686059ec147c832486256028b86d7be2