### PR TITLE
Use PTHREAD_MUTEX_INITIALIZER for static mutex

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -30,6 +30,7 @@ typedef struct {
 
 #define PTHREAD_MUTEX_NORMAL 0
 #define PTHREAD_MUTEX_RECURSIVE 1
+#define PTHREAD_MUTEX_INITIALIZER { ATOMIC_FLAG_INIT, PTHREAD_MUTEX_NORMAL, 0, 0 }
 
 typedef struct {
     atomic_int seq;  /* number of signals issued */

--- a/src/memory.c
+++ b/src/memory.c
@@ -48,7 +48,7 @@ struct block_header {
 };
 
 static struct block_header *free_list = NULL;
-static pthread_mutex_t free_lock = { ATOMIC_FLAG_INIT, PTHREAD_MUTEX_NORMAL, 0, 0 };
+static pthread_mutex_t free_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /*
  * free_impl() - return a block to the internal free list.


### PR DESCRIPTION
## Summary
- define `PTHREAD_MUTEX_INITIALIZER`
- use the macro in `memory.c`

## Testing
- `make test` *(fails: tests require unavailable environment or take too long)*

------
https://chatgpt.com/codex/tasks/task_e_6860af889d008324bafd028f4c3b1ddc