### PR TITLE
Fix test counter increment

### DIFF
--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -6628,9 +6628,7 @@ static const char *run_tests(const char *category, const char *name)
                 printf("%s %s\n", tests[i].category, tests[i].name);
                 continue;
             }
-            const char *msg = tests[i].func();
-            if (msg)
-                return msg;
+            mu_run_test(tests[i].func);
         }
     }
     return 0;


### PR DESCRIPTION
## Summary
- call `mu_run_test` for each case in `run_tests`

## Testing
- `make tests/run_tests` *(failed: output truncated)*
- `timeout 5 ./tests/run_tests memory test_malloc` *(failed: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6860c348d7288324bf22eb59089151e5