### PR TITLE
Add fallback static streams

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -11,26 +11,37 @@
 #include "memory.h"
 #include "string.h"
 
+/* Static fallbacks when allocations fail */
+static FILE static_stdin;
+static FILE static_stdout;
+static FILE static_stderr;
+
 void vlibc_init(void)
 {
     stdin = malloc(sizeof(FILE));
-    if (stdin) {
-        memset(stdin, 0, sizeof(FILE));
-        atomic_flag_clear(&stdin->lock);
-        stdin->fd = 0;
+    if (!stdin) {
+        dprintf(2, "vlibc_init: malloc failed for stdin\n");
+        stdin = &static_stdin;
     }
+    memset(stdin, 0, sizeof(FILE));
+    atomic_flag_clear(&stdin->lock);
+    stdin->fd = 0;
 
     stdout = malloc(sizeof(FILE));
-    if (stdout) {
-        memset(stdout, 0, sizeof(FILE));
-        atomic_flag_clear(&stdout->lock);
-        stdout->fd = 1;
+    if (!stdout) {
+        dprintf(2, "vlibc_init: malloc failed for stdout\n");
+        stdout = &static_stdout;
     }
+    memset(stdout, 0, sizeof(FILE));
+    atomic_flag_clear(&stdout->lock);
+    stdout->fd = 1;
 
     stderr = malloc(sizeof(FILE));
-    if (stderr) {
-        memset(stderr, 0, sizeof(FILE));
-        atomic_flag_clear(&stderr->lock);
-        stderr->fd = 2;
+    if (!stderr) {
+        dprintf(2, "vlibc_init: malloc failed for stderr\n");
+        stderr = &static_stderr;
     }
+    memset(stderr, 0, sizeof(FILE));
+    atomic_flag_clear(&stderr->lock);
+    stderr->fd = 2;
 }

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2465,6 +2465,33 @@ static const char *test_vscanf_variants(void)
     return 0;
 }
 
+static const char *test_init_stream_fallback(void)
+{
+    /* fail stdin allocation */
+    vlibc_test_alloc_fail_after = 0;
+    vlibc_init();
+    mu_assert("stdin fallback", stdin != NULL);
+    mu_assert("stdout ok", stdout != NULL);
+    mu_assert("stderr ok", stderr != NULL);
+
+    /* fail stdout allocation */
+    vlibc_test_alloc_fail_after = 1;
+    vlibc_init();
+    mu_assert("stdout fallback", stdout != NULL);
+
+    /* fail stderr allocation */
+    vlibc_test_alloc_fail_after = 2;
+    vlibc_init();
+    mu_assert("stderr fallback", stderr != NULL);
+
+    vlibc_test_alloc_fail_after = -1;
+
+    mu_assert("printf works", printf("fallback ok\n") > 0);
+    fprintf(stderr, "err\n");
+    fflush(stdout);
+    return 0;
+}
+
 static const char *test_fseek_rewind(void)
 {
     FILE *f = fopen("tmp_seek", "w+");
@@ -6698,6 +6725,7 @@ static const char *run_tests(const char *category, const char *name)
         REGISTER_TEST("stdio", test_dprintf_functions),
         REGISTER_TEST("stdio", test_scanf_functions),
         REGISTER_TEST("stdio", test_vscanf_variants),
+        REGISTER_TEST("stdio", test_init_stream_fallback),
         REGISTER_TEST("stdio", test_fseek_rewind),
         REGISTER_TEST("stdio", test_fgetpos_fsetpos),
         REGISTER_TEST("stdio", test_fgetc_fputc),


### PR DESCRIPTION
## Summary
- ensure vlibc_init never leaves standard streams NULL
- print warning and use static FILE objects when malloc fails
- add regression test covering malloc failures for stdio

## Testing
- `./tests/run_tests stdio test_init_stream_fallback`

------
https://chatgpt.com/codex/tasks/task_e_686c68b298608324b14cb245d8a99a54