### PR TITLE
Fix err/errx child output

### DIFF
--- a/src/err.c
+++ b/src/err.c
@@ -88,8 +88,13 @@ void warnx(const char *fmt, ...)
 static void __attribute__((noreturn))
 verr_internal(int status, const char *fmt, va_list ap, int use_errno)
 {
+    /*
+     * Use _exit() so a child process that hasn't run vlibc_init() doesn't
+     * execute any atexit handlers inherited from the parent. This ensures
+     * the warning message written above is the only output generated.
+     */
     vwarn_internal(fmt, ap, use_errno);
-    exit(status);
+    _exit(status);
     __builtin_unreachable();
 }
 


### PR DESCRIPTION
## Summary
- ensure err/errx terminate via `_exit`

## Testing
- `TEST_NAME=test_err_functions ./tests/run_tests process`

------
https://chatgpt.com/codex/tasks/task_e_6862092ffd708324a1ad51f21aaa36a1