### PR TITLE
Enable test listing option and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ Run `make test` to execute the suite. Use `TEST_GROUP` to select a subset. The
 tests are organized into groups like `stdio`, `dirent`, `time`, `process`,
 `locale`, `regex`, `memory`, `network`, and `fdopen`.
 
+List all available tests with:
+
+```sh
+make test TEST_LIST=1        # or ./tests/run_tests --list
+```
+
+Run a single test case by name:
+
+```sh
+make test-name NAME=test_getcwd_chdir
+# or
+TEST_NAME=test_getcwd_chdir make test
+```
+
+To run all tests in a specific category, pass the group name:
+
+```sh
+make test TEST_GROUP=memory
+```
+
 ## License
 
 Released under the [BSD 2-Clause "Simplified" License](LICENSE).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -72,3 +72,23 @@ Available groups are `memory`, `network`, `fdopen`, `stdio`, `dirent`, `time`,
 
 This builds `tests/run_tests` and executes the selected category.
 
+List all defined tests with:
+
+```sh
+make test TEST_LIST=1        # or ./tests/run_tests --list
+```
+
+To run a specific case only:
+
+```sh
+make test-name NAME=test_getcwd_chdir
+# or
+TEST_NAME=test_getcwd_chdir make test
+```
+
+Run every test in a chosen group:
+
+```sh
+make test TEST_GROUP=memory
+```
+


### PR DESCRIPTION
## Summary
- add `--list` option and `TEST_LIST` env var to list tests
- initialise environment for tests so `TEST_LIST` works
- document listing and filtering tests in README and overview docs

## Testing
- `./tests/run_tests --list | head`
- `TEST_LIST=1 ./tests/run_tests memory | head`


------
https://chatgpt.com/codex/tasks/task_e_6860bc10310083248dc6b7e4be7eb985