### PR TITLE
Improve clearenv error handling

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -254,17 +254,27 @@ int clearenv(void)
             environ[i] = NULL;
         return 0;
     }
-    for (int i = 0; environ[i]; ++i) {
-        if (environ_flags && environ_flags[i])
-            free(environ[i]);
-    }
-    free(environ);
-    free(environ_flags);
-    environ = malloc(sizeof(char *));
-    environ_flags = malloc(sizeof(unsigned char));
-    if (!environ || !environ_flags)
+    char **oldenv = environ;
+    unsigned char *oldflags = environ_flags;
+    char **newenv = malloc(sizeof(char *));
+    unsigned char *newflags = malloc(sizeof(unsigned char));
+    if (!newenv || !newflags) {
+        free(newenv);
+        free(newflags);
+        errno = ENOMEM;
         return -1;
+    }
+
+    for (int i = 0; oldenv[i]; ++i) {
+        if (oldflags && oldflags[i])
+            free(oldenv[i]);
+    }
+    free(oldenv);
+    free(oldflags);
+
     environ_owned = 1;
+    environ = newenv;
+    environ_flags = newflags;
     environ[0] = NULL;
     environ_flags[0] = 0;
     return 0;

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3827,6 +3827,37 @@ static const char *test_setenv_alloc_fail(void)
     return 0;
 }
 
+static const char *test_clearenv_alloc_fail(void)
+{
+    env_init(NULL);
+    mu_assert("setenv A", setenv("A", "1", 1) == 0);
+    mu_assert("setenv B", setenv("B", "2", 1) == 0);
+
+    vlibc_test_alloc_fail_after = 0;
+    errno = 0;
+    int r = clearenv();
+    mu_assert("alloc1 fail", r == -1);
+    mu_assert("errno ENOMEM", errno == ENOMEM);
+    mu_assert("env unchanged1", getenv("A") && getenv("B"));
+
+    vlibc_test_alloc_fail_after = -1;
+    mu_assert("clearenv success", clearenv() == 0);
+
+    mu_assert("setenv A2", setenv("A", "1", 1) == 0);
+    mu_assert("setenv B2", setenv("B", "2", 1) == 0);
+
+    vlibc_test_alloc_fail_after = 1;
+    errno = 0;
+    r = clearenv();
+    mu_assert("alloc2 fail", r == -1);
+    mu_assert("errno ENOMEM", errno == ENOMEM);
+    mu_assert("env unchanged2", getenv("A") && getenv("B"));
+
+    vlibc_test_alloc_fail_after = -1;
+    mu_assert("clearenv success2", clearenv() == 0);
+    return 0;
+}
+
 static const char *test_locale_from_env(void)
 {
     env_init(NULL);
@@ -6734,6 +6765,7 @@ static const char *run_tests(const char *category, const char *name)
         REGISTER_TEST("locale", test_setenv_alloc_fail),
         REGISTER_TEST("locale", test_setenv_realloc_fail_errno),
         REGISTER_TEST("locale", test_setenv_strdup_fail),
+        REGISTER_TEST("locale", test_clearenv_alloc_fail),
         REGISTER_TEST("locale", test_locale_from_env),
         REGISTER_TEST("locale", test_locale_objects),
         REGISTER_TEST("locale", test_langinfo_codeset),


### PR DESCRIPTION
## Summary
- handle allocation failures in `clearenv`
- add tests for failed `clearenv` allocations

## Testing
- `TEST_NAME=test_clearenv_alloc_fail ./tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c27684f508324875eb0aad9d0273d