### PR TITLE
Add base range checks in strto functions

### DIFF
--- a/src/strto.c
+++ b/src/strto.c
@@ -25,6 +25,13 @@ static int digit_val(char c)
 
 long strtol(const char *nptr, char **endptr, int base)
 {
+    if (base != 0 && (base < 2 || base > 36)) {
+        if (endptr)
+            *endptr = (char *)nptr;
+        errno = EINVAL;
+        return 0;
+    }
+
     const char *s = nptr;
     while (*s == ' ' || *s == '\t' || *s == '\n' || *s == '\r' || *s == '\f' || *s == '\v')
         s++;
@@ -90,6 +97,13 @@ long strtol(const char *nptr, char **endptr, int base)
 
 unsigned long strtoul(const char *nptr, char **endptr, int base)
 {
+    if (base != 0 && (base < 2 || base > 36)) {
+        if (endptr)
+            *endptr = (char *)nptr;
+        errno = EINVAL;
+        return 0;
+    }
+
     const char *s = nptr;
     while (*s == ' ' || *s == '\t' || *s == '\n' || *s == '\r' || *s == '\f' ||
            *s == '\v')
@@ -155,6 +169,13 @@ unsigned long strtoul(const char *nptr, char **endptr, int base)
 
 long long strtoll(const char *nptr, char **endptr, int base)
 {
+    if (base != 0 && (base < 2 || base > 36)) {
+        if (endptr)
+            *endptr = (char *)nptr;
+        errno = EINVAL;
+        return 0;
+    }
+
     const char *s = nptr;
     while (*s == ' ' || *s == '\t' || *s == '\n' || *s == '\r' || *s == '\f' ||
            *s == '\v')
@@ -221,6 +242,13 @@ long long strtoll(const char *nptr, char **endptr, int base)
 
 unsigned long long strtoull(const char *nptr, char **endptr, int base)
 {
+    if (base != 0 && (base < 2 || base > 36)) {
+        if (endptr)
+            *endptr = (char *)nptr;
+        errno = EINVAL;
+        return 0;
+    }
+
     const char *s = nptr;
     while (*s == ' ' || *s == '\t' || *s == '\n' || *s == '\r' || *s == '\f' ||
            *s == '\v')

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -1615,6 +1615,20 @@ static const char *test_string_helpers(void)
     mu_assert("strtoumax overflow",
               strtoumax(numbuf, &end, 10) == UINTMAX_MAX && errno == ERANGE && *end == '\0');
 
+    const char *bad = "10";
+    errno = 0;
+    mu_assert("strtol bad base", strtol(bad, &end, 1) == 0 && errno == EINVAL && end == bad);
+    errno = 0;
+    mu_assert("strtoul bad base", strtoul(bad, &end, 37) == 0 && errno == EINVAL && end == bad);
+    errno = 0;
+    mu_assert("strtoll bad base", strtoll(bad, &end, 1) == 0 && errno == EINVAL && end == bad);
+    errno = 0;
+    mu_assert("strtoull bad base", strtoull(bad, &end, 37) == 0 && errno == EINVAL && end == bad);
+    errno = 0;
+    mu_assert("strtoimax bad base", strtoimax(bad, &end, 1) == 0 && errno == EINVAL && end == bad);
+    errno = 0;
+    mu_assert("strtoumax bad base", strtoumax(bad, &end, 37) == 0 && errno == EINVAL && end == bad);
+
     wchar_t wbuf[64];
     mbstowcs(wbuf, "ff", 64);
     wchar_t *wend;


### PR DESCRIPTION
## Summary
- validate bases for strtol/strtoul/strtoll/strtoull and wrappers
- add unit tests for invalid bases

## Testing
- `make test` *(fails: didn't run due to environment limits)*
- `TEST_NAME=test_string_helpers ./tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c6c11e1a88324ba6d69688d971bb0