### PR TITLE
Implement full and line buffering modes

### DIFF
--- a/docs/io.md
+++ b/docs/io.md
@@ -216,10 +216,12 @@ Use `open_memstream` to capture output into a dynamically growing buffer or
 `fmemopen` to read and write to an existing memory region.
 
 Streams may be given a custom buffer with `setvbuf` or the simpler
-`setbuf`. When buffered, I/O operates on that memory until it is filled
-or explicitly flushed. When multiple threads share a stream use
-`flockfile(stream)` and `funlockfile(stream)` to guard accesses.
-`ftrylockfile` attempts the lock without blocking.
+`setbuf` and `setbuffer` helpers.  `_IOFBF` enables full buffering,
+`_IOLBF` line buffering and `_IONBF` turns buffering off.  When buffered,
+I/O operates on that memory until it is filled, a newline is written in
+line mode, or an explicit flush occurs. When multiple threads share a
+stream use `flockfile(stream)` and `funlockfile(stream)` to guard
+accesses. `ftrylockfile` attempts the lock without blocking.
 
 `freopen` can replace the file associated with an existing stream so the same
 `FILE` handle refers to a new path. This is handy for redirecting a standard

--- a/docs/other.md
+++ b/docs/other.md
@@ -77,8 +77,8 @@ speeds stored in a `termios` structure are changed with `cfsetispeed()` and
 
 ## Limitations
 
- - The I/O routines perform simple optional buffering and provide only
-   basic error reporting.
+ - The I/O routines support optional full and line buffering with more
+   detailed error codes but remain minimal compared to a full libc.
  - Process creation currently relies on Linux-specific syscalls.
  - BSD support is experimental and some subsystems may not compile yet.
  - The `system()` helper spawns `/bin/sh -c` and lacks detailed status

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -18,6 +18,7 @@ typedef struct {
     size_t bufpos;               /* current read/write position in buf */
     size_t buflen;               /* valid data length in buf */
     int buf_owned;               /* buffer should be freed on close */
+    int buf_mode;                /* buffering mode (_IOFBF, _IOLBF, _IONBF) */
     int error;                   /* error indicator */
     int eof;                     /* end-of-file indicator */
     int have_ungot;              /* ungetc() character available */
@@ -88,6 +89,8 @@ int fputs(const char *s, FILE *stream);
 int fflush(FILE *stream);
 int setvbuf(FILE *stream, char *buf, int mode, size_t size);
 void setbuf(FILE *stream, char *buf);
+void setbuffer(FILE *stream, char *buf, size_t size);
+int setlinebuf(FILE *stream);
 int feof(FILE *stream);
 int ferror(FILE *stream);
 void clearerr(FILE *stream);

--- a/src/fopencookie.c
+++ b/src/fopencookie.c
@@ -20,6 +20,7 @@ FILE *fopencookie(void *cookie, const char *mode,
     memset(f, 0, sizeof(FILE));
     atomic_flag_clear(&f->lock);
     f->fd = -1;
+    f->buf_mode = _IONBF;
     f->is_cookie = 1;
     f->cookie = cookie;
     f->cookie_read = functions.read;

--- a/src/init.c
+++ b/src/init.c
@@ -21,6 +21,7 @@ void vlibc_init(void)
         memset(stdin, 0, sizeof(FILE));
         atomic_flag_clear(&stdin->lock);
         stdin->fd = 0;
+        stdin->buf_mode = _IONBF;
     }
 
     stdout = malloc(sizeof(FILE));
@@ -30,6 +31,7 @@ void vlibc_init(void)
         memset(stdout, 0, sizeof(FILE));
         atomic_flag_clear(&stdout->lock);
         stdout->fd = 1;
+        stdout->buf_mode = _IONBF;
     }
 
     stderr = malloc(sizeof(FILE));
@@ -39,5 +41,6 @@ void vlibc_init(void)
         memset(stderr, 0, sizeof(FILE));
         atomic_flag_clear(&stderr->lock);
         stderr->fd = 2;
+        stderr->buf_mode = _IONBF;
     }
 }

--- a/src/memstream.c
+++ b/src/memstream.c
@@ -30,6 +30,7 @@ FILE *open_memstream(char **bufp, size_t *sizep)
     memset(f, 0, sizeof(FILE));
     atomic_flag_clear(&f->lock);
     f->fd = -1;
+    f->buf_mode = _IOFBF;
     f->is_mem = 1;
     f->writable = 1;
     f->mem_bufp = (void **)bufp;
@@ -66,6 +67,7 @@ FILE *open_wmemstream(wchar_t **bufp, size_t *sizep)
     memset(f, 0, sizeof(FILE));
     atomic_flag_clear(&f->lock);
     f->fd = -1;
+    f->buf_mode = _IOFBF;
     f->is_mem = 1;
     f->is_wmem = 1;
     f->writable = 1;
@@ -103,6 +105,7 @@ FILE *fmemopen(void *buf, size_t size, const char *mode)
     memset(f, 0, sizeof(FILE));
     atomic_flag_clear(&f->lock);
     f->fd = -1;
+    f->buf_mode = _IOFBF;
     f->is_mem = 1;
 
     if (!mode)

--- a/src/tempfile.c
+++ b/src/tempfile.c
@@ -175,6 +175,7 @@ FILE *tmpfile(void)
     memset(f, 0, sizeof(FILE));
     atomic_flag_clear(&f->lock);
     f->fd = fd;
+    f->buf_mode = _IONBF;
     return f;
 }
 


### PR DESCRIPTION
## Summary
- add buffering mode field to `FILE`
- support `_IOFBF`, `_IOLBF`, and `_IONBF` in `setvbuf`
- implement `setbuffer` and `setlinebuf`
- flush on newline for line-buffered output
- document new buffering behaviour and update limitations
- test buffering modes and error handling

## Testing
- `make test`
- `TEST_NAME=test_line_buffering ./tests/run_tests`
- `TEST_NAME=test_full_buffering ./tests/run_tests`
- `TEST_NAME=test_fflush_error_propagation ./tests/run_tests`


------
https://chatgpt.com/codex/tasks/task_e_686c87fe21788324ac7e8cc4151312bb