### PR TITLE
Add regression test for bad file descriptor in lseek

### DIFF
--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -559,6 +559,15 @@ static const char *test_lseek_errno(void)
     return 0;
 }
 
+static const char *test_lseek_badfd(void)
+{
+    errno = 0;
+    off_t off = lseek(-1, 0, SEEK_SET);
+    mu_assert("badfd fail", off == (off_t)-1);
+    mu_assert("errno EBADF", errno == EBADF);
+    return 0;
+}
+
 static const char *test_pread_pwrite(void)
 {
     const char *fname = "tmp_pread_file";
@@ -6361,6 +6370,7 @@ static const char *run_tests(const char *category, const char *name)
         REGISTER_TEST("stdio", test_lseek_dup),
         REGISTER_TEST("stdio", test_lseek_negative_offset),
         REGISTER_TEST("stdio", test_lseek_errno),
+        REGISTER_TEST("stdio", test_lseek_badfd),
         REGISTER_TEST("stdio", test_pread_pwrite),
         REGISTER_TEST("stdio", test_preadv_pwritev),
         REGISTER_TEST("stdio", test_readv_writev),


### PR DESCRIPTION
## Summary
- add regression test `test_lseek_badfd`
- register the new regression test

## Testing
- `make test-name NAME=test_lseek_badfd`

------
https://chatgpt.com/codex/tasks/task_e_6860deae5a3c8324a8c5ba74b166eb34