### PR TITLE
Add portable ucontext implementation

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -97,11 +97,15 @@ int sigdelset(sigset_t *set, int signo);
 int sigismember(const sigset_t *set, int signo);
 char *strsignal(int signum);
 
+#ifdef VLIBC_HAS_SYS_UCONTEXT
+#include <sys/ucontext.h>
+#else
 typedef struct {
     void  *ss_sp;
     size_t ss_size;
     int    ss_flags;
 } stack_t;
+#endif
 
 #define SS_ONSTACK  1
 #define SS_DISABLE  2

--- a/include/ucontext.h
+++ b/include/ucontext.h
@@ -7,10 +7,13 @@
 #define UCONTEXT_H
 
 #include "signal.h"
-#include "setjmp.h"
 #include <stdarg.h>
 
-#ifndef VLIBC_HAS_SYS_UCONTEXT
+#ifdef VLIBC_HAS_SYS_UCONTEXT
+#include_next <ucontext.h>
+#else
+#include <setjmp.h>
+
 typedef struct ucontext {
     struct ucontext *uc_link;
     stack_t          uc_stack;
@@ -18,13 +21,19 @@ typedef struct ucontext {
     void (*uc_func)(void);
     int              uc_argc;
     long             uc_args[6];
+#if defined(__x86_64__)
+    unsigned long    rbx, rbp, r12, r13, r14, r15;
+    unsigned long    rsp, rip;
+#else
     jmp_buf          __jmpbuf;
+#endif
 } ucontext_t;
 #endif
-
+#ifndef VLIBC_HAS_SYS_UCONTEXT
 int getcontext(ucontext_t *ucp);
 int setcontext(const ucontext_t *ucp);
 void makecontext(ucontext_t *ucp, void (*func)(void), int argc, ...);
 int swapcontext(ucontext_t *oucp, const ucontext_t *ucp);
+#endif
 
 #endif /* UCONTEXT_H */

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -73,7 +73,7 @@
 #include <signal.h>
 #include <openssl/evp.h>
 #include "../include/setjmp.h"
-#include "../include/ucontext.h"
+#include "ucontext.h"
 #include "../include/time.h"
 #include "../include/sys/resource.h"
 #include "../include/sys/times.h"


### PR DESCRIPTION
## Summary
- autodetect system ucontext support in Makefile
- provide a fallback ucontext implementation that saves registers with assembly
- avoid redefining `stack_t` when using the system headers
- use standard include for ucontext in tests

## Testing
- `make`
- `./tests/run_tests process test_ucontext_basic`
- `./tests/run_tests process test_ucontext_args`

------
https://chatgpt.com/codex/tasks/task_e_68621d281db4832484f49ec03293dd81