### PR TITLE
Improve crypto init and add hashing tests

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -77,6 +77,7 @@
 #include "stdlib.h"
 #include <alloca.h>
 #include <openssl/evp.h>
+#include <openssl/crypto.h>
 #include "crypt.h"
 
 #ifndef u_char
@@ -799,17 +800,22 @@ crypt_md5(const char *pw, const char *salt, char *buffer)
                 continue;
         sl = ep - salt;
 
+        if (!OPENSSL_init_crypto(0, NULL))
+                return (-1);
+
         ctx = EVP_MD_CTX_new();
         ctx1 = EVP_MD_CTX_new();
         if (ctx == NULL || ctx1 == NULL)
-                return (-1);
+                goto fail;
 
-        EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
+        if (EVP_DigestInit_ex(ctx, EVP_md5(), NULL) != 1)
+                goto fail;
         EVP_DigestUpdate(ctx, pw, strlen(pw));
         EVP_DigestUpdate(ctx, magic, strlen(magic));
         EVP_DigestUpdate(ctx, salt, sl);
 
-        EVP_DigestInit_ex(ctx1, EVP_md5(), NULL);
+        if (EVP_DigestInit_ex(ctx1, EVP_md5(), NULL) != 1)
+                goto fail;
         EVP_DigestUpdate(ctx1, pw, strlen(pw));
         EVP_DigestUpdate(ctx1, salt, sl);
         EVP_DigestUpdate(ctx1, pw, strlen(pw));
@@ -865,6 +871,13 @@ crypt_md5(const char *pw, const char *salt, char *buffer)
         EVP_MD_CTX_free(ctx);
         EVP_MD_CTX_free(ctx1);
         return (0);
+
+fail:
+        if (ctx)
+                EVP_MD_CTX_free(ctx);
+        if (ctx1)
+                EVP_MD_CTX_free(ctx1);
+        return (-1);
 }
 
 /*
@@ -909,16 +922,21 @@ crypt_sha256(const char *key, const char *salt, char *buffer)
                 salt_len = 16;
         key_len = strlen(key);
 
+        if (!OPENSSL_init_crypto(0, NULL))
+                return (-1);
+
         ctx = EVP_MD_CTX_new();
         alt_ctx = EVP_MD_CTX_new();
         if (ctx == NULL || alt_ctx == NULL)
-                return (-1);
+                goto fail;
 
-        EVP_DigestInit_ex(ctx, EVP_sha256(), NULL);
+        if (EVP_DigestInit_ex(ctx, EVP_sha256(), NULL) != 1)
+                goto fail;
         EVP_DigestUpdate(ctx, key, key_len);
         EVP_DigestUpdate(ctx, salt, salt_len);
 
-        EVP_DigestInit_ex(alt_ctx, EVP_sha256(), NULL);
+        if (EVP_DigestInit_ex(alt_ctx, EVP_sha256(), NULL) != 1)
+                goto fail;
         EVP_DigestUpdate(alt_ctx, key, key_len);
         EVP_DigestUpdate(alt_ctx, salt, salt_len);
         EVP_DigestUpdate(alt_ctx, key, key_len);
@@ -999,6 +1017,13 @@ crypt_sha256(const char *key, const char *salt, char *buffer)
         EVP_MD_CTX_free(ctx);
         EVP_MD_CTX_free(alt_ctx);
         return (0);
+
+fail:
+        if (ctx)
+                EVP_MD_CTX_free(ctx);
+        if (alt_ctx)
+                EVP_MD_CTX_free(alt_ctx);
+        return (-1);
 }
 
 /*
@@ -1043,16 +1068,21 @@ crypt_sha512(const char *key, const char *salt, char *buffer)
                 salt_len = 16;
         key_len = strlen(key);
 
+        if (!OPENSSL_init_crypto(0, NULL))
+                return (-1);
+
         ctx = EVP_MD_CTX_new();
         alt_ctx = EVP_MD_CTX_new();
         if (ctx == NULL || alt_ctx == NULL)
-                return (-1);
+                goto fail;
 
-        EVP_DigestInit_ex(ctx, EVP_sha512(), NULL);
+        if (EVP_DigestInit_ex(ctx, EVP_sha512(), NULL) != 1)
+                goto fail;
         EVP_DigestUpdate(ctx, key, key_len);
         EVP_DigestUpdate(ctx, salt, salt_len);
 
-        EVP_DigestInit_ex(alt_ctx, EVP_sha512(), NULL);
+        if (EVP_DigestInit_ex(alt_ctx, EVP_sha512(), NULL) != 1)
+                goto fail;
         EVP_DigestUpdate(alt_ctx, key, key_len);
         EVP_DigestUpdate(alt_ctx, salt, salt_len);
         EVP_DigestUpdate(alt_ctx, key, key_len);
@@ -1144,6 +1174,13 @@ crypt_sha512(const char *key, const char *salt, char *buffer)
         EVP_MD_CTX_free(ctx);
         EVP_MD_CTX_free(alt_ctx);
         return (0);
+
+fail:
+        if (ctx)
+                EVP_MD_CTX_free(ctx);
+        if (alt_ctx)
+                EVP_MD_CTX_free(alt_ctx);
+        return (-1);
 }
 
 /*

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -71,6 +71,7 @@
 #include <errno.h>
 #include <sys/wait.h>
 #include <signal.h>
+#include <openssl/evp.h>
 #include "../include/setjmp.h"
 #include "../include/ucontext.h"
 #include "../include/time.h"
@@ -5727,6 +5728,60 @@ static const char *test_crypt_sha512(void)
     return 0;
 }
 
+static const char *test_md5_hash(void)
+{
+    unsigned char md[EVP_MAX_MD_SIZE];
+    unsigned int len = 0;
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    mu_assert("ctx", ctx != NULL);
+    mu_assert("init", EVP_DigestInit_ex(ctx, EVP_md5(), NULL) == 1);
+    EVP_DigestUpdate(ctx, "pw", 2);
+    EVP_DigestFinal_ex(ctx, md, &len);
+    EVP_MD_CTX_free(ctx);
+    char hex[2*EVP_MAX_MD_SIZE+1];
+    for (unsigned int i = 0; i < len; i++)
+        sprintf(hex + i*2, "%02x", md[i]);
+    hex[len*2] = '\0';
+    mu_assert("md5 hash", strcmp(hex, "8fe4c11451281c094a6578e6ddbf5eed") == 0);
+    return 0;
+}
+
+static const char *test_sha256_hash(void)
+{
+    unsigned char md[EVP_MAX_MD_SIZE];
+    unsigned int len = 0;
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    mu_assert("ctx", ctx != NULL);
+    mu_assert("init", EVP_DigestInit_ex(ctx, EVP_sha256(), NULL) == 1);
+    EVP_DigestUpdate(ctx, "pw", 2);
+    EVP_DigestFinal_ex(ctx, md, &len);
+    EVP_MD_CTX_free(ctx);
+    char hex[2*EVP_MAX_MD_SIZE+1];
+    for (unsigned int i = 0; i < len; i++)
+        sprintf(hex + i*2, "%02x", md[i]);
+    hex[len*2] = '\0';
+    mu_assert("sha256 hash", strcmp(hex, "30c952fab122c3f9759f02a6d95c3758b246b4fee239957b2d4fee46e26170c4") == 0);
+    return 0;
+}
+
+static const char *test_sha512_hash(void)
+{
+    unsigned char md[EVP_MAX_MD_SIZE];
+    unsigned int len = 0;
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    mu_assert("ctx", ctx != NULL);
+    mu_assert("init", EVP_DigestInit_ex(ctx, EVP_sha512(), NULL) == 1);
+    EVP_DigestUpdate(ctx, "pw", 2);
+    EVP_DigestFinal_ex(ctx, md, &len);
+    EVP_MD_CTX_free(ctx);
+    char hex[2*EVP_MAX_MD_SIZE+1];
+    for (unsigned int i = 0; i < len; i++)
+        sprintf(hex + i*2, "%02x", md[i]);
+    hex[len*2] = '\0';
+    mu_assert("sha512 hash", strcmp(hex, "be196838736ddfd0007dd8b2e8f46f22d440d4c5959925cb49135abc9cdb01e84961aa43dd0ddb6ee59975eb649280d9f44088840af37451828a6412b9b574fc") == 0);
+    return 0;
+}
+
 static const char *test_wordexp_basic(void)
 {
     char tmpl[] = "/tmp/wexpXXXXXX";
@@ -6598,6 +6653,9 @@ static const char *run_tests(const char *category, const char *name)
         REGISTER_TEST("stdlib", test_crypt_md5),
         REGISTER_TEST("stdlib", test_crypt_sha256),
         REGISTER_TEST("stdlib", test_crypt_sha512),
+        REGISTER_TEST("stdlib", test_md5_hash),
+        REGISTER_TEST("stdlib", test_sha256_hash),
+        REGISTER_TEST("stdlib", test_sha512_hash),
         REGISTER_TEST("stdlib", test_wordexp_basic),
         REGISTER_TEST("stdlib", test_wordexp_malformed),
         REGISTER_TEST("dirent", test_dirent),


### PR DESCRIPTION
## Summary
- check OpenSSL initialization in crypt functions
- free OpenSSL contexts on failure
- test MD5, SHA-256 and SHA-512 hashing

## Testing
- `make test` *(fails: sbrk fail NULL)*

------
https://chatgpt.com/codex/tasks/task_e_6860e024e07083249e9f23fe2e318abd