### PR TITLE
Handle posix_memalign errors in aligned_alloc

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -321,8 +321,11 @@ void *aligned_alloc(size_t alignment, size_t size)
     }
 
     void *ptr = NULL;
-    if (posix_memalign(&ptr, alignment, size) != 0)
+    int rc = posix_memalign(&ptr, alignment, size);
+    if (rc != 0) {
+        errno = rc;
         return NULL;
+    }
     return ptr;
 }
 

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -358,8 +358,10 @@ static const char *test_aligned_alloc_bad_size(void)
 
 static const char *test_aligned_alloc_bad_alignment(void)
 {
+    errno = 0;
     void *p = aligned_alloc(24, 48);
     mu_assert("bad alignment NULL", p == NULL);
+    mu_assert("errno EINVAL", errno == EINVAL);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- propagate `posix_memalign` errors through `errno` in `aligned_alloc`
- ensure bad alignment test checks `errno`
- add test run instructions

## Testing
- `TEST_GROUP=memory ./tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c07cc7da48324a08a1cdec6f889cb