### PR TITLE
Fix abs functions for extreme negatives

### DIFF
--- a/src/abs.c
+++ b/src/abs.c
@@ -7,32 +7,39 @@
  */
 
 #include "stdlib.h"
+#include <limits.h>
 
 /* Return the absolute value of a signed int. */
 int abs(int j)
 {
-    unsigned int u = (unsigned int)j;
-    if (j < 0)
-        u = 0u - u;
-    return (int)u;
+    if (j < 0) {
+        if (j == INT_MIN)
+            return j;
+        return -j;
+    }
+    return j;
 }
 
 /* Return the absolute value of a signed long. */
 long labs(long j)
 {
-    unsigned long u = (unsigned long)j;
-    if (j < 0)
-        u = 0ul - u;
-    return (long)u;
+    if (j < 0) {
+        if (j == LONG_MIN)
+            return j;
+        return -j;
+    }
+    return j;
 }
 
 /* Return the absolute value of a signed long long. */
 long long llabs(long long j)
 {
-    unsigned long long u = (unsigned long long)j;
-    if (j < 0)
-        u = 0ull - u;
-    return (long long)u;
+    if (j < 0) {
+        if (j == LLONG_MIN)
+            return j;
+        return -j;
+    }
+    return j;
 }
 
 /* Compute quotient and remainder of numer divided by denom. */

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -6375,6 +6375,14 @@ static const char *test_abs_div_functions(void)
     return 0;
 }
 
+static const char *test_abs_min_values(void)
+{
+    mu_assert("abs INT_MIN", abs(INT_MIN) == INT_MIN);
+    mu_assert("labs LONG_MIN", labs(LONG_MIN) == LONG_MIN);
+    mu_assert("llabs LLONG_MIN", llabs(LLONG_MIN) == LLONG_MIN);
+    return 0;
+}
+
 static const char *test_fp_checks(void)
 {
     volatile double zero = 0.0;
@@ -7004,6 +7012,7 @@ static const char *run_tests(const char *category, const char *name)
         REGISTER_TEST("stdlib", test_math_functions),
         REGISTER_TEST("stdlib", test_complex_cabs_cexp),
         REGISTER_TEST("stdlib", test_abs_div_functions),
+        REGISTER_TEST("stdlib", test_abs_min_values),
         REGISTER_TEST("stdlib", test_vis_roundtrip),
         REGISTER_TEST("stdlib", test_nvis_basic),
         REGISTER_TEST("stdlib", test_fp_checks),


### PR DESCRIPTION
## Summary
- handle INT_MIN/LONG_MIN/LLONG_MIN specially in `abs`, `labs`, `llabs`
- test that these functions work with minimum integer values

## Testing
- `make test`
- `TEST_NAME=test_abs_min_values ./tests/run_tests`


------
https://chatgpt.com/codex/tasks/task_e_686c7f8d52b0832480fd104129bdb8cd