### PR TITLE
Check empty names in POSIX shm helpers

### DIFF
--- a/src/shm.c
+++ b/src/shm.c
@@ -28,7 +28,11 @@ int shm_open(const char *name, int oflag, mode_t mode)
     extern int host_shm_open(const char *, int, mode_t) __asm__("shm_open");
     return host_shm_open(name, oflag, mode);
 #else
-    if (!name || name[0] != '/') {
+    if (!name || name[0] == '\0') {
+        errno = EINVAL;
+        return -1;
+    }
+    if (name[0] != '/') {
         errno = EINVAL;
         return -1;
     }
@@ -59,7 +63,11 @@ int shm_unlink(const char *name)
     extern int host_shm_unlink(const char *) __asm__("shm_unlink");
     return host_shm_unlink(name);
 #else
-    if (!name || name[0] != '/') {
+    if (!name || name[0] == '\0') {
+        errno = EINVAL;
+        return -1;
+    }
+    if (name[0] != '/') {
         errno = EINVAL;
         return -1;
     }


### PR DESCRIPTION
## Summary
- validate that a name string isn't empty before using it in `shm_open`
- apply the same check in `shm_unlink`

## Testing
- `make test` *(fails to run tests)*
- `./tests/run_tests default` *(fails: "lseek fail")*

------
https://chatgpt.com/codex/tasks/task_e_68608e836efc832492dc5a5b8b696a2e