### PR TITLE
Add %j support to vsnprintf

### DIFF
--- a/src/printf.c
+++ b/src/printf.c
@@ -105,6 +105,9 @@ static int vsnprintf_impl(char *str, size_t size, const char *fmt, va_list ap)
                 length = 2;
                 ++p;
             }
+        } else if (*p == 'j') {
+            length = 3;
+            ++p;
         }
 
         char spec = *p;
@@ -130,7 +133,14 @@ static int vsnprintf_impl(char *str, size_t size, const char *fmt, va_list ap)
             break;
         }
         case 'd': {
-            if (length == 2) {
+            if (length == 3) {
+                intmax_t v = va_arg(ap, intmax_t);
+                unsigned long long uv = (unsigned long long)v;
+                sign = v < 0;
+                if (sign)
+                    uv = 0ull - uv;
+                len = ull_to_base(uv, 10, 0, buf, sizeof(buf));
+            } else if (length == 2) {
                 long long v = va_arg(ap, long long);
                 unsigned long long uv = (unsigned long long)v;
                 sign = v < 0;
@@ -155,7 +165,10 @@ static int vsnprintf_impl(char *str, size_t size, const char *fmt, va_list ap)
             break;
         }
         case 'u': {
-            if (length == 2) {
+            if (length == 3) {
+                uintmax_t v = va_arg(ap, uintmax_t);
+                len = ull_to_base((unsigned long long)v, 10, 0, buf, sizeof(buf));
+            } else if (length == 2) {
                 unsigned long long v = va_arg(ap, unsigned long long);
                 len = ull_to_base(v, 10, 0, buf, sizeof(buf));
             } else if (length == 1) {
@@ -169,7 +182,10 @@ static int vsnprintf_impl(char *str, size_t size, const char *fmt, va_list ap)
         }
         case 'x':
         case 'X': {
-            if (length == 2) {
+            if (length == 3) {
+                uintmax_t v = va_arg(ap, uintmax_t);
+                len = ull_to_base((unsigned long long)v, 16, spec == 'X', buf, sizeof(buf));
+            } else if (length == 2) {
                 unsigned long long v = va_arg(ap, unsigned long long);
                 len = ull_to_base(v, 16, spec == 'X', buf, sizeof(buf));
             } else if (length == 1) {
@@ -182,7 +198,10 @@ static int vsnprintf_impl(char *str, size_t size, const char *fmt, va_list ap)
             break;
         }
         case 'o': {
-            if (length == 2) {
+            if (length == 3) {
+                uintmax_t v = va_arg(ap, uintmax_t);
+                len = ull_to_base((unsigned long long)v, 8, 0, buf, sizeof(buf));
+            } else if (length == 2) {
                 unsigned long long v = va_arg(ap, unsigned long long);
                 len = ull_to_base(v, 8, 0, buf, sizeof(buf));
             } else if (length == 1) {

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2179,6 +2179,12 @@ static const char *test_printf_functions(void)
     n = snprintf(buf, sizeof(buf), "%llu", (unsigned long long)123456789012345ULL);
     mu_assert("snprintf ulong long", strcmp(buf, "123456789012345") == 0);
 
+    n = snprintf(buf, sizeof(buf), "%jd", (intmax_t)-123456789012345LL);
+    mu_assert("snprintf intmax", strcmp(buf, "-123456789012345") == 0);
+
+    n = snprintf(buf, sizeof(buf), "%ju", (uintmax_t)123456789012345ULL);
+    mu_assert("snprintf uintmax", strcmp(buf, "123456789012345") == 0);
+
     n = snprintf(buf, sizeof(buf), "%d", INT_MIN);
     mu_assert("snprintf INT_MIN len", n == (int)strlen(buf));
     char *endptr;


### PR DESCRIPTION
## Summary
- recognize `j` length modifier in `vsnprintf_impl`
- handle `intmax_t`/`uintmax_t` for `%jd` `%ju` `%jx` `%jo`
- add unit tests for `%jd` and `%ju`

## Testing
- `make test-name NAME=test_printf_functions`

------
https://chatgpt.com/codex/tasks/task_e_68621b611214832482a134f9d18fbd7e