### PR TITLE
Fix wordexp unterminated quotes

### DIFF
--- a/src/wordexp.c
+++ b/src/wordexp.c
@@ -114,8 +114,15 @@ static int parse_word(const char **strp, struct part *out)
         if (!q && c == '"') { q=2; s++; continue; }
         if (q==2) {
             if (c == '"') { q=0; s++; continue; }
-            if (c == '\\' && s[1]) {
-                c = s[1]; s += 2;
+            if (c == '\\') {
+                if (s[1]) {
+                    c = s[1];
+                    s += 2;
+                } else {
+                    trailing_bs = 1;
+                    s++;
+                    break;
+                }
             } else {
                 s++;
             }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -5857,6 +5857,25 @@ static const char *test_wordexp_malformed(void)
     return 0;
 }
 
+static const char *test_wordexp_unterminated_cases(void)
+{
+    wordexp_t we;
+
+    errno = 0;
+    int r = wordexp("'foo", &we);
+    mu_assert("unterminated single", r == WRDE_SYNTAX && errno == EINVAL);
+
+    errno = 0;
+    r = wordexp("\"foo", &we);
+    mu_assert("unterminated double", r == WRDE_SYNTAX && errno == EINVAL);
+
+    errno = 0;
+    r = wordexp("foo\\", &we);
+    mu_assert("final backslash", r == WRDE_SYNTAX && errno == EINVAL);
+
+    return 0;
+}
+
 static int int_cmp(const void *a, const void *b)
 {
     int ia = *(const int *)a;
@@ -6692,6 +6711,7 @@ static const char *run_tests(const char *category, const char *name)
         REGISTER_TEST("stdlib", test_sha512_hash),
         REGISTER_TEST("stdlib", test_wordexp_basic),
         REGISTER_TEST("stdlib", test_wordexp_malformed),
+        REGISTER_TEST("stdlib", test_wordexp_unterminated_cases),
         REGISTER_TEST("dirent", test_dirent),
         REGISTER_TEST("dirent", test_ftw_walk),
         REGISTER_TEST("ftw", test_ftw_long_path_fail),


### PR DESCRIPTION
## Summary
- detect trailing backslashes inside double quoted strings
- add tests for unterminated quote and escape sequences

## Testing
- `make test-name NAME=test_wordexp_unterminated_cases`
- `make test-name NAME=test_wordexp_basic`

------
https://chatgpt.com/codex/tasks/task_e_6860e34760088324a457ca0a8c6bc087