### PR TITLE
Fix clearenv errno

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -252,6 +252,7 @@ int clearenv(void)
     if (!environ_owned) {
         for (int i = 0; environ[i]; ++i)
             environ[i] = NULL;
+        errno = 0;
         return 0;
     }
     char **oldenv = environ;

--- a/src/process.c
+++ b/src/process.c
@@ -31,6 +31,7 @@ extern int __posix_spawnp(pid_t *, const char *,
 #include <stdarg.h>
 #include <fcntl.h>
 #include "stdio.h"
+#include <stdint.h>
 extern long syscall(long number, ...);
 
 /* from atexit.c */

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -3683,7 +3683,9 @@ static const char *test_env_init_clearenv(void)
 
     env_init(copy);
     char **orig = environ;
+    errno = 1;
     mu_assert("clearenv", clearenv() == 0);
+    mu_assert("errno cleared", errno == 0);
     mu_assert("same pointer", environ == orig);
     mu_assert("first null", copy[0] == NULL);
     env_init(NULL);


### PR DESCRIPTION
## Summary
- reset errno after clearing non-owned environment
- include `<stdint.h>` in process.c for SIZE_MAX usage
- test that clearenv zeroes errno when clearing non-owned env

## Testing
- `TEST_NAME=test_env_init_clearenv ./tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c5c46a38883249393070d8c6366c3