### PR TITLE
Ensure ENOMEM set on wmemstream allocation failure

### DIFF
--- a/src/memstream.c
+++ b/src/memstream.c
@@ -59,8 +59,10 @@ FILE *open_wmemstream(wchar_t **bufp, size_t *sizep)
         return NULL;
     }
     FILE *f = malloc(sizeof(FILE));
-    if (!f)
+    if (!f) {
+        errno = ENOMEM;
         return NULL;
+    }
     memset(f, 0, sizeof(FILE));
     atomic_flag_clear(&f->lock);
     f->fd = -1;

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1990,6 +1990,18 @@ static const char *test_open_memstream_alloc_fail(void)
     return 0;
 }
 
+static const char *test_open_wmemstream_alloc_fail(void)
+{
+    vlibc_test_alloc_fail_after = 0;
+    errno = 0;
+    wchar_t *buf = NULL;
+    size_t size = 0;
+    FILE *f = open_wmemstream(&buf, &size);
+    mu_assert("alloc fail", f == NULL && errno == ENOMEM);
+    vlibc_test_alloc_fail_after = -1;
+    return 0;
+}
+
 static const char *test_fmemopen_bad_mode(void)
 {
     errno = 0;
@@ -6640,6 +6652,7 @@ static const char *run_tests(const char *category, const char *name)
         REGISTER_TEST("stdlib", test_wchar_search),
         REGISTER_TEST("stdio", test_wmemstream_basic),
         REGISTER_TEST("stdio", test_open_memstream_alloc_fail),
+        REGISTER_TEST("stdio", test_open_wmemstream_alloc_fail),
         REGISTER_TEST("stdio", test_fmemopen_bad_mode),
         REGISTER_TEST("stdio", test_fopencookie_basic),
         REGISTER_TEST("stdlib", test_iconv_ascii_roundtrip),


### PR DESCRIPTION
## Summary
- set `errno` to `ENOMEM` when the `FILE` allocation fails in `open_wmemstream`
- add unit test verifying failure handling in `open_wmemstream`

## Testing
- `TEST_NAME=test_open_wmemstream_alloc_fail tests/run_tests`
- `TEST_NAME=test_open_memstream_alloc_fail tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c0ee4ae1c8324a6918af0999a2b37