### PR TITLE
Fix barrier wait ordering

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -45,6 +45,7 @@ typedef struct {
 typedef struct {
     unsigned count;
     atomic_uint waiting;
+    atomic_uint phase;
     pthread_mutex_t lock;
     pthread_cond_t cond;
 } pthread_barrier_t;

--- a/src/pthread_barrier.c
+++ b/src/pthread_barrier.c
@@ -15,6 +15,7 @@ int pthread_barrier_init(pthread_barrier_t *barrier, void *attr, unsigned count)
         return EINVAL;
     barrier->count = count;
     atomic_store(&barrier->waiting, 0);
+    atomic_store(&barrier->phase, 0);
     pthread_mutex_init(&barrier->lock, NULL);
     pthread_cond_init(&barrier->cond, NULL);
     return 0;
@@ -23,15 +24,20 @@ int pthread_barrier_init(pthread_barrier_t *barrier, void *attr, unsigned count)
 int pthread_barrier_wait(pthread_barrier_t *barrier)
 {
     pthread_mutex_lock(&barrier->lock);
-    unsigned w = atomic_fetch_add_explicit(&barrier->waiting, 1,
-                                           memory_order_acquire) + 1;
+    unsigned phase =
+        atomic_load_explicit(&barrier->phase, memory_order_acquire);
+    unsigned w =
+        atomic_fetch_add_explicit(&barrier->waiting, 1, memory_order_acquire) +
+        1;
     if (w == barrier->count) {
         atomic_store_explicit(&barrier->waiting, 0, memory_order_release);
+        atomic_fetch_add_explicit(&barrier->phase, 1, memory_order_release);
         pthread_cond_broadcast(&barrier->cond);
         pthread_mutex_unlock(&barrier->lock);
         return PTHREAD_BARRIER_SERIAL_THREAD;
     }
-    while (atomic_load_explicit(&barrier->waiting, memory_order_acquire) != 0)
+    while (phase ==
+           atomic_load_explicit(&barrier->phase, memory_order_acquire))
         pthread_cond_wait(&barrier->cond, &barrier->lock);
     pthread_mutex_unlock(&barrier->lock);
     return 0;

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2945,6 +2945,7 @@ static const char *test_semaphore_trywait(void)
 
 static pthread_barrier_t barrier;
 static int barrier_step[3];
+static int barrier_step2[3];
 
 static void *barrier_worker(void *arg)
 {
@@ -2952,6 +2953,8 @@ static void *barrier_worker(void *arg)
     barrier_step[idx] = 1;
     pthread_barrier_wait(&barrier);
     barrier_step[idx] = 2;
+    pthread_barrier_wait(&barrier);
+    barrier_step2[idx] = 3;
     return NULL;
 }
 
@@ -2960,17 +2963,20 @@ static const char *test_pthread_barrier(void)
     pthread_t t1, t2;
     int i1 = 0, i2 = 1;
     memset(barrier_step, 0, sizeof(barrier_step));
+    memset(barrier_step2, 0, sizeof(barrier_step2));
     pthread_barrier_init(&barrier, NULL, 3);
     pthread_create(&t1, NULL, barrier_worker, &i1);
     pthread_create(&t2, NULL, barrier_worker, &i2);
     barrier_step[2] = 1;
     pthread_barrier_wait(&barrier);
     barrier_step[2] = 2;
+    pthread_barrier_wait(&barrier);
+    barrier_step2[2] = 3;
     pthread_join(t1, NULL);
     pthread_join(t2, NULL);
     pthread_barrier_destroy(&barrier);
-    mu_assert("barrier phase1", barrier_step[0] == 1 && barrier_step[1] == 1 && barrier_step[2] == 2);
-    mu_assert("barrier phase2", barrier_step[0] == 2 && barrier_step[1] == 2);
+    mu_assert("barrier phase1", barrier_step[0] == 2 && barrier_step[1] == 2 && barrier_step[2] == 2);
+    mu_assert("barrier phase2", barrier_step2[0] == 3 && barrier_step2[1] == 3 && barrier_step2[2] == 3);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- keep track of barrier phase so that waiting counter is reset only after
  the last thread arrives
- update `pthread_barrier_wait` to wait on the phase change
- extend pthread barrier test to exercise two barrier cycles

## Testing
- `make test`
- `./tests/run_tests process test_pthread_barrier`

------
https://chatgpt.com/codex/tasks/task_e_68621d179ba08324ac8919cd2644e869