### PR TITLE
Fix errno for invalid fopen mode

### DIFF
--- a/src/stdio.c
+++ b/src/stdio.c
@@ -115,8 +115,10 @@ FILE *fopen(const char *path, const char *mode)
         flags = O_WRONLY | O_CREAT | O_APPEND;
     else if (strcmp(mode, "a+") == 0)
         flags = O_RDWR | O_CREAT | O_APPEND;
-    else
+    else {
+        errno = EINVAL;
         return NULL;
+    }
 
     int fd = open(path, flags, 0644);
     if (fd < 0)

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2591,6 +2591,15 @@ static const char *test_ferror_flag(void)
     return 0;
 }
 
+static const char *test_fopen_invalid_mode(void)
+{
+    errno = 0;
+    FILE *f = fopen("tmp_invalid", "z");
+    mu_assert("invalid mode NULL", f == NULL);
+    mu_assert("errno EINVAL", errno == EINVAL);
+    return 0;
+}
+
 struct write_arg {
     FILE *f;
     char ch;
@@ -6354,6 +6363,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_fflush),
         REGISTER_TEST("default", test_feof_flag),
         REGISTER_TEST("default", test_ferror_flag),
+        REGISTER_TEST("default", test_fopen_invalid_mode),
         REGISTER_TEST("default", test_flockfile_threadsafe),
         REGISTER_TEST("default", test_pthread_create_join),
         REGISTER_TEST("default", test_pthread),


### PR DESCRIPTION
## Summary
- set `errno = EINVAL` for unsupported fopen modes
- test that invalid fopen mode sets errno

## Testing
- `make test` *(fails: timeout due to heavy test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68605d99e3b08324a7c181f6f163339f