### PR TITLE
Fix fmtmsg output spacing

### DIFF
--- a/src/fmtmsg.c
+++ b/src/fmtmsg.c
@@ -69,7 +69,7 @@ fmtmsg(long class, const char *label, int sev, const char *text,
 
 #define INSERT_COLON   if (*output != '\0') strlcat(output, ": ", size)
 #define INSERT_NEWLINE if (*output != '\0') strlcat(output, "\n", size)
-#define INSERT_SPACE   if (*output != '\0') strlcat(output, " ", size)
+#define INSERT_SPACE   if (*output != '\0') strlcat(output, "  ", size)
 
 static char *
 printfmt(char *msgverb, long class, const char *label, int sev,


### PR DESCRIPTION
## Summary
- adjust fmtmsg spacing before the tag to match expected format

## Testing
- `make test`
- compile and run a small fmtmsg demo program

------
https://chatgpt.com/codex/tasks/task_e_6862001064f08324b399c871fc728d33