### PR TITLE
Check write return in wprintf

### DIFF
--- a/src/wprintf.c
+++ b/src/wprintf.c
@@ -207,8 +207,10 @@ static int vfdwprintf(int fd, const wchar_t *format, va_list ap)
             return -1;
         }
         ssize_t w = write(fd, buf, out);
-        if (w < 0)
+        if (w != (ssize_t)out) {
+            errno = EIO;
             return -1;
+        }
     }
     return len;
 }


### PR DESCRIPTION
## Summary
- ensure vfdwprintf validates the number of bytes written

## Testing
- `make test` *(fails: not run due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_686c685c9cd88324b495a0b28fd84bde