### PR TITLE
Handle missing group files

### DIFF
--- a/src/grp.c
+++ b/src/grp.c
@@ -67,16 +67,18 @@ static struct group *parse_line(const char *line)
     gr.gr_passwd = strtok_r(NULL, ":", &save);
     char *gid_s = strtok_r(NULL, ":", &save);
     char *mem_list = strtok_r(NULL, ":\n", &save);
-    if (!gr.gr_name || !gr.gr_passwd || !gid_s || !mem_list)
+    if (!gr.gr_name || !gr.gr_passwd || !gid_s)
         return NULL;
     gr.gr_gid = (gid_t)atoi(gid_s);
 
     char *save_mem;
     int i = 0;
-    for (char *m = strtok_r(mem_list, ",", &save_mem); m &&
-         i < (int)(sizeof(members)/sizeof(members[0]) - 1);
-         m = strtok_r(NULL, ",", &save_mem)) {
-        members[i++] = m;
+    if (mem_list && *mem_list) {
+        for (char *m = strtok_r(mem_list, ",", &save_mem); m &&
+             i < (int)(sizeof(members)/sizeof(members[0]) - 1);
+             m = strtok_r(NULL, ",", &save_mem)) {
+            members[i++] = m;
+        }
     }
     members[i] = NULL;
     gr.gr_mem = members;
@@ -181,6 +183,7 @@ static __thread char *members[64];
 static __thread char linebuf[256];
 static __thread char filebuf[4096];
 static __thread char *next_line;
+static __thread int gr_initialized;
 
 /* parse_line() - parse an entry from the group file */
 static struct group *parse_line(const char *line)
@@ -218,6 +221,7 @@ void setgrent(void)
     int flags = O_RDONLY;
 #endif
     int fd = open(group_path(), flags, 0);
+    gr_initialized = 1;
     if (fd < 0) {
         next_line = NULL;
         return;
@@ -235,7 +239,7 @@ void setgrent(void)
 /* getgrent() - read next group from file */
 struct group *getgrent(void)
 {
-    if (!next_line)
+    if (!gr_initialized)
         setgrent();
     if (!next_line)
         return NULL;
@@ -249,6 +253,7 @@ struct group *getgrent(void)
 void endgrent(void)
 {
     next_line = NULL;
+    gr_initialized = 0;
 }
 
 #endif

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -5641,6 +5641,30 @@ static const char *test_group_threadsafe(void)
     return 0;
 }
 
+static const char *test_system_passwd(void)
+{
+    unsetenv("VLIBC_PASSWD");
+    if (access("/etc/passwd", R_OK) != 0)
+        return 0; /* skip when not available */
+    setpwent();
+    struct passwd *pw = getpwent();
+    endpwent();
+    mu_assert("system passwd", pw != NULL);
+    return 0;
+}
+
+static const char *test_system_group(void)
+{
+    unsetenv("VLIBC_GROUP");
+    if (access("/etc/group", R_OK) != 0)
+        return 0; /* skip when not available */
+    setgrent();
+    struct group *gr = getgrent();
+    endgrent();
+    mu_assert("system group", gr != NULL);
+    return 0;
+}
+
 static const char *test_getgrouplist_basic(void)
 {
     char tmpl[] = "/tmp/glstXXXXXX";
@@ -6698,6 +6722,8 @@ static const char *run_tests(const char *category, const char *name)
         REGISTER_TEST("process", test_passwd_long_entries),
         REGISTER_TEST("process", test_group_enum),
         REGISTER_TEST("process", test_group_threadsafe),
+        REGISTER_TEST("process", test_system_passwd),
+        REGISTER_TEST("process", test_system_group),
         REGISTER_TEST("process", test_getgrouplist_basic),
         REGISTER_TEST("process", test_getgrouplist_overflow),
         REGISTER_TEST("process", test_getlogin_fn),


### PR DESCRIPTION
## Summary
- fix group entry parser to handle missing member list
- keep state so getgrent() stops at EOF
- add tests for system passwd and group files

## Testing
- `./tests/run_tests process test_group_enum`
- `./tests/run_tests process test_system_passwd`
- `./tests/run_tests process test_system_group`

------
https://chatgpt.com/codex/tasks/task_e_6860e515c05c8324b97f71dc973c99a2