### PR TITLE
Check wcstombs failures in vfdwprintf

### DIFF
--- a/src/wprintf.c
+++ b/src/wprintf.c
@@ -202,11 +202,13 @@ static int vfdwprintf(int fd, const wchar_t *format, va_list ap)
     if (len > 0 && fd >= 0) {
         char buf[4096];
         size_t out = wcstombs(buf, wbuf, sizeof(buf));
-        if (out != (size_t)-1) {
-            ssize_t w = write(fd, buf, out);
-            if (w < 0)
-                return -1;
+        if (out == (size_t)-1) {
+            errno = EILSEQ;
+            return -1;
         }
+        ssize_t w = write(fd, buf, out);
+        if (w < 0)
+            return -1;
     }
     return len;
 }


### PR DESCRIPTION
## Summary
- return error if wcstombs fails in vfdwprintf

## Testing
- `make test` *(fails: Nothing to be done)*
- `TEST_NAME=basic ./tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c5ac2c2788324a00f0de1666aad35