### PR TITLE
Add ISO-8859-1 and UTF-16 iconv support

### DIFF
--- a/docs/strings.md
+++ b/docs/strings.md
@@ -172,11 +172,12 @@ free(out);
 ### Character Set Conversion
 
 `iconv_open` returns a descriptor for translating between character
-sets.  vlibc understands only conversions between `"ASCII"` and
-`"UTF-8"`.  The `iconv` function copies bytes from the input buffer to
-the output buffer and fails with `EILSEQ` on bytes that cannot be
-represented.  On BSD systems other conversions are delegated to the
-host `iconv` implementation when present.
+sets.  vlibc ships with small tables supporting conversions between
+`"ASCII"`, `"ISO-8859-1"`, `"UTF-8"` and `"UTF-16"`.  The `iconv`
+function copies bytes from the input buffer to the output buffer and
+fails with `EILSEQ` on sequences that cannot be represented.  On BSD
+systems other conversions are delegated to the host `iconv`
+implementation when present.
 
 ## Character Classification
 

--- a/src/iconv.c
+++ b/src/iconv.c
@@ -30,6 +30,18 @@ enum {
     CD_ASCII_UTF8,
     CD_UTF8_ASCII,
     CD_UTF8_UTF8,
+    CD_ASCII_8859_1,
+    CD_8859_1_ASCII,
+    CD_8859_1_8859_1,
+    CD_8859_1_UTF8,
+    CD_UTF8_8859_1,
+    CD_ASCII_UTF16,
+    CD_UTF16_ASCII,
+    CD_UTF8_UTF16,
+    CD_UTF16_UTF8,
+    CD_8859_1_UTF16,
+    CD_UTF16_8859_1,
+    CD_UTF16_UTF16,
     CD_HOST
 };
 
@@ -51,6 +63,111 @@ static int is_ascii_cs(const char *name)
 static int is_utf8_cs(const char *name)
 {
     return name && (!strcasecmp(name, "UTF-8") || !strcasecmp(name, "UTF8"));
+}
+
+/* Determine whether a character set name refers to ISO-8859-1. */
+static int is_8859_1_cs(const char *name)
+{
+    return name && (!strcasecmp(name, "ISO-8859-1") ||
+                    !strcasecmp(name, "ISO8859-1") ||
+                    !strcasecmp(name, "LATIN1") ||
+                    !strcasecmp(name, "LATIN-1"));
+}
+
+/* Determine whether a character set name refers to UTF-16. */
+static int is_utf16_cs(const char *name)
+{
+    return name && (!strcasecmp(name, "UTF-16") || !strcasecmp(name, "UTF16"));
+}
+
+/* Decode a single UTF-8 sequence from SRC advancing pointers on success. */
+static int decode_utf8(const unsigned char **src, size_t *left, unsigned *cp)
+{
+    if (*left == 0)
+        return -2;
+    unsigned char c0 = (*src)[0];
+    if (c0 < 0x80) {
+        *cp = c0;
+        (*src)++; (*left)--;
+        return 0;
+    }
+    if ((c0 & 0xE0) == 0xC0) {
+        if (*left < 2) return -2;
+        unsigned char c1 = (*src)[1];
+        if ((c1 & 0xC0) != 0x80)
+            return -1;
+        *cp = ((c0 & 0x1F) << 6) | (c1 & 0x3F);
+        if (*cp < 0x80)
+            return -1;
+        (*src) += 2; (*left) -= 2;
+        return 0;
+    }
+    if ((c0 & 0xF0) == 0xE0) {
+        if (*left < 3) return -2;
+        unsigned char c1 = (*src)[1];
+        unsigned char c2 = (*src)[2];
+        if ((c1 & 0xC0) != 0x80 || (c2 & 0xC0) != 0x80)
+            return -1;
+        *cp = ((c0 & 0x0F) << 12) | ((c1 & 0x3F) << 6) | (c2 & 0x3F);
+        if (*cp < 0x800)
+            return -1;
+        (*src) += 3; (*left) -= 3;
+        return 0;
+    }
+    return -1;
+}
+
+/* Encode a Unicode codepoint to UTF-8 advancing DST on success. */
+static int encode_utf8(unsigned cp, unsigned char **dst, size_t *left)
+{
+    if (cp < 0x80) {
+        if (*left < 1) return -2;
+        (*dst)[0] = cp;
+        (*dst)++; (*left)--;
+        return 0;
+    }
+    if (cp < 0x800) {
+        if (*left < 2) return -2;
+        (*dst)[0] = 0xC0 | (cp >> 6);
+        (*dst)[1] = 0x80 | (cp & 0x3F);
+        (*dst) += 2; (*left) -= 2;
+        return 0;
+    }
+    if (cp <= 0xFFFF) {
+        if (*left < 3) return -2;
+        (*dst)[0] = 0xE0 | (cp >> 12);
+        (*dst)[1] = 0x80 | ((cp >> 6) & 0x3F);
+        (*dst)[2] = 0x80 | (cp & 0x3F);
+        (*dst) += 3; (*left) -= 3;
+        return 0;
+    }
+    return -1;
+}
+
+/* Decode a 16-bit character from little-endian UTF-16. */
+static int decode_utf16(const unsigned char **src, size_t *left, unsigned *cp)
+{
+    if (*left < 2)
+        return -2;
+    unsigned c = (*src)[0] | ((*src)[1] << 8);
+    if (c >= 0xD800 && c <= 0xDFFF)
+        return -1;
+    *cp = c;
+    (*src) += 2; (*left) -= 2;
+    return 0;
+}
+
+/* Encode a codepoint to little-endian UTF-16. */
+static int encode_utf16(unsigned cp, unsigned char **dst, size_t *left)
+{
+    if (cp > 0xFFFF || (cp >= 0xD800 && cp <= 0xDFFF))
+        return -1;
+    if (*left < 2)
+        return -2;
+    (*dst)[0] = cp & 0xFF;
+    (*dst)[1] = (cp >> 8) & 0xFF;
+    (*dst) += 2; (*left) -= 2;
+    return 0;
 }
 
 /*
@@ -95,6 +212,30 @@ iconv_t iconv_open(const char *tocode, const char *fromcode)
         cd->type = CD_UTF8_ASCII;
     else if (is_utf8_cs(fromcode) && is_utf8_cs(tocode))
         cd->type = CD_UTF8_UTF8;
+    else if (is_ascii_cs(fromcode) && is_8859_1_cs(tocode))
+        cd->type = CD_ASCII_8859_1;
+    else if (is_8859_1_cs(fromcode) && is_ascii_cs(tocode))
+        cd->type = CD_8859_1_ASCII;
+    else if (is_8859_1_cs(fromcode) && is_8859_1_cs(tocode))
+        cd->type = CD_8859_1_8859_1;
+    else if (is_8859_1_cs(fromcode) && is_utf8_cs(tocode))
+        cd->type = CD_8859_1_UTF8;
+    else if (is_utf8_cs(fromcode) && is_8859_1_cs(tocode))
+        cd->type = CD_UTF8_8859_1;
+    else if (is_ascii_cs(fromcode) && is_utf16_cs(tocode))
+        cd->type = CD_ASCII_UTF16;
+    else if (is_utf16_cs(fromcode) && is_ascii_cs(tocode))
+        cd->type = CD_UTF16_ASCII;
+    else if (is_utf8_cs(fromcode) && is_utf16_cs(tocode))
+        cd->type = CD_UTF8_UTF16;
+    else if (is_utf16_cs(fromcode) && is_utf8_cs(tocode))
+        cd->type = CD_UTF16_UTF8;
+    else if (is_8859_1_cs(fromcode) && is_utf16_cs(tocode))
+        cd->type = CD_8859_1_UTF16;
+    else if (is_utf16_cs(fromcode) && is_8859_1_cs(tocode))
+        cd->type = CD_UTF16_8859_1;
+    else if (is_utf16_cs(fromcode) && is_utf16_cs(tocode))
+        cd->type = CD_UTF16_UTF16;
     else {
         free(cd);
         errno = EINVAL;
@@ -131,31 +272,108 @@ size_t iconv(iconv_t cd_, char **inbuf, size_t *inbytesleft,
     size_t converted = 0;
 
     while (inleft > 0) {
-        if (outleft == 0) {
-            errno = E2BIG;
-            return (size_t)-1;
-        }
         unsigned char c = (unsigned char)*src;
-        if (cd->type == CD_ASCII_ASCII || cd->type == CD_ASCII_UTF8) {
-            if (c >= 0x80) {
-                errno = EILSEQ;
-                return (size_t)-1;
+        unsigned cp = 0;
+        int r;
+
+        switch (cd->type) {
+        case CD_ASCII_ASCII:
+        case CD_ASCII_UTF8:
+        case CD_ASCII_8859_1:
+            if (c >= 0x80) { errno = EILSEQ; return (size_t)-1; }
+            if (outleft < 1) { errno = E2BIG; return (size_t)-1; }
+            *dst++ = *src++; inleft--; outleft--; converted++; break;
+
+        case CD_8859_1_ASCII:
+            if (c >= 0x80) { errno = EILSEQ; return (size_t)-1; }
+            if (outleft < 1) { errno = E2BIG; return (size_t)-1; }
+            *dst++ = *src++; inleft--; outleft--; converted++; break;
+
+        case CD_8859_1_8859_1:
+            if (outleft < 1) { errno = E2BIG; return (size_t)-1; }
+            *dst++ = *src++; inleft--; outleft--; converted++; break;
+
+        case CD_8859_1_UTF8:
+            if (c < 0x80) {
+                if (outleft < 1) { errno = E2BIG; return (size_t)-1; }
+                *dst++ = *src++; inleft--; outleft--; converted++; break;
+            } else {
+                if (outleft < 2) { errno = E2BIG; return (size_t)-1; }
+                dst[0] = 0xC0 | (c >> 6);
+                dst[1] = 0x80 | (c & 0x3F);
+                dst += 2; src++; inleft--; outleft -= 2; converted++; break;
             }
-            *dst++ = *src++;
-            inleft--; outleft--; converted++;
-        } else if (cd->type == CD_UTF8_ASCII) {
-            if (c >= 0x80) {
-                errno = EILSEQ;
-                return (size_t)-1;
-            }
-            *dst++ = *src++;
-            inleft--; outleft--; converted++;
-        } else if (cd->type == CD_UTF8_UTF8) {
-            *dst++ = *src++;
-            inleft--; outleft--; converted++;
-        } else {
-            errno = EINVAL;
-            return (size_t)-1;
+
+        case CD_UTF8_ASCII:
+            r = decode_utf8((const unsigned char **)&src, &inleft, &cp);
+            if (r == -2) { errno = EINVAL; return (size_t)-1; }
+            if (r == -1 || cp > 0x7F) { errno = EILSEQ; return (size_t)-1; }
+            if (outleft < 1) { errno = E2BIG; return (size_t)-1; }
+            *dst++ = (char)cp; outleft--; converted++; break;
+
+        case CD_UTF8_8859_1:
+            r = decode_utf8((const unsigned char **)&src, &inleft, &cp);
+            if (r == -2) { errno = EINVAL; return (size_t)-1; }
+            if (r == -1 || cp > 0xFF) { errno = EILSEQ; return (size_t)-1; }
+            if (outleft < 1) { errno = E2BIG; return (size_t)-1; }
+            *dst++ = (char)cp; outleft--; converted++; break;
+
+        case CD_UTF8_UTF8:
+            if (outleft < 1) { errno = E2BIG; return (size_t)-1; }
+            *dst++ = *src++; inleft--; outleft--; converted++; break;
+
+        case CD_ASCII_UTF16:
+            if (c >= 0x80) { errno = EILSEQ; return (size_t)-1; }
+            r = encode_utf16(c, (unsigned char **)&dst, &outleft);
+            if (r == -2) { errno = E2BIG; return (size_t)-1; }
+            src++; inleft--; converted++; break;
+
+        case CD_UTF16_ASCII:
+            r = decode_utf16((const unsigned char **)&src, &inleft, &cp);
+            if (r == -2) { errno = EINVAL; return (size_t)-1; }
+            if (r == -1 || cp > 0x7F) { errno = EILSEQ; return (size_t)-1; }
+            if (outleft < 1) { errno = E2BIG; return (size_t)-1; }
+            *dst++ = (char)cp; outleft--; converted++; break;
+
+        case CD_UTF8_UTF16:
+            r = decode_utf8((const unsigned char **)&src, &inleft, &cp);
+            if (r == -2) { errno = EINVAL; return (size_t)-1; }
+            if (r == -1) { errno = EILSEQ; return (size_t)-1; }
+            r = encode_utf16(cp, (unsigned char **)&dst, &outleft);
+            if (r == -1) { errno = EILSEQ; return (size_t)-1; }
+            if (r == -2) { errno = E2BIG; return (size_t)-1; }
+            converted++; break;
+
+        case CD_UTF16_UTF8:
+            r = decode_utf16((const unsigned char **)&src, &inleft, &cp);
+            if (r == -2) { errno = EINVAL; return (size_t)-1; }
+            if (r == -1) { errno = EILSEQ; return (size_t)-1; }
+            r = encode_utf8(cp, (unsigned char **)&dst, &outleft);
+            if (r == -1) { errno = EILSEQ; return (size_t)-1; }
+            if (r == -2) { errno = E2BIG; return (size_t)-1; }
+            converted++; break;
+
+        case CD_8859_1_UTF16:
+            r = encode_utf16(c, (unsigned char **)&dst, &outleft);
+            if (r == -2) { errno = E2BIG; return (size_t)-1; }
+            src++; inleft--; converted++; break;
+
+        case CD_UTF16_8859_1:
+            r = decode_utf16((const unsigned char **)&src, &inleft, &cp);
+            if (r == -2) { errno = EINVAL; return (size_t)-1; }
+            if (r == -1 || cp > 0xFF) { errno = EILSEQ; return (size_t)-1; }
+            if (outleft < 1) { errno = E2BIG; return (size_t)-1; }
+            *dst++ = (char)cp; outleft--; converted++; break;
+
+        case CD_UTF16_UTF16:
+            if (inleft < 2) { errno = EINVAL; return (size_t)-1; }
+            if (outleft < 2) { errno = E2BIG; return (size_t)-1; }
+            dst[0] = src[0]; dst[1] = src[1];
+            dst += 2; src += 2;
+            inleft -= 2; outleft -= 2; converted++; break;
+
+        default:
+            errno = EINVAL; return (size_t)-1;
         }
     }
 

--- a/tests/test_vlibc.c
+++ b/tests/test_vlibc.c
@@ -2180,6 +2180,38 @@ static const char *test_iconv_invalid_byte(void)
     return 0;
 }
 
+static const char *test_iconv_iso8859_utf8(void)
+{
+    iconv_t cd = iconv_open("UTF-8", "ISO-8859-1");
+    mu_assert("open", cd != (iconv_t)-1);
+    char in[] = { 'h', (char)0xE9, 0 };
+    char *pin = in;
+    size_t inleft = 2;
+    char out[8] = {0};
+    char *pout = out;
+    size_t outleft = sizeof(out);
+    size_t r = iconv(cd, &pin, &inleft, &pout, &outleft);
+    mu_assert("conv", r != (size_t)-1 && strcmp(out, "h\xC3\xA9") == 0);
+    iconv_close(cd);
+    return 0;
+}
+
+static const char *test_iconv_utf16_ascii(void)
+{
+    iconv_t cd = iconv_open("ASCII", "UTF-16");
+    mu_assert("open", cd != (iconv_t)-1);
+    char in[] = { 'h', 0, 'i', 0, 0, 0 };
+    char *pin = in;
+    size_t inleft = 4;
+    char out[4] = {0};
+    char *pout = out;
+    size_t outleft = sizeof(out);
+    size_t r = iconv(cd, &pin, &inleft, &pout, &outleft);
+    mu_assert("conv", r != (size_t)-1 && strcmp(out, "hi") == 0);
+    iconv_close(cd);
+    return 0;
+}
+
 static const char *test_strtok_basic(void)
 {
     char buf[] = "a,b,c";
@@ -6946,6 +6978,8 @@ static const char *run_tests(const char *category, const char *name)
         REGISTER_TEST("stdio", test_fopencookie_basic),
         REGISTER_TEST("stdlib", test_iconv_ascii_roundtrip),
         REGISTER_TEST("stdlib", test_iconv_invalid_byte),
+        REGISTER_TEST("stdlib", test_iconv_iso8859_utf8),
+        REGISTER_TEST("stdlib", test_iconv_utf16_ascii),
         REGISTER_TEST("stdlib", test_strtok_basic),
         REGISTER_TEST("stdlib", test_strtok_r_basic),
         REGISTER_TEST("stdlib", test_strsep_basic),


### PR DESCRIPTION
## Summary
- extend iconv with ISO-8859-1 and UTF-16 tables
- document extra conversions
- test additional iconv conversions

## Testing
- `make test`
- `TEST_NAME=test_iconv_iso8859_utf8 ./tests/run_tests`
- `TEST_NAME=test_iconv_utf16_ascii ./tests/run_tests`


------
https://chatgpt.com/codex/tasks/task_e_686c87f218248324b96265a3525fea37