### PR TITLE
Fix priority wrappers

### DIFF
--- a/src/sched.c
+++ b/src/sched.c
@@ -68,7 +68,15 @@ int getpriority(int which, int who)
         errno = -ret;
         return -1;
     }
+#ifdef __linux__
+    /*
+     * On Linux the raw syscall returns "20 - nice".  Convert this
+     * back to the standard nice value range of -20..19.
+     */
+    return 20 - (int)ret;
+#else
     return (int)ret;
+#endif
 #elif defined(__FreeBSD__) || defined(__NetBSD__) || \
       defined(__OpenBSD__) || defined(__DragonFly__)
     extern int host_getpriority(int, int) __asm("getpriority");

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3196,8 +3196,14 @@ static const char *test_priority_wrappers(void)
     mu_assert("getpriority", orig != -1 || errno == 0);
     mu_assert("setpriority", setpriority(PRIO_PROCESS, 0, orig + 1) == 0);
     mu_assert("verify", getpriority(PRIO_PROCESS, 0) == orig + 1);
-    mu_assert("nice", nice(-1) == orig);
-    mu_assert("restore", getpriority(PRIO_PROCESS, 0) == orig);
+    int n = nice(-1);
+    if (n == -1 && (errno == EPERM || errno == EACCES)) {
+        /* lack privilege to raise priority; ensure value unchanged */
+        mu_assert("nice", getpriority(PRIO_PROCESS, 0) == orig + 1);
+    } else {
+        mu_assert("nice", n == orig);
+        mu_assert("restore", getpriority(PRIO_PROCESS, 0) == orig);
+    }
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- adjust getpriority wrapper on Linux to translate kernel return value
- handle permission errors in priority tests

## Testing
- `TEST_NAME=test_priority_wrappers ./tests/run_tests time`

------
https://chatgpt.com/codex/tasks/task_e_6861d09078988324876701e7d4f1c289