### PR TITLE
Set errno in fts_close on NULL

### DIFF
--- a/src/fts.c
+++ b/src/fts.c
@@ -222,8 +222,10 @@ FTSENT *fts_read(FTS *fts)
  */
 int fts_close(FTS *fts)
 {
-    if (!fts)
+    if (!fts) {
+        errno = EINVAL;
         return -1;
+    }
     free_entry(fts->cur);
     struct node *n;
     while ((n = queue_pop(fts))) {

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -5606,6 +5606,14 @@ static const char *test_fts_alloc_fail(void)
     return 0;
 }
 
+static const char *test_fts_close_null(void)
+{
+    errno = 0;
+    mu_assert("fts_close", fts_close(NULL) == -1);
+    mu_assert("errno EINVAL", errno == EINVAL);
+    return 0;
+}
+
 static const char *test_passwd_lookup(void)
 {
     char tmpl[] = "/tmp/pwtestXXXXXX";
@@ -6886,6 +6894,7 @@ static const char *run_tests(const char *category, const char *name)
         REGISTER_TEST("ftw", test_ftw_long_path_fail),
         REGISTER_TEST("dirent", test_fts_walk),
         REGISTER_TEST("dirent", test_fts_alloc_fail),
+        REGISTER_TEST("dirent", test_fts_close_null),
         REGISTER_TEST("stdlib", test_qsort_int),
         REGISTER_TEST("stdlib", test_qsort_strings),
         REGISTER_TEST("stdlib", test_qsort_r_desc),


### PR DESCRIPTION
## Summary
- handle NULL parameter in `fts_close` by setting `errno = EINVAL`
- add regression test to verify errno when closing a NULL FTS handle

## Testing
- `TEST_GROUP=dirent tests/run_tests`
- `TEST_NAME=test_fts_close_null tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c6c18c4a08324a879ef3192772acc