### PR TITLE
Fix fmtmsg output with uninitialized stderr

### DIFF
--- a/src/fmtmsg.c
+++ b/src/fmtmsg.c
@@ -45,8 +45,12 @@ fmtmsg(long class, const char *label, int sev, const char *text,
             free(msgverb);
             return MM_NOTOK;
         }
-        if (*output != '\0')
-            fprintf(stderr, "%s", output);
+        if (*output != '\0') {
+            if (stderr)
+                fprintf(stderr, "%s", output);
+            else
+                dprintf(2, "%s", output);
+        }
         free(msgverb);
         free(output);
     }


### PR DESCRIPTION
## Summary
- ensure `fmtmsg()` writes to stderr even if stdio isn't initialized

## Testing
- `make test-name NAME=test_fmtmsg_basic`

------
https://chatgpt.com/codex/tasks/task_e_6862abbfe7988324a88b5ba9bfa7473f