### PR TITLE
Fix O_CLOEXEC for internal opens

### DIFF
--- a/src/arc4random.c
+++ b/src/arc4random.c
@@ -25,7 +25,12 @@
 
 static ssize_t try_urandom(void *buf, size_t len)
 {
-    int fd = open("/dev/urandom", O_RDONLY);
+#ifdef O_CLOEXEC
+    int flags = O_RDONLY | O_CLOEXEC;
+#else
+    int flags = O_RDONLY;
+#endif
+    int fd = open("/dev/urandom", flags);
     if (fd < 0)
         return -1;
     size_t off = 0;

--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -102,7 +102,12 @@ void *dlopen(const char *filename, int flag)
     (void)flag;
     dl_err[0] = '\0';
 
-    int fd = open(filename, O_RDONLY);
+#ifdef O_CLOEXEC
+    int flags = O_RDONLY | O_CLOEXEC;
+#else
+    int flags = O_RDONLY;
+#endif
+    int fd = open(filename, flags);
     if (fd < 0) {
         set_error("open failed");
         return NULL;

--- a/src/grp.c
+++ b/src/grp.c
@@ -86,7 +86,12 @@ static struct group *parse_line(const char *line)
 /* lookup() - search the group file by name or gid */
 static struct group *lookup(const char *name, gid_t gid, int by_name)
 {
-    int fd = open(group_path(), O_RDONLY, 0);
+#ifdef O_CLOEXEC
+    int flags = O_RDONLY | O_CLOEXEC;
+#else
+    int flags = O_RDONLY;
+#endif
+    int fd = open(group_path(), flags, 0);
     if (fd < 0)
         return NULL;
     char buf[4096];
@@ -207,7 +212,12 @@ static struct group *parse_line(const char *line)
 /* setgrent() - open group file for iteration */
 void setgrent(void)
 {
-    int fd = open(group_path(), O_RDONLY, 0);
+#ifdef O_CLOEXEC
+    int flags = O_RDONLY | O_CLOEXEC;
+#else
+    int flags = O_RDONLY;
+#endif
+    int fd = open(group_path(), flags, 0);
     if (fd < 0) {
         next_line = NULL;
         return;
@@ -290,7 +300,12 @@ int getgrouplist(const char *user, gid_t group, gid_t *groups, int *ngroups)
     int count = 0;
     groups[count++] = group;
 
-    int fd = open(group_path(), O_RDONLY, 0);
+#ifdef O_CLOEXEC
+    int flags = O_RDONLY | O_CLOEXEC;
+#else
+    int flags = O_RDONLY;
+#endif
+    int fd = open(group_path(), flags, 0);
     if (fd < 0)
         return -1;
     char buf[4096];

--- a/src/grp_r.c
+++ b/src/grp_r.c
@@ -109,7 +109,12 @@ static int lookup_r(const char *name, gid_t gid, int by_name,
         return -1;
     *result = NULL;
 
-    int fd = open(group_path(), O_RDONLY, 0);
+#ifdef O_CLOEXEC
+    int flags = O_RDONLY | O_CLOEXEC;
+#else
+    int flags = O_RDONLY;
+#endif
+    int fd = open(group_path(), flags, 0);
     if (fd < 0)
         return -1;
     char filebuf[4096];

--- a/src/pwd_r.c
+++ b/src/pwd_r.c
@@ -83,7 +83,12 @@ static int lookup_r(const char *name, uid_t uid, int by_name,
         return -1;
     *result = NULL;
 
-    int fd = open(passwd_path(), O_RDONLY, 0);
+#ifdef O_CLOEXEC
+    int flags = O_RDONLY | O_CLOEXEC;
+#else
+    int flags = O_RDONLY;
+#endif
+    int fd = open(passwd_path(), flags, 0);
     if (fd < 0)
         return -1;
     char filebuf[4096];


### PR DESCRIPTION
## Summary
- use `O_CLOEXEC` when opening internal files so FDs don't leak across exec

## Testing
- `make test` *(fails: Nothing to be done)*

------
https://chatgpt.com/codex/tasks/task_e_6860afa05f108324905fc8ef5fcec797