### PR TITLE
Fix ttyname test skip when no TTY

### DIFF
--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -927,9 +927,12 @@ static const char *test_isatty_stdin(void)
 
 static const char *test_ttyname_dev_tty(void)
 {
-    int fd = open("/dev/tty", O_RDWR);
-    if (fd < 0)
-        return 0; /* skip when not available */
+    int fd = open("/dev/tty", O_RDWR | O_NONBLOCK);
+    if (fd < 0) {
+        if (errno == ENXIO || errno == ENODEV)
+            return 0; /* skip when no controlling tty */
+        mu_assert("open /dev/tty", fd >= 0);
+    }
     char buf[64];
     int r = ttyname_r(fd, buf, sizeof(buf));
     char *name = ttyname(fd);


### PR DESCRIPTION
## Summary
- avoid hanging in `test_ttyname_dev_tty` by skipping when `/dev/tty` cannot be opened
- run test harness to ensure build works

## Testing
- `make tests/run_tests`
- `./tests/run_tests memory test_malloc`
- `timeout 2 ./tests/run_tests stdio test_ttyname_dev_tty; echo exit:$?`

------
https://chatgpt.com/codex/tasks/task_e_6861d66530b08324907d96e422413ef3