### PR TITLE
Improve writev nonblocking behavior

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -143,8 +143,10 @@ ssize_t writev(int fd, const struct iovec *iov, int iovcnt)
         while (off < len) {
             ssize_t w = write(fd, base + off, len - off);
             if (w < 0) {
-                if (errno == EINTR || errno == EAGAIN)
+                if (errno == EINTR)
                     continue;
+                if (errno == EAGAIN)
+                    return total ? total : -1;
                 return total ? total : -1;
             }
             off += (size_t)w;
@@ -267,8 +269,10 @@ ssize_t pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset)
         while (off < len) {
             ssize_t w = pwrite(fd, base + off, len - off, offset + total);
             if (w < 0) {
-                if (errno == EINTR || errno == EAGAIN)
+                if (errno == EINTR)
                     continue;
+                if (errno == EAGAIN)
+                    return total ? total : -1;
                 return total ? total : -1;
             }
             off += (size_t)w;

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -781,9 +781,6 @@ static const char *test_writev_nonblocking(void)
         }
     }
 
-    pthread_t t;
-    pthread_create(&t, NULL, drain_socket, &sv[1]);
-
     struct iovec iov[2];
     const char *a = "ab";
     const char *b = "cd";
@@ -792,6 +789,13 @@ static const char *test_writev_nonblocking(void)
     iov[1].iov_base = (void *)b;
     iov[1].iov_len = 2;
     ssize_t r = writev(sv[0], iov, 2);
+    mu_assert("EAGAIN writev", r == -1 && errno == EAGAIN);
+
+    pthread_t t;
+    pthread_create(&t, NULL, drain_socket, &sv[1]);
+    usleep(200000);
+
+    r = writev(sv[0], iov, 2);
     mu_assert("writev", r == 4);
 
     close(sv[0]);


### PR DESCRIPTION
## Summary
- fix `writev`/`pwritev` manual fallbacks to return `EAGAIN`
- adjust `test_writev_nonblocking` for correct expectations

## Testing
- `env TEST_NAME=test_writev_nonblocking ./tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_6860dbecb0288324b630049219c3abe7