### PR TITLE
Validate fmemopen mode parsing

### DIFF
--- a/src/memstream.c
+++ b/src/memstream.c
@@ -98,16 +98,31 @@ FILE *fmemopen(void *buf, size_t size, const char *mode)
     atomic_flag_clear(&f->lock);
     f->fd = -1;
     f->is_mem = 1;
-    if (mode && strchr(mode, '+')) {
+
+    if (!mode)
+        mode = "r";
+
+    if (strcmp(mode, "r") == 0) {
+        f->readable = 1;
+    } else if (strcmp(mode, "r+") == 0) {
         f->readable = 1;
         f->writable = 1;
-    } else if (mode && mode[0] == 'w') {
+    } else if (strcmp(mode, "w") == 0) {
         f->writable = 1;
-    } else if (mode && mode[0] == 'a') {
+    } else if (strcmp(mode, "w+") == 0) {
+        f->readable = 1;
+        f->writable = 1;
+    } else if (strcmp(mode, "a") == 0) {
+        f->writable = 1;
+        f->append = 1;
+    } else if (strcmp(mode, "a+") == 0) {
+        f->readable = 1;
         f->writable = 1;
         f->append = 1;
     } else {
-        f->readable = 1;
+        free(f);
+        errno = EINVAL;
+        return NULL;
     }
     f->buf = buf ? (unsigned char *)buf : malloc(size);
     if (!f->buf) {

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1942,6 +1942,17 @@ static const char *test_wmemstream_basic(void)
     return 0;
 }
 
+static const char *test_fmemopen_bad_mode(void)
+{
+    errno = 0;
+    FILE *f = fmemopen(NULL, 16, "rx");
+    mu_assert("bad mode", f == NULL && errno == EINVAL);
+    errno = 0;
+    f = fmemopen(NULL, 16, "abc");
+    mu_assert("bad mode 2", f == NULL && errno == EINVAL);
+    return 0;
+}
+
 struct cookie_buf {
     char buf[64];
     size_t pos;
@@ -6332,6 +6343,7 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_wmem_ops),
         REGISTER_TEST("default", test_wchar_search),
         REGISTER_TEST("default", test_wmemstream_basic),
+        REGISTER_TEST("default", test_fmemopen_bad_mode),
         REGISTER_TEST("default", test_fopencookie_basic),
         REGISTER_TEST("default", test_iconv_ascii_roundtrip),
         REGISTER_TEST("default", test_iconv_invalid_byte),


### PR DESCRIPTION
## Summary
- validate mode string in `fmemopen`
- error out on bad mode strings
- test invalid `fmemopen` modes

## Testing
- `make test` *(fails: "Nothing to be done")*
- `TEST_GROUP=default timeout 60 ./tests/run_tests` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68605da137888324ae337ca2411a4947