### PR TITLE
Fix putenv ENOMEM handling

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -204,6 +204,7 @@ int putenv(const char *str)
                 free(newenv);
             if (newflags && newflags != environ_flags)
                 free(newflags);
+            errno = ENOMEM;
             return -1;
         }
         environ = newenv;
@@ -225,6 +226,7 @@ int putenv(const char *str)
         if (!newenv || !newflags) {
             free(newenv);
             free(newflags);
+            errno = ENOMEM;
             return -1;
         }
         for (int i = 0; i < count; ++i) {

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3659,6 +3659,39 @@ static const char *test_putenv_unsetenv_stack(void)
     return 0;
 }
 
+static const char *test_putenv_alloc_fail_basic(void)
+{
+    env_init(NULL);
+    vlibc_test_alloc_fail_after = 0;
+    errno = 0;
+    char buf[] = "OOM=1";
+    int r = putenv(buf);
+    mu_assert("alloc fail", r == -1);
+    mu_assert("errno ENOMEM", errno == ENOMEM);
+    vlibc_test_alloc_fail_after = -1;
+    env_init(NULL);
+    return 0;
+}
+
+static const char *test_putenv_realloc_fail_errno(void)
+{
+    env_init(NULL);
+    char base[] = "BASE=1";
+    mu_assert("putenv", putenv(base) == 0);
+
+    vlibc_test_alloc_fail_after = 1;
+    errno = 0;
+    char add[] = "NEW=2";
+    int r = putenv(add);
+    mu_assert("realloc fail", r == -1);
+    mu_assert("errno ENOMEM", errno == ENOMEM);
+    vlibc_test_alloc_fail_after = -1;
+
+    mu_assert("unchanged", getenv("NEW") == NULL && strcmp(getenv("BASE"), "1") == 0);
+    clearenv();
+    return 0;
+}
+
 static const char *test_setenv_alloc_fail(void)
 {
     env_init(NULL);
@@ -6267,6 +6300,8 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("memory", test_setenv_alloc_fail_basic),
         REGISTER_TEST("memory", test_setenv_realloc_fail_errno),
         REGISTER_TEST("memory", test_setenv_strdup_fail),
+        REGISTER_TEST("memory", test_putenv_alloc_fail_basic),
+        REGISTER_TEST("memory", test_putenv_realloc_fail_errno),
         REGISTER_TEST("memory", test_memory_ops),
         REGISTER_TEST("default", test_io),
         REGISTER_TEST("default", test_lseek_dup),
@@ -6406,6 +6441,8 @@ static const char *run_tests(const char *category)
         REGISTER_TEST("default", test_env_init_clearenv),
         REGISTER_TEST("default", test_putenv_setenv_clearenv),
         REGISTER_TEST("default", test_putenv_unsetenv_stack),
+        REGISTER_TEST("default", test_putenv_alloc_fail_basic),
+        REGISTER_TEST("default", test_putenv_realloc_fail_errno),
         REGISTER_TEST("default", test_setenv_alloc_fail_basic),
         REGISTER_TEST("default", test_setenv_realloc_fail_errno),
         REGISTER_TEST("default", test_setenv_strdup_fail),


### PR DESCRIPTION
## Summary
- return ENOMEM on putenv allocation failure
- add regression tests for putenv allocation failure

## Testing
- `make test` *(fails: output truncated)*
- `./tests/run_tests memory` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_68605dab45b08324bf0eb207559b488f