### PR TITLE
Fix getsubopt comma handling

### DIFF
--- a/src/getsubopt.c
+++ b/src/getsubopt.c
@@ -21,22 +21,26 @@ int getsubopt(char **optionp, char * const *tokens, char **valuep)
         end++;
 
     char *val = NULL;
+    char *next = NULL;
+
     if (*end == '=') {
         *end = '\0';
         val = end + 1;
         end = val;
         while (*end && *end != ',')
             end++;
-        if (*end)
+        if (*end == ',') {
+            next = end + 1;
             *end = '\0';
+        }
+        if (val[0] == '\0')
+            val = NULL;
+    } else if (*end == ',') {
+        next = end + 1;
+        *end = '\0';
     }
 
-    if (*end == ',') {
-        *end = '\0';
-        *optionp = end + 1;
-    } else {
-        *optionp = end;
-    }
+    *optionp = next ? next : end;
 
     for (int i = 0; tokens && tokens[i]; i++) {
         if (strcmp(arg, tokens[i]) == 0) {


### PR DESCRIPTION
## Summary
- fix pointer advancement in `getsubopt`
- return NULL for suboptions without values

## Testing
- `./tests/run_tests stdlib test_getsubopt_basic`
- `./tests/run_tests stdlib test_getsubopt_unknown`


------
https://chatgpt.com/codex/tasks/task_e_6860debff7288324a1a1322666299ddd