### PR TITLE
Fix vfork test hang

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -76,9 +76,10 @@ void exit(int status);
 ```
 
 `vfork` returns 0 in the child process and the child's PID in the parent,
-matching the behaviour of `fork`. When the host provides the `SYS_vfork`
-system call it is used directly, otherwise the wrapper falls back to
-`fork`.
+matching the behaviour of `fork`.  The implementation emulates `vfork` by
+calling `fork` instead of issuing the `SYS_vfork` syscall directly.  This
+avoids issues that arise when the child invokes library functions before
+exiting or executing a new program.
 
 These wrappers retrieve and manipulate process information. `getuid`,
 `geteuid`, `getgid`, and `getegid` return the real and effective user and


### PR DESCRIPTION
## Summary
- reimplement vfork using fork to avoid stack corruption
- document vfork implementation change

## Testing
- `tests/run_tests process test_vfork_basic`

------
https://chatgpt.com/codex/tasks/task_e_6861fdcbcebc83248e46d20fcf80f809