### PR TITLE
Fix bsearch midpoint overflow

### DIFF
--- a/src/qsort.c
+++ b/src/qsort.c
@@ -66,7 +66,7 @@ void *bsearch(const void *key, const void *base, size_t nmemb, size_t size,
     const char *b = base;
 
     while (low < high) {
-        size_t mid = (low + high) / 2;
+        size_t mid = low + (high - low) / 2;
         const void *elem = b + mid * size;
         int c = compar(key, elem);
         if (c < 0)

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -6081,6 +6081,23 @@ static const char *test_qsort_strings(void)
     return 0;
 }
 
+static const char *test_bsearch_large(void)
+{
+    const size_t count = 1000000;
+    int *arr = malloc(count * sizeof(int));
+    if (!arr)
+        return "alloc fail";
+    for (size_t i = 0; i < count; ++i)
+        arr[i] = (int)i;
+
+    int key = (int)(count - 1);
+    int *res = bsearch(&key, arr, count, sizeof(int), int_cmp);
+    int ok = res && *res == key;
+    free(arr);
+    mu_assert("bsearch large", ok);
+    return 0;
+}
+
 static int int_cmp_dir(const void *a, const void *b, void *ctx)
 {
     int dir = *(int *)ctx;
@@ -6888,6 +6905,7 @@ static const char *run_tests(const char *category, const char *name)
         REGISTER_TEST("dirent", test_fts_alloc_fail),
         REGISTER_TEST("stdlib", test_qsort_int),
         REGISTER_TEST("stdlib", test_qsort_strings),
+        REGISTER_TEST("stdlib", test_bsearch_large),
         REGISTER_TEST("stdlib", test_qsort_r_desc),
         REGISTER_TEST("stdlib", test_hsearch_basic),
         REGISTER_TEST("stdlib", test_tsearch_basic),


### PR DESCRIPTION
## Summary
- avoid potential overflow in `bsearch` midpoint calculation
- add regression test covering large array searches

## Testing
- `make test-name NAME=test_bsearch_large`

------
https://chatgpt.com/codex/tasks/task_e_686c6c1fb69883248a141ea321ff039e