### PR TITLE
Fix errno set on open_memstream alloc failure

### DIFF
--- a/src/memstream.c
+++ b/src/memstream.c
@@ -23,8 +23,10 @@ FILE *open_memstream(char **bufp, size_t *sizep)
         return NULL;
     }
     FILE *f = malloc(sizeof(FILE));
-    if (!f)
+    if (!f) {
+        errno = ENOMEM;
         return NULL;
+    }
     memset(f, 0, sizeof(FILE));
     atomic_flag_clear(&f->lock);
     f->fd = -1;

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1978,6 +1978,18 @@ static const char *test_wmemstream_basic(void)
     return 0;
 }
 
+static const char *test_open_memstream_alloc_fail(void)
+{
+    vlibc_test_alloc_fail_after = 0;
+    errno = 0;
+    char *buf = NULL;
+    size_t size = 0;
+    FILE *f = open_memstream(&buf, &size);
+    mu_assert("alloc fail", f == NULL && errno == ENOMEM);
+    vlibc_test_alloc_fail_after = -1;
+    return 0;
+}
+
 static const char *test_fmemopen_bad_mode(void)
 {
     errno = 0;
@@ -6627,6 +6639,7 @@ static const char *run_tests(const char *category, const char *name)
         REGISTER_TEST("stdlib", test_wmem_ops),
         REGISTER_TEST("stdlib", test_wchar_search),
         REGISTER_TEST("stdio", test_wmemstream_basic),
+        REGISTER_TEST("stdio", test_open_memstream_alloc_fail),
         REGISTER_TEST("stdio", test_fmemopen_bad_mode),
         REGISTER_TEST("stdio", test_fopencookie_basic),
         REGISTER_TEST("stdlib", test_iconv_ascii_roundtrip),


### PR DESCRIPTION
## Summary
- return ENOMEM when open_memstream cannot allocate a FILE
- add regression test exercising this ENOMEM path

## Testing
- `TEST_NAME=test_open_memstream_alloc_fail ./tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c08b6c2788324b7a798b452cc3c79