### PR TITLE
Add long/long long specifiers to snprintf

### DIFF
--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2135,7 +2135,7 @@ static const char *test_printf_functions(void)
     mu_assert("lower hex", strcmp(buf, "2b") == 0);
 
     n = snprintf(buf, sizeof(buf), "[%4o]", 9);
-    mu_assert("octal width", strcmp(buf, "[   11]") == 0);
+    mu_assert("octal width", strcmp(buf, "[  11]") == 0);
 
     n = snprintf(buf, sizeof(buf), "[%.3o]", 7);
     mu_assert("octal precision", strcmp(buf, "[007]") == 0);
@@ -2149,6 +2149,18 @@ static const char *test_printf_functions(void)
 
     n = snprintf(buf, sizeof(buf), "[%.4x]", 3);
     mu_assert("precision", strcmp(buf, "[0003]") == 0);
+
+    n = snprintf(buf, sizeof(buf), "%ld", (long)123456L);
+    mu_assert("snprintf long", n == (int)strlen("123456") && strcmp(buf, "123456") == 0);
+
+    n = snprintf(buf, sizeof(buf), "%lu", (unsigned long)987654321UL);
+    mu_assert("snprintf ulong", n == (int)strlen("987654321") && strcmp(buf, "987654321") == 0);
+
+    n = snprintf(buf, sizeof(buf), "%lld", (long long)-123456789012345LL);
+    mu_assert("snprintf long long", strcmp(buf, "-123456789012345") == 0);
+
+    n = snprintf(buf, sizeof(buf), "%llu", (unsigned long long)123456789012345ULL);
+    mu_assert("snprintf ulong long", strcmp(buf, "123456789012345") == 0);
 
     n = snprintf(buf, sizeof(buf), "%d", INT_MIN);
     mu_assert("snprintf INT_MIN len", n == (int)strlen(buf));


### PR DESCRIPTION
## Summary
- support length modifiers `l` and `ll` in `vsnprintf_impl`
- format `%ld`, `%lu`, `%lld`, `%llu`
- adjust octal width check in tests

## Testing
- `make test TEST_LIST=1`
- `./tests/run_tests stdio test_printf_functions`


------
https://chatgpt.com/codex/tasks/task_e_6860dec8e8d483249de311f29d25d924