### PR TITLE
Fix wcstombs error handling

### DIFF
--- a/src/wprintf.c
+++ b/src/wprintf.c
@@ -238,6 +238,7 @@ int vfwprintf(FILE *stream, const wchar_t *format, va_list ap)
             size_t mlen = wcstombs(NULL, wbuf, 0);
             if (mlen == (size_t)-1) {
                 free(wbuf);
+                errno = EILSEQ;
                 return -1;
             }
             char *mbuf = malloc(mlen + 1);


### PR DESCRIPTION
## Summary
- verify `wcstombs` result before converting wide output

## Testing
- `make test` *(fails: tests hang when running `run_tests`)*

------
https://chatgpt.com/codex/tasks/task_e_68606d2094e08324a6c763ee7f535075