### PR TITLE
Fix isatty fallback for ENOTTY

### DIFF
--- a/src/isatty.c
+++ b/src/isatty.c
@@ -11,6 +11,7 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 #include "syscall.h"
+#include <sys/ioctl.h>
 #ifndef __has_include
 #define __has_include(x) 0
 #endif
@@ -28,19 +29,33 @@ int isatty(int fd)
 {
 #ifdef SYS_isatty
     long ret = vlibc_syscall(SYS_isatty, fd, 0, 0, 0, 0, 0);
-    if (ret < 0) {
+    if (ret >= 0) {
+        if (ret == 0)
+            errno = ENOTTY;
+        return (int)ret;
+    }
+    if (ret != -ENOSYS) {
         errno = -ret;
         return 0;
     }
-    return (int)ret;
-#else
+#endif
 #if __has_include(<termios.h>)
     struct termios t;
-    return tcgetattr(fd, &t) == 0;
+#ifdef SYS_ioctl
+    long r = vlibc_syscall(SYS_ioctl, fd, TCGETS, (long)&t, 0, 0, 0);
+    if (r < 0) {
+        errno = -r;
+        return 0;
+    }
+    return 1;
+#else
+    if (ioctl(fd, TCGETS, &t) == -1)
+        return 0;
+    return 1;
+#endif
 #else
     (void)fd;
     errno = ENOTTY;
     return 0;
-#endif
 #endif
 }


### PR DESCRIPTION
## Summary
- fall back to an ioctl termios check when SYS_isatty is missing or fails
- set `errno` to `ENOTTY` when the descriptor isn't a terminal

## Testing
- `make test-name NAME=test_isatty_stdin`

------
https://chatgpt.com/codex/tasks/task_e_6860cddd92648324b4a9d3cbedf54b3a